### PR TITLE
[Explorer] add color evolution (r-g and its rate) in the explorer page

### DIFF
--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -445,7 +445,7 @@ schema = clientP.schema()
 schema_list = list(schema.columnNames())
 fink_fields = [i for i in schema_list if i.startswith('d:')]
 ztf_fields = [i for i in schema_list if i.startswith('i:')]
-fink_additional_fields = ['d:r-g', 'd:classification', 'i:lastdate']
+fink_additional_fields = ['a:r-g', 'a:classification', 'a:lastdate']
 
 layout = html.Div(
     [
@@ -742,9 +742,10 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
         pdfs['i:classtar']
     )
 
-    pdfs['d:classification'] = classifications
+    pdfs['a:classification'] = classifications
 
-    pdfs['d:r-g'] = extract_last_r_minus_g_each_object(pdfs)
+    pdfs = pdfs.sort_values('i:objectId')
+    pdfs['a:r-g'] = extract_last_r_minus_g_each_object(pdfs)
 
     # Make clickable objectId
     pdfs['i:objectId'] = pdfs['i:objectId'].apply(markdownify_objectid)
@@ -752,7 +753,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
     # Display only the last alert
     pdfs['i:jd'] = pdfs['i:jd'].astype(float)
     pdfs = pdfs.loc[pdfs.groupby('i:objectId')['i:jd'].idxmax()]
-    pdfs['i:lastdate'] = pdfs['i:jd'].apply(convert_jd)
+    pdfs['a:lastdate'] = pdfs['i:jd'].apply(convert_jd)
 
     data = pdfs.sort_values('i:jd', ascending=False).to_dict('records')
 

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -445,7 +445,7 @@ schema = clientP.schema()
 schema_list = list(schema.columnNames())
 fink_fields = [i for i in schema_list if i.startswith('d:')]
 ztf_fields = [i for i in schema_list if i.startswith('i:')]
-fink_additional_fields = ['a:r-g', 'a:rate(r-g)', 'a:classification', 'a:lastdate']
+fink_additional_fields = ['v:r-g', 'v:rate(r-g)', 'v:classification', 'v:lastdate']
 
 layout = html.Div(
     [
@@ -618,7 +618,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
         return [], []
 
     colnames_to_display = [
-        'i:objectId', 'i:ra', 'i:dec', 'a:lastdate', 'a:classification', 'i:ndethist'
+        'i:objectId', 'i:ra', 'i:dec', 'v:lastdate', 'v:classification', 'i:ndethist'
     ]
 
     # default table
@@ -792,13 +792,13 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
         pdfs['i:classtar']
     )
 
-    pdfs['a:classification'] = classifications
+    pdfs['v:classification'] = classifications
 
     pdfs = pdfs.sort_values('i:objectId')
-    pdfs['a:r-g'] = extract_last_r_minus_g_each_object(pdfs, kind='last')
-    pdfs['a:rate(r-g)'] = extract_last_r_minus_g_each_object(pdfs, kind='rate')
+    pdfs['v:r-g'] = extract_last_r_minus_g_each_object(pdfs, kind='last')
+    pdfs['v:rate(r-g)'] = extract_last_r_minus_g_each_object(pdfs, kind='rate')
     if alert_class is not None and alert_class != '' and alert_class != 'allclasses':
-        pdfs = pdfs[pdfs['a:classification'] == alert_class]
+        pdfs = pdfs[pdfs['v:classification'] == alert_class]
 
     # Make clickable objectId
     pdfs['i:objectId'] = pdfs['i:objectId'].apply(markdownify_objectid)
@@ -806,7 +806,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
     # Display only the last alert
     pdfs['i:jd'] = pdfs['i:jd'].astype(float)
     pdfs = pdfs.loc[pdfs.groupby('i:objectId')['i:jd'].idxmax()]
-    pdfs['a:lastdate'] = pdfs['i:jd'].apply(convert_jd)
+    pdfs['v:lastdate'] = pdfs['i:jd'].apply(convert_jd)
 
     data = pdfs.sort_values('i:jd', ascending=False).to_dict('records')
 

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -744,7 +744,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
 
     pdfs['d:classification'] = classifications
 
-    # pdfs['d:r-g'] = extract_last_r_minus_g_each_object(pdfs)
+    pdfs['d:r-g'] = extract_last_r_minus_g_each_object(pdfs)
 
     # Make clickable objectId
     pdfs['i:objectId'] = pdfs['i:objectId'].apply(markdownify_objectid)

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -662,6 +662,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
                 results = r
             else:
                 results.putAll(r)
+            count += 1
 
     # Search for latest alerts (all classes)
     elif alert_class == 'allclasses':

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -648,6 +648,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
             ),
             "*", 0, False, False
         )
