### PR TITLE
Improve documentation for explorer

### DIFF
--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -103,8 +103,8 @@ object_id = dbc.FormGroup(
                             outline=True,
                             size="sm",
                             style=dict(height='10%')
-                        ), width=1),
-                    dbc.Col("Search by Object ID", width=1),
+                        )),
+                    dbc.Col("Search by Object ID"),
                 ],
             )
         ),
@@ -149,8 +149,9 @@ conesearch = dbc.FormGroup(
                             outline=True,
                             size="sm",
                             style=dict(height='10%')
-                        ), width=1),
-                    dbc.Col("Conesearch", width=1),
+                        )
+                    ),
+                    dbc.Col("Conesearch"),
                 ],
             )
         ),
@@ -195,8 +196,9 @@ date_range = dbc.FormGroup(
                             outline=True,
                             size="sm",
                             style=dict(height='10%')
-                        ), width=1),
-                    dbc.Col("Search by Date", width=1),
+                        ),
+                    ),
+                    dbc.Col("Search by Date"),
                 ],
             )
         ),
@@ -250,8 +252,9 @@ dropdown = dbc.FormGroup(
                             outline=True,
                             size="sm",
                             style=dict(height='10%')
-                        ), width=1),
-                    dbc.Col("Get latest 100 alerts by class", width=1),
+                        )
+                    ),
+                    dbc.Col("Get latest 100 alerts by class"),
                 ],
             )
         ),

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -37,24 +37,18 @@ from apps.utils import extract_fink_classification
 from apps.utils import markdownify_objectid
 
 msg = """
-Fill one of the fields on the left, and click on the _Submit Query_ button.
+![logoexp](/assets/Fink_PrimaryLogo_WEB.png)
 
-* _**Search by Object ID:** Enter a valid object ID to access its data, e.g. try_:
-  * ZTF19acmdpyr, ZTF19acnjwgm, ZTF17aaaabte, ZTF20abqehqf, ZTF18acuajcr
-* _**Conesearch:** Perform a conesearch around a position on the sky given by (RA, Dec, radius). The initializer for RA/Dec is very flexible and supports inputs provided in a number of convenient formats. The following ways of initializing a conesearch are all equivalent (radius in arcsecond):_
-  * (271.3914265, 45.2545134, 5), (271d23m29.1354s, 45d15m16.2482s, 5), (18h05m33.9424s, +45d15m16.2482s, 5), (18 05 33.9424, +45 15 16.2482, 5), (18:05:33.9424, 45:15:16.2482, 5)
-* _**Search by Date:** Choose a starting date and a time window to see all alerts in this period. Dates are in UTC, and the time window in minutes. Example of valid search:_
-  * 2019-11-03 02:40:00
-* _**Get latest 100 alerts by class:** Choose a class of interest using the drop-down menu to see the 100 latest alerts processed by Fink._
+Fill one of the fields on the left, and click on the _Submit Query_ button. You can access help by clicking on the buttons at the left of each field.
 
-_The table shows:_
+The table shows:
 
-- _objectId: Unique identifier for this object_
-- _RA: Right Ascension of candidate; J2000 (deg)_
-- _Dec: Declination of candidate; J2000 (deg)_
-- _last seen: last date the object has been seen by Fink_
-- _classification: Classification inferred by Fink (Supernova candidate, Microlensing candidate, Solar System Object, SIMBAD class, ...)_
-- _ndethist: Number of spatially coincident detections falling within 1.5 arcsec going back to the beginning of the survey; only detections that fell on the same field and readout-channel ID where the input candidate was observed are counted. All raw detections down to a photometric S/N of ~ 3 are included._
+- objectId: Unique identifier for this object
+- RA: Right Ascension of candidate; J2000 (deg)
+- Dec: Declination of candidate; J2000 (deg)
+- last seen: last date the object has been seen by Fink
+- classification: Classification inferred by Fink (Supernova candidate, Microlensing candidate, Solar System Object, SIMBAD class, ...)
+- ndethist: Number of spatially coincident detections falling within 1.5 arcsec going back to the beginning of the survey; only detections that fell on the same field and readout-channel ID where the input candidate was observed are counted. All raw detections down to a photometric S/N of ~ 3 are included.
 """
 
 msg_conesearch = """
@@ -103,7 +97,7 @@ object_id = dbc.FormGroup(
                             outline=True,
                             size="sm",
                             style=dict(height='10%')
-                        )),
+                        ), width=1),
                     dbc.Col("Search by Object ID"),
                 ],
             )
@@ -149,9 +143,9 @@ conesearch = dbc.FormGroup(
                             outline=True,
                             size="sm",
                             style=dict(height='10%')
-                        )
+                        ), width=1
                     ),
-                    dbc.Col("Conesearch"),
+                    dbc.Col("Conesearch", width=1),
                 ],
             )
         ),
@@ -196,9 +190,9 @@ date_range = dbc.FormGroup(
                             outline=True,
                             size="sm",
                             style=dict(height='10%')
-                        ),
+                        ), width=1
                     ),
-                    dbc.Col("Search by Date"),
+                    dbc.Col("Search by Date", width=10),
                 ],
             )
         ),
@@ -252,11 +246,11 @@ dropdown = dbc.FormGroup(
                             outline=True,
                             size="sm",
                             style=dict(height='10%')
-                        )
+                        ), width=1
                     ),
-                    dbc.Col("Get latest 100 alerts by class"),
-                ],
-            )
+                    dbc.Col(dbc.Label("Get latest 100 alerts by class"), width=11),
+                ], justify='start',
+            ), style={'width': '100%', 'display': 'inline-block'}
         ),
         dbc.Toast(
             [dcc.Markdown(msg_latest_alerts, className="mb-0")],

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -57,6 +57,18 @@ _The table shows:_
 - _ndethist: Number of spatially coincident detections falling within 1.5 arcsec going back to the beginning of the survey; only detections that fell on the same field and readout-channel ID where the input candidate was observed are counted. All raw detections down to a photometric S/N of ~ 3 are included._
 """
 
