### PR TITLE
[Classification] Update the criteria to label alerts

### DIFF
--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -392,7 +392,11 @@ def construct_table(n_clicks, objectid, radecradius, startdate, window, alert_cl
         pdfs['d:mulens_class_1'],
         pdfs['d:mulens_class_2'],
         pdfs['d:snn_snia_vs_nonia'],
-        pdfs['d:snn_sn_vs_all']
+        pdfs['d:snn_sn_vs_all'],
+        pdfs['d:rfscore'],
+        pdfs['i:ndethist'],
+        pdfs['i:drb'],
+        pdfs['i:classtar']
     )
 
     # inplace (booo)

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -116,8 +116,10 @@ dropdown = dbc.FormGroup(
             options=[
                 {'label': 'All classes', 'value': 'allclasses'},
                 {'label': 'Fink derived classes', 'disabled': True, 'value': 'None'},
+                {'label': 'Early Supernova candidates', 'value': 'Early SN candidate'},
                 {'label': 'Supernova candidates', 'value': 'SN candidate'},
                 {'label': 'Microlensing candidates', 'value': 'Microlensing candidate'},
+                {'label': 'Ambiguous', 'value': 'Ambiguous'},
                 {'label': 'Solar System Object candidates', 'value': 'Solar System'},
                 {'label': 'Simbad crossmatch', 'disabled': True, 'value': 'None'},
                 *[{'label': simtype, 'value': simtype} for simtype in simbad_types]

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -266,7 +266,11 @@ def construct_table(n_clicks, objectid, radecradius, startdate, window, alert_cl
         'd:mulens_class_1',
         'd:mulens_class_2',
         'd:snn_snia_vs_nonia',
-        'd:snn_sn_vs_all'
+        'd:snn_sn_vs_all',
+        'd:rfscore',
+        'i:ndethist',
+        'i:drb',
+        'i:classtar'
     ]
 
     # Column name to display

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -86,7 +86,11 @@ def extract_fink_classification_single(data):
             'd:mulens_class_2',
             'd:roid',
             'd:snn_sn_vs_all',
-            'd:snn_snia_vs_nonia'
+            'd:snn_snia_vs_nonia',
+            'd:rfscore',
+            'i:ndethist',
+            'i:drb',
+            'i:classtar'
         ]
     )
     pdf = pdf.sort_values('i:jd', ascending=False)
@@ -97,24 +101,70 @@ def extract_fink_classification_single(data):
         pdf['d:mulens_class_1'],
         pdf['d:mulens_class_1'],
         pdf['d:snn_snia_vs_nonia'],
-        pdf['d:snn_sn_vs_all']
+        pdf['d:snn_sn_vs_all'],
+        pdf['d:rfscore'],
+        pdf['i:ndethist'],
+        pdf['i:drb'],
+        pdf['i:classtar']
     )
 
     return classification[0]
 
-def extract_fink_classification(cdsxmatch, roid, mulens_class_1, mulens_class_2, snn_snia_vs_nonia, snn_sn_vs_all):
-    """ return np.array
+def extract_fink_classification(
+        cdsxmatch, roid, mulens_class_1, mulens_class_2,
+        snn_snia_vs_nonia, snn_sn_vs_all, rfscore,
+        ndethist, drb, classtar):
+    """ Assign label to alerts based on individual science module results
+
+    See https://arxiv.org/abs/2009.10185 for more information
     """
     classification = pd.Series(['Unknown'] * len(cdsxmatch))
     ambiguity = pd.Series([0] * len(cdsxmatch))
 
+    # Microlensing classification
     f_mulens = (mulens_class_1 == 'ML') & (mulens_class_2 == 'ML')
-    f_sn = (snn_snia_vs_nonia.astype(float) > 0.5) & (snn_sn_vs_all.astype(float) > 0.5)
+
+    # SN Ia
+    snn1 = snn_snia_vs_nonia.astype(float) > 0.5
+    snn2 = snn_sn_vs_all.astype(float) > 0.5
+    active_learn = rfscore.astype(float) > 0.5
+    low_ndethist = ndethist.astype(int) < 400
+    high_drb = drb.astype(float) > 0.5
+    high_classtar = classtar.astype(float) > 0.4
+
+    list_simbad_galaxies = [
+        "galaxy",
+        "Galaxy",
+        "EmG",
+        "Seyfert",
+        "Seyfert_1",
+        "Seyfert_2",
+        "BlueCompG",
+        "StarburstG",
+        "LSB_G",
+        "HII_G",
+        "High_z_G",
+        "GinPair",
+        "GinGroup",
+        "BClG",
+        "GinCl",
+        "PartofG",
+    ]
+    keep_cds = \
+        ["Unknown", "Candidate_SN*", "SN", "Transient"] + list_simbad_galaxies
+
+    f_sn = (snn1 | snn2) & cdsxmatch.isin(keep_cds) & low_ndethist & high_drb & high_classtar
+    f_sn_early = (active_learn) & f_sn
+
+    # Solar System Objects
     f_roid = roid.astype(int).isin([2, 3])
+
+    # Simbad xmatch
     f_simbad = ~cdsxmatch.isin(['Unknown', 'Transient', 'Fail'])
 
     classification.mask(f_mulens.values, 'Microlensing candidate', inplace=True)
     classification.mask(f_sn.values, 'SN candidate', inplace=True)
+    classification.mask(f_sn_early.values, 'Early SN candidate', inplace=True)
     classification.mask(f_roid.values, 'Solar System', inplace=True)
 
     # If several flags are up, we cannot rely on the classification


### PR DESCRIPTION
This PR brings a new approach to label alerts:

1. Is this alert in SIMBAD? [`cdsxmatch`]
2. Is is this alert a Solar System Object? [`roid`]
3. Is this alert an early SN Ia? [`rfscore`, `snn_snia_vs_nonia`, `snn_sn_vs_all`, `classtar`, `ndethist`, `drb`]
4. Is this alert a SN Ia? [`snn_snia_vs_nonia`, `snn_sn_vs_all`, `classtar`, `ndethist`, `drb`]
5. Is this alert a microlensing event? [`mulens_class_1`, `mulens_class_2`]

if none, this alert is `Unknown`. If several, this alert is `Ambiguous`. 