+        schema_client = clientS.schema()
 
         # Slow but accurate solution below
         # # Get first objectId
@@ -694,6 +695,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
             "*",
             0, True, True
         )
+        schema_client = clientT.schema()
     elif radecradius is not None and radecradius != '':
         clientP.setLimit(1000)
 
@@ -724,6 +726,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
             "*",
             0, True, True
         )
+        schema_client = clientP.schema()
     elif startdate is not None and window is not None and startdate != '':
         # Time to jd
         jd_start = Time(startdate).jd
@@ -738,6 +741,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
             "*",
             0, True, True
         )
+        schema_client = clientT.schema()
     else:
         # objectId search
         # TODO: check input with a regex
@@ -749,6 +753,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
             "*",
             0, True, True
         )
+        schema_client = client.schema()
 
     # reset the limit in case it has been changed above
     client.setLimit(nlimit)
@@ -759,7 +764,10 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
     # Loop over results and construct the dataframe
     pdfs = pd.DataFrame.from_dict(results, orient='index')
 
-    schema_client = client.schema()
+    # weird... I do not understand why this can happen (all indices table are treated the same)
+    if 'key:key' in pdfs.columns or 'key:time' in pdfs.columns:
+        pdfs = pdfs.drop(columns=['key:key', 'key:time'])
+
     converter = {
         'integer': int,
         'long': int,

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -628,6 +628,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
 
     # Search for latest alerts for a specific class
     if alert_class is not None and alert_class != '' and alert_class != 'allclasses':
+        # double trouble method
         clientS.setLimit(100)
         clientS.setRangeScan(True)
         clientS.setReversed(True)
@@ -636,7 +637,8 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
         jd_start = Time('2019-11-01 00:00:00').jd
         jd_stop = Time.now().jd
 
-        results = clientS.scan(
+        # Get first objectId
+        objectids = clientS.scan(
             "",
             "key:key:{}_{},key:key:{}_{}".format(
                 alert_class,
@@ -644,8 +646,19 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
                 alert_class,
                 jd_stop
             ),
-            "*", 0, False, False
+            "i:objectId", 0, False, False
         )
+        pdf_objectids = pd.DataFrame.from_dict(objectids, orient='index')
+
+        # Get data then
+        results = {}
+        for obj in np.unique(pdf_objectids['i:objectId'].values):
+            r = client.scan(
+                "",
+                "key:key:{}".format(obj),
+                "*", 0, False, False
+            )
+            results.update(dict(r))
     # Search for latest alerts (all classes)
     elif alert_class == 'allclasses':
         clientT.setLimit(100)

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -637,8 +637,8 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
         jd_start = Time('2019-11-01 00:00:00').jd
         jd_stop = Time.now().jd
 
-        # Get first objectId
-        objectids = clientS.scan(
+        # Fast but inaccurate solution
+        results = clientS.scan(
             "",
             "key:key:{}_{},key:key:{}_{}".format(
                 alert_class,
@@ -646,23 +646,36 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
                 alert_class,
                 jd_stop
             ),
-            "i:objectId", 0, False, False
+            "*", 0, False, False
         )
-        pdf_objectids = pd.DataFrame.from_dict(objectids, orient='index')
 
-        # Get data then
-        count = 0
-        for obj in np.unique(pdf_objectids['i:objectId'].values):
-            r = client.scan(
-                "",
-                "key:key:{}".format(obj),
-                "*", 0, False, False
-            )
-            if count == 0:
-                results = r
-            else:
-                results.putAll(r)
-            count += 1
+        # Slow but accurate solution below
+        # # Get first objectId
+        # objectids = clientS.scan(
+        #     "",
+        #     "key:key:{}_{},key:key:{}_{}".format(
+        #         alert_class,
+        #         jd_start,
+        #         alert_class,
+        #         jd_stop
+        #     ),
+        #     "i:objectId", 0, False, False
+        # )
+        # pdf_objectids = pd.DataFrame.from_dict(objectids, orient='index')
+        #
+        # # Get data then
+        # count = 0
+        # for obj in np.unique(pdf_objectids['i:objectId'].values):
+        #     r = client.scan(
+        #         "",
+        #         "key:key:{}".format(obj),
+        #         "*", 0, False, False
+        #     )
+        #     if count == 0:
+        #         results = r
+        #     else:
+        #         results.putAll(r)
+        #     count += 1
 
     # Search for latest alerts (all classes)
     elif alert_class == 'allclasses':

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -445,7 +445,7 @@ schema = clientP.schema()
 schema_list = list(schema.columnNames())
 fink_fields = [i for i in schema_list if i.startswith('d:')]
 ztf_fields = [i for i in schema_list if i.startswith('i:')]
-fink_additional_fields = ['a:r-g', 'a:classification', 'a:lastdate']
+fink_additional_fields = ['a:r-g', 'a:rate(r-g)', 'a:classification', 'a:lastdate']
 
 layout = html.Div(
     [
@@ -774,7 +774,8 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
     pdfs['a:classification'] = classifications
 
     pdfs = pdfs.sort_values('i:objectId')
-    pdfs['a:r-g'] = extract_last_r_minus_g_each_object(pdfs)
+    pdfs['a:r-g'] = extract_last_r_minus_g_each_object(pdfs, kind='last')
+    pdfs['a:rate(r-g)'] = extract_last_r_minus_g_each_object(pdfs, kind='rate')
     if alert_class is not None and alert_class != '' and alert_class != 'allclasses':
         pdfs = pdfs[pdfs['a:classification'] == alert_class]
 

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -775,6 +775,8 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
 
     pdfs = pdfs.sort_values('i:objectId')
     pdfs['a:r-g'] = extract_last_r_minus_g_each_object(pdfs)
+    if alert_class is not None and alert_class != '' and alert_class != 'allclasses':
+        pdfs = pdfs[pdfs['a:classification'] == alert_class]
 
     # Make clickable objectId
     pdfs['i:objectId'] = pdfs['i:objectId'].apply(markdownify_objectid)

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -651,14 +651,18 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
         pdf_objectids = pd.DataFrame.from_dict(objectids, orient='index')
 
         # Get data then
-        results = {}
+        count = 0
         for obj in np.unique(pdf_objectids['i:objectId'].values):
             r = client.scan(
                 "",
                 "key:key:{}".format(obj),
                 "*", 0, False, False
             )
-            results.update(dict(r))
+            if count == 0:
+                results = r
+            else:
+                results.putAll(r)
+
     # Search for latest alerts (all classes)
     elif alert_class == 'allclasses':
         clientT.setLimit(100)

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -744,7 +744,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
 
     pdfs['d:classification'] = classifications
 
-    pdfs['d:r-g'] = extract_last_r_minus_g_each_object(pdfs)
+    # pdfs['d:r-g'] = extract_last_r_minus_g_each_object(pdfs)
 
     # Make clickable objectId
     pdfs['i:objectId'] = pdfs['i:objectId'].apply(markdownify_objectid)

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -751,7 +751,8 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
         'long': int,
         'float': float,
         'double': float,
-        'string': str
+        'string': str,
+        'fits/image': str
     }
     pdfs = pdfs.astype({i: converter[schema_client.type(i)] for i in pdfs.columns})
 

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -618,7 +618,7 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
         return [], []
 
     colnames_to_display = [
-        'i:objectId', 'i:ra', 'i:dec', 'i:lastdate', 'd:classification', 'i:ndethist'
+        'i:objectId', 'i:ra', 'i:dec', 'a:lastdate', 'a:classification', 'i:ndethist'
     ]
 
     # default table
@@ -727,6 +727,16 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
 
     # Loop over results and construct the dataframe
     pdfs = pd.DataFrame.from_dict(results, orient='index')
+
+    schema_client = client.schema()
+    converter = {
+        'integer': int,
+        'long': int,
+        'float': float,
+        'double': float,
+        'string': str
+    }
+    pdfs = pdfs.astype({i: converter[schema_client.type(i)] for i in pdfs.columns})
 
     # Fink final classification
     classifications = extract_fink_classification(

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -588,6 +588,8 @@ def construct_table(n_clicks, reset_button, objectid, radecradius, startdate, wi
         columns.append({
             'name': field_dropdown,
             'id': field_dropdown,
+            'type': 'text',
+            'presentation': 'markdown'
             # 'hideable': True,
         })
 

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -407,6 +407,7 @@ def extract_last_r_minus_g_each_object(pdf):
 
         subpdf['i:jd'] = subpdf['i:jd'].astype(float)
         subpdf['i:fid'] = subpdf['i:fid'].astype(int)
+        subpdf = subpdf.sort_values('i:jd', ascending=False)
 
         # Compute DC mag
         cols = [

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -405,6 +405,9 @@ def extract_last_r_minus_g_each_object(pdf):
     for id_ in ids:
         subpdf = pdf[pdf['i:objectId'] == id_]
 
+        subpdf['i:jd'] = subpdf['i:jd'].astype(float)
+        subpdf['i:fid'] = subpdf['i:jd'].astype(int)
+
         # Compute DC mag
         cols = [
             'i:fid', 'i:magpsf', 'i:sigmapsf', 'i:magnr', 'i:sigmagnr', 'i:magzpsci', 'i:isdiffpos',

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -441,6 +441,11 @@ def extract_last_r_minus_g_each_object(pdf):
                 ]
             )
         else:
-            last_r_minus_g = None
+            last_r_minus_g = np.concatenate(
+                [
+                    last_r_minus_g,
+                    [None] * len(subpdf)
+                ]
+            )
 
     return last_r_minus_g

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -372,3 +372,69 @@ def dc_mag(fid, magpsf, sigmapsf, magnr, sigmagnr, magzpsci, isdiffpos):
         dc_sigmag = sigmapsf
 
     return dc_mag, dc_sigmag
+
+def r_minus_g(fid, mag):
+    """ Compute r-g based on vectors of filters and magnitudes
+    """
+    if len(fid) == 2:
+        # +1 if [g, r]
+        # -1 if [r, g]
+        sign = np.diff(fid)[0]
+    else:
+        # last measurement
+        last_fid = fid[-1]
+
+        # last measurement with different filter
+        # could take the mean
+        index_other = np.where(np.array(fid) != last_fid)[0][-1]
+
+        sign = np.diff([fid[index_other], last_fid])[0]
+        mag = [mag[index_other], mag[-1]]
+
+    return sign * np.diff(mag)[0]
+
+def extract_last_r_minus_g_each_object(pdf):
+    """ Extract last r-g for each object in a pandas DataFrame
+    """
+    # extract unique objects
+    ids, indices = np.unique(pdf['i:objectId'].values, return_index=True)
+    ids = [pdf['i:objectId'].values[index] for index in sorted(indices)]
+    last_r_minus_g = []
+
+    # loop over objects
+    for id_ in ids:
+        subpdf = pdf[pdf['i:objectId'] == id_]
+
+        # Compute DC mag
+        cols = [
+            'i:fid', 'i:magpsf', 'i:sigmapsf', 'i:magnr', 'i:sigmagnr', 'i:magzpsci', 'i:isdiffpos',
+        ]
+
+        mag, err = np.array(
+            [
+                dc_mag(i[0], i[1], i[2], i[3], i[4], i[5], i[6])
+                    for i in zip(*[subpdf[j].values for j in cols])
+            ]
+        ).T
+        subpdf['i:dcmag'] = mag
+
+        # group by night
+        gpdf = subpdf.groupby('i:nid')[['i:dcmag', 'i:fid', 'i:jd']].agg(list)
+
+        # take only nights with at least measurements on 2 different filters
+        mask = gpdf['i:fid'].apply(
+            lambda x: (len(x) > 1) & (np.sum(x) / len(x) != x[0])
+        )
+        gpdf_night = gpdf[mask]
+
+        # compute r-g for those nights
+        gpdf_night['r-g'] = [r_minus_g(i, j) for i, j in zip(gpdf_night['i:fid'].values, gpdf_night['i:dcmag'].values)]
+
+        last_r_minus_g = np.concatenate(
+            [
+                last_r_minus_g,
+                [gpdf_night['r-g'].values[-1]]*len(subpdf)
+            ]
+        )
+
+    return last_r_minus_g

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -393,13 +393,13 @@ def r_minus_g(fid, mag):
 
     return sign * np.diff(mag)[0]
 
-def extract_last_r_minus_g_each_object(pdf):
+def extract_last_r_minus_g_each_object(pdf, kind):
     """ Extract last r-g for each object in a pandas DataFrame
     """
     # extract unique objects
     ids, indices = np.unique(pdf['i:objectId'].values, return_index=True)
     ids = [pdf['i:objectId'].values[index] for index in sorted(indices)]
-    last_r_minus_g = []
+    r_minus_g = []
 
     # loop over objects
     for id_ in ids:
@@ -434,19 +434,29 @@ def extract_last_r_minus_g_each_object(pdf):
         # compute r-g for those nights
         values = [r_minus_g(i, j) for i, j in zip(gpdf_night['i:fid'].values, gpdf_night['i:dcmag'].values)]
 
-        if len(values) > 0:
-            last_r_minus_g = np.concatenate(
+        if kind == 'last':
+            if len(values) > 0:
+                val = values[-1]
+            else:
+                val = None
+            r_minus_g = np.concatenate(
                 [
-                    last_r_minus_g,
-                    [values[-1]] * len(subpdf)
+                    r_minus_g,
+                    [val] * len(subpdf)
                 ]
             )
-        else:
-            last_r_minus_g = np.concatenate(
+        elif kind == 'rate':
+            if len(values) > 1:
+                val = values[-1] - values[0]
+                dt = np.mean(gpdf_night['i:jd'].values[-1]) - np.mean(gpdf_night['i:jd'].values[0])
+                rate = val / dt
+            else:
+                rate = None
+            r_minus_g = np.concatenate(
                 [
-                    last_r_minus_g,
-                    [None] * len(subpdf)
+                    r_minus_g,
+                    [rate] * len(subpdf)
                 ]
             )
 
-    return last_r_minus_g
+    return r_minus_g

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -412,7 +412,7 @@ def extract_last_r_minus_g_each_object(pdf):
 
         mag, err = np.array(
             [
-                dc_mag(i[0], i[1], i[2], i[3], i[4], i[5], i[6])
+                dc_mag(int(i[0]), float(i[1]), float(i[2]), float(i[3]), float(i[4]), float(i[5]), i[6])
                     for i in zip(*[subpdf[j].values for j in cols])
             ]
         ).T

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -406,7 +406,7 @@ def extract_last_r_minus_g_each_object(pdf):
         subpdf = pdf[pdf['i:objectId'] == id_]
 
         subpdf['i:jd'] = subpdf['i:jd'].astype(float)
-        subpdf['i:fid'] = subpdf['i:jd'].astype(int)
+        subpdf['i:fid'] = subpdf['i:fid'].astype(int)
 
         # Compute DC mag
         cols = [

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -399,7 +399,7 @@ def extract_last_r_minus_g_each_object(pdf, kind):
     # extract unique objects
     ids, indices = np.unique(pdf['i:objectId'].values, return_index=True)
     ids = [pdf['i:objectId'].values[index] for index in sorted(indices)]
-    r_minus_g = []
+    out_r_minus_g = []
 
     # loop over objects
     for id_ in ids:
@@ -439,9 +439,9 @@ def extract_last_r_minus_g_each_object(pdf, kind):
                 val = values[-1]
             else:
                 val = None
-            r_minus_g = np.concatenate(
+            out_r_minus_g = np.concatenate(
                 [
-                    r_minus_g,
+                    out_r_minus_g,
                     [val] * len(subpdf)
                 ]
             )
@@ -452,11 +452,11 @@ def extract_last_r_minus_g_each_object(pdf, kind):
                 rate = val / dt
             else:
                 rate = None
-            r_minus_g = np.concatenate(
+            out_r_minus_g = np.concatenate(
                 [
-                    r_minus_g,
+                    out_r_minus_g,
                     [rate] * len(subpdf)
                 ]
             )
 
-    return r_minus_g
+    return out_r_minus_g

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -431,13 +431,16 @@ def extract_last_r_minus_g_each_object(pdf):
         gpdf_night = gpdf[mask]
 
         # compute r-g for those nights
-        gpdf_night['r-g'] = [r_minus_g(i, j) for i, j in zip(gpdf_night['i:fid'].values, gpdf_night['i:dcmag'].values)]
+        values = [r_minus_g(i, j) for i, j in zip(gpdf_night['i:fid'].values, gpdf_night['i:dcmag'].values)]
 
-        last_r_minus_g = np.concatenate(
-            [
-                last_r_minus_g,
-                [gpdf_night['r-g'].values[-1]]*len(subpdf)
-            ]
-        )
+        if len(values) > 0:
+            last_r_minus_g = np.concatenate(
+                [
+                    last_r_minus_g,
+                    [values[-1]] * len(subpdf)
+                ]
+            )
+        else:
+            last_r_minus_g = None
 
     return last_r_minus_g


### PR DESCRIPTION
#59 

Users can now add columns with the measurement of the last `r-g` and the `rate(r-g)`. 

There are some limitations though:
- `r-g` is measured from two measurements inside the same night. The displayed `r-g` is not from the latest measurement, but from the latest night from which we had at least two measurements. Hence keep in mind the displayed `r-g` can be a week old. You can check when this value was taken by looking at object data directly.
- When displaying data from latest class `C`, we query the database for alerts with classtag `C`. `r-g` and its rate are computed from this pool of results. Hence if an object has alert with different classtag, its `r-g` can be different than the one that would be derived from the full object data (since alerts with classtag `C` represent only a subset of all data for this object). I implemented a method to get this correctly, but it is slow. Hence for the moment it is not used.
- `r-g` and its rate are based on DC magnitudes.

Remaining (other PR):
- Add this information when downloading the data
- Add `r-g` evolution in the SN view
- Add `r-g` and its rate in the textual information on the summary & SN views