+msg_conesearch = """
+Perform a conesearch around a position on the sky given by (RA, Dec, radius).
+The initializer for RA/Dec is very flexible and supports inputs provided in a number of convenient formats.
+The following ways of initializing a conesearch are all equivalent (radius in arcsecond):             
+
+* 271.3914265, 45.2545134, 5
+* 271d23m29.1354s, 45d15m16.2482s, 5
+* 18h05m33.9424s, +45d15m16.2482s, 5
+* 18 05 33.9424, +45 15 16.2482, 5
+* 18:05:33.9424, 45:15:16.2482, 5
+"""
+
 simbad_types = pd.read_csv('assets/simbad_types.csv', header=None)[0].values
 simbad_types = np.sort(simbad_types)
 
@@ -84,13 +96,7 @@ conesearch = dbc.FormGroup(
         ),
         dbc.FormText("e.g. 271.3914265, 45.2545134, 5"),
         dbc.Tooltip(
-            dcc.Markdown("""Perform a conesearch around a position on the sky given by (RA, Dec, radius). The initializer for RA/Dec is very flexible and supports inputs provided in a number of convenient formats. The following ways of initializing a conesearch are all equivalent (radius in arcsecond):"
-            * 271.3914265, 45.2545134, 5
-            * 271d23m29.1354s, 45d15m16.2482s, 5
-            * 18h05m33.9424s, +45d15m16.2482s, 5
-            * 18 05 33.9424, +45 15 16.2482, 5
-            * 18:05:33.9424, 45:15:16.2482, 5
-            """),
+            dcc.Markdown(msg_conesearch),
             target="conesearch",
             placement='right',
         ),

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -85,7 +85,7 @@ simbad_types = pd.read_csv('assets/simbad_types.csv', header=None)[0].values
 simbad_types = np.sort(simbad_types)
 
 
-noresults = dbc.Toast(
+noresults_toast = dbc.Toast(
     [dcc.Markdown("Try another query", className="mb-0")],
     id="noresults-toast",
     header="No results found",
@@ -367,6 +367,7 @@ layout = html.Div(
                             #dbc.Row(advanced_search),
                             dbc.Row(dropdown),
                             dbc.Row(submit_button),
+                            noresults_toast,
                         ], width=3
                     ),
                     dbc.Col([

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -366,8 +366,7 @@ layout = html.Div(
                             #dbc.Row(advanced_search_button),
                             #dbc.Row(advanced_search),
                             dbc.Row(dropdown),
-                            dbc.Row(submit_button),
-                            noresults_toast,
+                            dbc.Row([submit_button, noresults_toast]),
                         ], width=3
                     ),
                     dbc.Col([

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -366,11 +366,12 @@ layout = html.Div(
                             #dbc.Row(advanced_search_button),
                             #dbc.Row(advanced_search),
                             dbc.Row(dropdown),
-                            dbc.Row([submit_button, noresults_toast]),
+                            dbc.Row(submit_button),
                         ], width=3
                     ),
                     dbc.Col([
                         html.H6(id="table"),
+                        noresults_toast,
                         dbc.Card(
                             dbc.CardBody(
                                 dcc.Markdown(msg)

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -83,6 +83,15 @@ conesearch = dbc.FormGroup(
             debounce=True
         ),
         dbc.FormText("e.g. 271.3914265, 45.2545134, 5"),
+        dbc.Tooltip(
+            "Perform a conesearch around a position on the sky given by (RA, Dec, radius). The initializer for RA/Dec is very flexible and supports inputs provided in a number of convenient formats. The following ways of initializing a conesearch are all equivalent (radius in arcsecond):"
+            "271.3914265, 45.2545134, 5"
+            "271d23m29.1354s, 45d15m16.2482s, 5"
+            "18h05m33.9424s, +45d15m16.2482s, 5"
+            "18 05 33.9424, +45 15 16.2482, 5"
+            "18:05:33.9424, 45:15:16.2482, 5",
+            target="conesearch",
+        ),
     ], style={'width': '100%', 'display': 'inline-block'}
 )
 

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -84,6 +84,27 @@ Choose a class of interest using the drop-down menu to see the 100 latest alerts
 simbad_types = pd.read_csv('assets/simbad_types.csv', header=None)[0].values
 simbad_types = np.sort(simbad_types)
 
+
+noresults = dbc.Toast(
+    [dcc.Markdown("Try another query", className="mb-0")],
+    id="noresults-toast",
+    header="No results found",
+    icon="danger",
+    dismissable=True,
+    is_open=False,
+    style={"position": "fixed", "top": 66, "right": 10, "width": 350},
+),
+
+@app.callback(
+    Output("noresults-toast", "is_open"),
+    [Input("submit_query", "n_clicks"), Input("table", "children")],
+    [State("noresults-toast", "is_open")],
+)
+def open_noresults(n, table, is_open):
+    if n and not table.children:
+        return not is_open
+    return is_open
+
 object_id = dbc.FormGroup(
     [
         dbc.Label(

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -86,7 +86,7 @@ simbad_types = np.sort(simbad_types)
 
 
 noresults_toast = dbc.Toast(
-    [dcc.Markdown("Try another query", className="mb-0")],
+    dcc.Markdown("Try another query", className="mb-0"),
     id="noresults-toast",
     header="No results found",
     icon="danger",
@@ -100,7 +100,7 @@ noresults_toast = dbc.Toast(
     [Input("submit_query", "n_clicks"), Input("table", "children")]
 )
 def open_noresults(n, table):
-    if n and table is None:
+    if n and (table is None):
         return True
     return False
 

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -84,13 +84,13 @@ conesearch = dbc.FormGroup(
         ),
         dbc.FormText("e.g. 271.3914265, 45.2545134, 5"),
         dbc.Tooltip(
-            """Perform a conesearch around a position on the sky given by (RA, Dec, radius). The initializer for RA/Dec is very flexible and supports inputs provided in a number of convenient formats. The following ways of initializing a conesearch are all equivalent (radius in arcsecond):"
+            dcc.Markdown("""Perform a conesearch around a position on the sky given by (RA, Dec, radius). The initializer for RA/Dec is very flexible and supports inputs provided in a number of convenient formats. The following ways of initializing a conesearch are all equivalent (radius in arcsecond):"
               271.3914265, 45.2545134, 5
               271d23m29.1354s, 45d15m16.2482s, 5
               18h05m33.9424s, +45d15m16.2482s, 5
               18 05 33.9424, +45 15 16.2482, 5
               18:05:33.9424, 45:15:16.2482, 5
-            """,
+            """),
             target="conesearch",
             placement='right',
         ),

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -368,9 +368,9 @@ layout = html.Div(
                             dbc.Row(submit_button),
                         ], width=3
                     ),
+                    noresults_toast,
                     dbc.Col([
                         html.H6(id="table"),
-                        noresults_toast,
                         dbc.Card(
                             dbc.CardBody(
                                 dcc.Markdown(msg)

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -150,8 +150,8 @@ def open_noresults(n, table, objectid, radecradius, startdate, window, alert_cla
                 Time(jd_start, format='jd').iso,
                 Time(jd_stop, format='jd').iso
             )
-        return True, text
-    return False, ""
+        return True, text, header
+    return False, "", ""
 
 object_id = dbc.FormGroup(
     [

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -125,13 +125,13 @@ def open_noresults(n, table, objectid, radecradius, startdate, window, alert_cla
     class_click = (alert_class is not None) and (alert_class != '')
 
     # multiple queries
-    if type(table) == str:
+    if np.sum([id_click, conesearch_click, date_click, class_click]) > 1:
         m = []
-        for name, condition in zip([objectid, radecradius, startdate, alert_class], [id_click, conesearch_click, date_click, class_click]):
+        for name, condition in zip(["Search by Object ID", "Conesearch", "Search by Date", "Get latest 100 alerts by class"], [id_click, conesearch_click, date_click, class_click]):
             if condition:
                 m.append(name)
-        header = "Multiple constraints"
-        text = "Multiple constraints are not yet allowed. Keep only one among {}".format(m)
+        header = "Multi index search"
+        text = "Searching along multiple fields is not yet allowed. Keep only one among {}".format(m)
         return True, text, header
 
     # ugly hack on the type
@@ -498,7 +498,7 @@ def construct_table(n_clicks, objectid, radecradius, startdate, window, alert_cl
     class_click = (alert_class is not None) and (alert_class != '')
 
     if np.sum([id_click, conesearch_click, date_click, class_click]) > 1:
-        return 'multiple queries'
+        raise PreventUpdate
 
     # wrong query
     wrong_id = (objectid is None) or (objectid == '')

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -125,7 +125,7 @@ object_id = dbc.FormGroup(
     [Input("open-objectid", "n_clicks")],
 )
 def open_objectid(n):
-    if n > 0:
+    if n is not None or n > 0:
         return True
     else:
         return False
@@ -172,7 +172,7 @@ conesearch = dbc.FormGroup(
     [Input("open-conesearch", "n_clicks")],
 )
 def open_conesearch(n):
-    if n > 0:
+    if n is not None or n > 0:
         return True
     else:
         return False
@@ -228,7 +228,7 @@ date_range = dbc.FormGroup(
     [Input("open-date", "n_clicks")],
 )
 def open_date(n):
-    if n > 0:
+    if n is not None or n > 0:
         return True
     else:
         return False
@@ -280,15 +280,25 @@ dropdown = dbc.FormGroup(
     ], style={'width': '100%', 'display': 'inline-block'}
 )
 
+# @app.callback(
+#     Output("latest-alerts-toast", "is_open"),
+#     [Input("open-latest-alerts", "n_clicks")],
+# )
+# def open_latest_alerts(n):
+#     if n is not None or n > 0:
+#         return True
+#     else:
+#         return False
+
 @app.callback(
     Output("latest-alerts-toast", "is_open"),
     [Input("open-latest-alerts", "n_clicks")],
+    [State("latest-alerts-toast", "is_open")],
 )
-def open_latest_alerts(n):
-    if n > 0:
-        return True
-    else:
-        return False
+def open_latest_alerts(n, is_open):
+    if n:
+        return not is_open
+    return is_open
 
 submit_button = dbc.Button(
     'Submit Query',

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -129,7 +129,7 @@ def open_noresults(n, table, objectid, radecradius, startdate, window, alert_cla
             )
         elif date_click:
             header = "Search by Date"
-            if window >= 0:
+            if window:
                 jd_start = Time(startdate).jd
                 jd_end = jd_start + TimeDelta(window * 60, format='sec').jd
 

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -114,6 +114,11 @@ noresults_toast = dbc.Toast(
 def open_noresults(n, table, objectid, radecradius, startdate, window, alert_class):
     """ Toast to warn the user about the fact that we found no results
     """
+    # Trigger the query only if the submit button is pressed.
+    changed_id = [p['prop_id'] for p in dash.callback_context.triggered][0]
+    if 'submit_query' not in changed_id:
+        raise PreventUpdate
+
     id_click = (objectid is not None) and (objectid != '')
     conesearch_click = (radecradius is not None) and (radecradius != '')
     date_click = (startdate is not None) and (startdate != '')
@@ -126,7 +131,7 @@ def open_noresults(n, table, objectid, radecradius, startdate, window, alert_cla
             if condition:
                 m.append(name)
         header = "Multiple constraints"
-        text = "Multiple constraints are not yet allowed. Keep only one among {}".format(name)
+        text = "Multiple constraints are not yet allowed. Keep only one among {}".format(m)
         return True, text, header
 
     # ugly hack on the type

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -86,7 +86,7 @@ simbad_types = np.sort(simbad_types)
 
 
 noresults_toast = dbc.Toast(
-    "", #dcc.Markdown("Try another query", className="mb-0"),
+    "",
     header="",
     id="noresults-toast",
     icon="danger",
@@ -112,10 +112,22 @@ noresults_toast = dbc.Toast(
     ]
 )
 def open_noresults(n, table, objectid, radecradius, startdate, window, alert_class):
+    """ Toast to warn the user about the fact that we found no results
+    """
     id_click = (objectid is not None) and (objectid != '')
     conesearch_click = (radecradius is not None) and (radecradius != '')
     date_click = (startdate is not None) and (startdate != '')
     class_click = (alert_class is not None) and (alert_class != '')
+
+    # multiple queries
+    if type(table) == str:
+        m = []
+        for name, condition in zip([objectid, radecradius, startdate, alert_class], [id_click, conesearch_click, date_click, class_click]):
+            if condition:
+                m.append(name)
+        header = "Multiple constraints"
+        text = "Multiple constraints are not yet allowed. Keep only one among {}".format(name)
+        return True, text, header
 
     # ugly hack on the type
     if n and (table['namespace'] == 'dash_html_components'):
@@ -474,6 +486,14 @@ def construct_table(n_clicks, objectid, radecradius, startdate, window, alert_cl
     changed_id = [p['prop_id'] for p in dash.callback_context.triggered][0]
     if 'submit_query' not in changed_id:
         raise PreventUpdate
+
+    id_click = (objectid is not None) and (objectid != '')
+    conesearch_click = (radecradius is not None) and (radecradius != '')
+    date_click = (startdate is not None) and (startdate != '')
+    class_click = (alert_class is not None) and (alert_class != '')
+
+    if np.sum([id_click, conesearch_click, date_click, class_click]) > 1:
+        return 'multiple queries'
 
     # wrong query
     wrong_id = (objectid is None) or (objectid == '')

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -105,7 +105,7 @@ object_id = dbc.FormGroup(
         dbc.Toast(
             [dcc.Markdown(msg_objectid, className="mb-0")],
             id="objectid-toast",
-            header="ObjectId help",
+            header="Help",
             icon="light",
             dismissable=True,
             is_open=False
@@ -123,12 +123,12 @@ object_id = dbc.FormGroup(
 @app.callback(
     Output("objectid-toast", "is_open"),
     [Input("open-objectid", "n_clicks")],
+    [State("objectid-toast", "is_open")],
 )
-def open_objectid(n):
-    if n is not None or n > 0:
-        return True
-    else:
-        return False
+def open_objectid(n, is_open):
+    if n:
+        return not is_open
+    return is_open
 
 conesearch = dbc.FormGroup(
     [
@@ -152,7 +152,7 @@ conesearch = dbc.FormGroup(
         dbc.Toast(
             [dcc.Markdown(msg_conesearch, className="mb-0")],
             id="conesearch-toast",
-            header="Conesearch help",
+            header="Help",
             icon="light",
             dismissable=True,
             is_open=False
@@ -170,12 +170,12 @@ conesearch = dbc.FormGroup(
 @app.callback(
     Output("conesearch-toast", "is_open"),
     [Input("open-conesearch", "n_clicks")],
+    [State("conesearch-toast", "is_open")],
 )
-def open_conesearch(n):
-    if n is not None or n > 0:
-        return True
-    else:
-        return False
+def open_conesearch(n, is_open):
+    if n:
+        return not is_open
+    return is_open
 
 date_range = dbc.FormGroup(
     [
@@ -199,7 +199,7 @@ date_range = dbc.FormGroup(
         dbc.Toast(
             [dcc.Markdown(msg_date, className="mb-0")],
             id="date-toast",
-            header="Date help",
+            header="Help",
             icon="light",
             dismissable=True,
             is_open=False
@@ -226,12 +226,12 @@ date_range = dbc.FormGroup(
 @app.callback(
     Output("date-toast", "is_open"),
     [Input("open-date", "n_clicks")],
+    [State("date-toast", "is_open")],
 )
-def open_date(n):
-    if n is not None or n > 0:
-        return True
-    else:
-        return False
+def open_date(n, is_open):
+    if n:
+        return not is_open
+    return is_open
 
 dropdown = dbc.FormGroup(
     [
@@ -255,7 +255,7 @@ dropdown = dbc.FormGroup(
         dbc.Toast(
             [dcc.Markdown(msg_latest_alerts, className="mb-0")],
             id="latest-alerts-toast",
-            header="Latest alerts help",
+            header="Help",
             icon="light",
             dismissable=True,
             is_open=False
@@ -279,16 +279,6 @@ dropdown = dbc.FormGroup(
         )
     ], style={'width': '100%', 'display': 'inline-block'}
 )
-
-# @app.callback(
-#     Output("latest-alerts-toast", "is_open"),
-#     [Input("open-latest-alerts", "n_clicks")],
-# )
-# def open_latest_alerts(n):
-#     if n is not None or n > 0:
-#         return True
-#     else:
-#         return False
 
 @app.callback(
     Output("latest-alerts-toast", "is_open"),

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -101,9 +101,9 @@ noresults_toast = dbc.Toast(
     [State("noresults-toast", "is_open")],
 )
 def open_noresults(n, table, is_open):
-    if n and not table.children:
-        return not is_open
-    return is_open
+    if n and table.children is None:
+        return True
+    return False
 
 object_id = dbc.FormGroup(
     [

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -85,11 +85,11 @@ conesearch = dbc.FormGroup(
         dbc.FormText("e.g. 271.3914265, 45.2545134, 5"),
         dbc.Tooltip(
             dcc.Markdown("""Perform a conesearch around a position on the sky given by (RA, Dec, radius). The initializer for RA/Dec is very flexible and supports inputs provided in a number of convenient formats. The following ways of initializing a conesearch are all equivalent (radius in arcsecond):"
-              271.3914265, 45.2545134, 5
-              271d23m29.1354s, 45d15m16.2482s, 5
-              18h05m33.9424s, +45d15m16.2482s, 5
-              18 05 33.9424, +45 15 16.2482, 5
-              18:05:33.9424, 45:15:16.2482, 5
+            * 271.3914265, 45.2545134, 5
+            * 271d23m29.1354s, 45d15m16.2482s, 5
+            * 18h05m33.9424s, +45d15m16.2482s, 5
+            * 18 05 33.9424, +45 15 16.2482, 5
+            * 18:05:33.9424, 45:15:16.2482, 5
             """),
             target="conesearch",
             placement='right',

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -112,10 +112,10 @@ noresults_toast = dbc.Toast(
     ]
 )
 def open_noresults(n, table, objectid, radecradius, startdate, window, alert_class):
-    id_click = (objectid is not None) or (objectid != '')
-    conesearch_click = (radecradius is not None) or (radecradius != '')
-    date_click = (startdate is not None) or (startdate != '')
-    class_click = (alert_class is not None) or (alert_class != '')
+    id_click = (objectid is not None) and (objectid != '')
+    conesearch_click = (radecradius is not None) and (radecradius != '')
+    date_click = (startdate is not None) and (startdate != '')
+    class_click = (alert_class is not None) and (alert_class != '')
 
     # ugly hack on the type
     if n and (table['namespace'] == 'dash_html_components'):

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -87,8 +87,8 @@ simbad_types = np.sort(simbad_types)
 
 noresults_toast = dbc.Toast(
     "", #dcc.Markdown("Try another query", className="mb-0"),
+    header="",
     id="noresults-toast",
-    header="No results found",
     icon="danger",
     dismissable=True,
     is_open=False,
@@ -98,7 +98,8 @@ noresults_toast = dbc.Toast(
 @app.callback(
     [
         Output("noresults-toast", "is_open"),
-        Output("noresults-toast", "children")
+        Output("noresults-toast", "children"),
+        Output("noresults-toast", "header")
     ],
     [
         Input("submit_query", "n_clicks"),
@@ -119,12 +120,15 @@ def open_noresults(n, table, objectid, radecradius, startdate, window, alert_cla
     # ugly hack on the type
     if n and (table['namespace'] == 'dash_html_components'):
         if id_click:
+            header = "Search by Object ID"
             text = "{} not found".format(objectid)
         elif conesearch_click:
+            header = "Conesearch"
             text = "No alerts found for (RA, Dec, radius) = {}".format(
                 radecradius
             )
         elif date_click:
+            header = "Search by Date"
             if window >= 0:
                 jd_start = Time(startdate).jd
                 jd_end = jd_start + TimeDelta(window * 60, format='sec').jd
@@ -136,6 +140,7 @@ def open_noresults(n, table, objectid, radecradius, startdate, window, alert_cla
             else:
                 text = "You need to set a window (in minutes)"
         elif class_click:
+            header = "Get latest 100 alerts by class"
             # start of the Fink operations
             jd_start = Time('2019-11-01 00:00:00').jd
             jd_stop = Time.now().jd

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -60,7 +60,7 @@ _The table shows:_
 msg_conesearch = """
 Perform a conesearch around a position on the sky given by (RA, Dec, radius).
 The initializer for RA/Dec is very flexible and supports inputs provided in a number of convenient formats.
-The following ways of initializing a conesearch are all equivalent (radius in arcsecond):             
+The following ways of initializing a conesearch are all equivalent (radius in arcsecond):
 
 * 271.3914265, 45.2545134, 5
 * 271d23m29.1354s, 45d15m16.2482s, 5
@@ -69,12 +69,53 @@ The following ways of initializing a conesearch are all equivalent (radius in ar
 * 18:05:33.9424, 45:15:16.2482, 5
 """
 
+msg_objectid = """
+Enter a valid object ID to access its data, e.g. try:
+
+* ZTF19acmdpyr, ZTF19acnjwgm, ZTF17aaaabte, ZTF20abqehqf, ZTF18acuajcr
+"""
+
+msg_date = """
+Choose a starting date and a time window to see all alerts in this period.
+Dates are in UTC, and the time window in minutes.
+Example of valid search:
+
+* 2019-11-03 02:40:00
+"""
+
+msg_latest_alerts = """
+Choose a class of interest using the drop-down menu to see the 100 latest alerts processed by Fink.
+"""
+
 simbad_types = pd.read_csv('assets/simbad_types.csv', header=None)[0].values
 simbad_types = np.sort(simbad_types)
 
 object_id = dbc.FormGroup(
     [
-        dbc.Label("Search by Object ID"),
+        dbc.Label(
+            dbc.Row(
+                [
+                    dbc.Col(
+                        dbc.Button(
+                            "",
+                            color="secondary",
+                            id='open-objectid',
+                            outline=True,
+                            size="sm",
+                            style=dict(height='10%')
+                        ), width=1),
+                    dbc.Col("Search by Object ID", width=1),
+                ],
+            )
+        ),
+        dbc.Toast(
+            [dcc.Markdown(msg_objectid, className="mb-0")],
+            id="objectid-toast",
+            header="ObjectId help",
+            icon="light",
+            dismissable=True,
+            is_open=False
+        ),
         dbc.Input(
             placeholder="e.g. ZTF19acmdpyr",
             type="text",
@@ -85,9 +126,42 @@ object_id = dbc.FormGroup(
     ], style={'width': '100%', 'display': 'inline-block'}
 )
 
+@app.callback(
+    Output("objectid-toast", "is_open"),
+    [Input("open-objectid", "n_clicks")],
+)
+def open_objectid(n):
+    if n > 0:
+        return True
+    else:
+        return False
+
 conesearch = dbc.FormGroup(
     [
-        dbc.Label("Conesearch"),
+        dbc.Label(
+            dbc.Row(
+                [
+                    dbc.Col(
+                        dbc.Button(
+                            "",
+                            color="secondary",
+                            id='open-conesearch',
+                            outline=True,
+                            size="sm",
+                            style=dict(height='10%')
+                        ), width=1),
+                    dbc.Col("Conesearch", width=1),
+                ],
+            )
+        ),
+        dbc.Toast(
+            [dcc.Markdown(msg_conesearch, className="mb-0")],
+            id="conesearch-toast",
+            header="Conesearch help",
+            icon="light",
+            dismissable=True,
+            is_open=False
+        ),
         dbc.Input(
             placeholder="ra, dec, radius",
             type="text",
@@ -95,17 +169,45 @@ conesearch = dbc.FormGroup(
             debounce=True
         ),
         dbc.FormText("e.g. 271.3914265, 45.2545134, 5"),
-        dbc.Tooltip(
-            dcc.Markdown(msg_conesearch),
-            target="conesearch",
-            placement='right',
-        ),
     ], style={'width': '100%', 'display': 'inline-block'}
 )
 
+@app.callback(
+    Output("conesearch-toast", "is_open"),
+    [Input("open-conesearch", "n_clicks")],
+)
+def open_conesearch(n):
+    if n > 0:
+        return True
+    else:
+        return False
+
 date_range = dbc.FormGroup(
     [
-        dbc.Label("Search by Date"),
+        dbc.Label(
+            dbc.Row(
+                [
+                    dbc.Col(
+                        dbc.Button(
+                            "",
+                            color="secondary",
+                            id='open-date',
+                            outline=True,
+                            size="sm",
+                            style=dict(height='10%')
+                        ), width=1),
+                    dbc.Col("Search by Date", width=1),
+                ],
+            )
+        ),
+        dbc.Toast(
+            [dcc.Markdown(msg_date, className="mb-0")],
+            id="date-toast",
+            header="Date help",
+            icon="light",
+            dismissable=True,
+            is_open=False
+        ),
         html.Br(),
         dbc.Input(
             placeholder="YYYY-MM-DD HH:mm:ss",
@@ -125,9 +227,42 @@ date_range = dbc.FormGroup(
     ], style={'width': '100%', 'display': 'inline-block'}
 )
 
+@app.callback(
+    Output("date-toast", "is_open"),
+    [Input("open-date", "n_clicks")],
+)
+def open_date(n):
+    if n > 0:
+        return True
+    else:
+        return False
+
 dropdown = dbc.FormGroup(
     [
-        dbc.Label("Get latest 100 alerts by class"),
+        dbc.Label(
+            dbc.Row(
+                [
+                    dbc.Col(
+                        dbc.Button(
+                            "",
+                            color="secondary",
+                            id='open-latest-alerts',
+                            outline=True,
+                            size="sm",
+                            style=dict(height='10%')
+                        ), width=1),
+                    dbc.Col("Get latest 100 alerts by class", width=1),
+                ],
+            )
+        ),
+        dbc.Toast(
+            [dcc.Markdown(msg_latest_alerts, className="mb-0")],
+            id="latest-alerts-toast",
+            header="Latest alerts help",
+            icon="light",
+            dismissable=True,
+            is_open=False
+        ),
         dcc.Dropdown(
             id='class-dropdown',
             options=[
@@ -147,6 +282,16 @@ dropdown = dbc.FormGroup(
         )
     ], style={'width': '100%', 'display': 'inline-block'}
 )
+
+@app.callback(
+    Output("latest-alerts-toast", "is_open"),
+    [Input("open-latest-alerts", "n_clicks")],
+)
+def open_latest_alerts(n):
+    if n > 0:
+        return True
+    else:
+        return False
 
 submit_button = dbc.Button(
     'Submit Query',

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -141,9 +141,9 @@ def open_noresults(n, table, objectid, radecradius, startdate, window, alert_cla
             jd_stop = Time.now().jd
 
             text = "No alerts for class {} in between {} and {}".format(
-                class,
+                alert_class,
                 Time(jd_start, format='jd').iso,
-                Time(jd_end, format='jd').iso
+                Time(jd_stop, format='jd').iso
             )
         return True, text
     return False, ""

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -101,7 +101,7 @@ noresults_toast = dbc.Toast(
     [State("noresults-toast", "is_open")],
 )
 def open_noresults(n, table, is_open):
-    if n and table.children is None:
+    if n and table is None:
         return True
     return False
 

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -84,12 +84,13 @@ conesearch = dbc.FormGroup(
         ),
         dbc.FormText("e.g. 271.3914265, 45.2545134, 5"),
         dbc.Tooltip(
-            "Perform a conesearch around a position on the sky given by (RA, Dec, radius). The initializer for RA/Dec is very flexible and supports inputs provided in a number of convenient formats. The following ways of initializing a conesearch are all equivalent (radius in arcsecond):"
-            "271.3914265, 45.2545134, 5"
-            "271d23m29.1354s, 45d15m16.2482s, 5"
-            "18h05m33.9424s, +45d15m16.2482s, 5"
-            "18 05 33.9424, +45 15 16.2482, 5"
-            "18:05:33.9424, 45:15:16.2482, 5",
+            """Perform a conesearch around a position on the sky given by (RA, Dec, radius). The initializer for RA/Dec is very flexible and supports inputs provided in a number of convenient formats. The following ways of initializing a conesearch are all equivalent (radius in arcsecond):"
+              271.3914265, 45.2545134, 5
+              271d23m29.1354s, 45d15m16.2482s, 5
+              18h05m33.9424s, +45d15m16.2482s, 5
+              18 05 33.9424, +45 15 16.2482, 5
+              18:05:33.9424, 45:15:16.2482, 5
+            """,
             target="conesearch",
             placement='right',
         ),

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -91,6 +91,7 @@ conesearch = dbc.FormGroup(
             "18 05 33.9424, +45 15 16.2482, 5"
             "18:05:33.9424, 45:15:16.2482, 5",
             target="conesearch",
+            placement='right',
         ),
     ], style={'width': '100%', 'display': 'inline-block'}
 )

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -97,10 +97,9 @@ noresults_toast = dbc.Toast(
 
 @app.callback(
     Output("noresults-toast", "is_open"),
-    [Input("submit_query", "n_clicks"), Input("table", "children")],
-    [State("noresults-toast", "is_open")],
+    [Input("submit_query", "n_clicks"), Input("table", "children")]
 )
-def open_noresults(n, table, is_open):
+def open_noresults(n, table):
     if n and table is None:
         return True
     return False

--- a/assets/home.css
+++ b/assets/home.css
@@ -27,3 +27,5 @@ html, body {
   top: 0; left: 0; bottom: 0; right: 0;
   vertical-align: middle;
 }
+
+img[alt=logoexp] { width: 200px; horizontal-align: middle; display: block; margin: auto;}


### PR DESCRIPTION
This PR brings two major change in the explorer documentation:
- Help for each type of query is now accessible next to the query (#35 )

<img width="433" alt="Screenshot 2020-11-24 at 13 13 28" src="https://user-images.githubusercontent.com/20426972/100092752-df19b080-2e56-11eb-80af-2c154b29d4a8.png">


- A message is shown whenever the query returns no results, or is not allowed (e.g. multi index search) (#36 )

<img width="1440" alt="Screenshot 2020-11-24 at 13 12 50" src="https://user-images.githubusercontent.com/20426972/100092760-e345ce00-2e56-11eb-8d41-1ef208f8de3f.png">

<img width="1440" alt="Screenshot 2020-11-24 at 13 13 07" src="https://user-images.githubusercontent.com/20426972/100092767-e6d95500-2e56-11eb-97bd-7fe3a4e668cf.png">


