### PR TITLE
Select alert fields to transfer

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -705,6 +705,7 @@ def latest_objects():
             ),
             "*", 0, False, False
         )
+        schema_client = clientS.schema()
     elif request.json['class'] == 'allclasses':
         clientT.setLimit(nalerts)
         clientT.setRangeScan(True)
@@ -721,6 +722,7 @@ def latest_objects():
             "*",
             0, True, True
         )
+        schema_client = clientT.schema()
 
     if results.isEmpty():
         return pd.DataFrame({}).to_json()

--- a/apps/api.py
+++ b/apps/api.py
@@ -514,22 +514,6 @@ def query_db():
             }
             return Response(str(rep), 400)
 
-    # Columns of interest
-    colnames = [
-        'i:objectId', 'i:ra', 'i:dec', 'i:jd', 'd:cdsxmatch', 'i:ndethist'
-    ]
-
-    # Column name to display
-    colnames_to_display = [
-        'i:objectId', 'i:ra', 'i:dec', 'v:lastdate', 'v:classification', 'i:ndethist'
-    ]
-
-    # Types of columns
-    dtypes_ = [
-        np.str, np.float, np.float, np.float, np.str, np.int
-    ]
-    dtypes = {i: j for i, j in zip(colnames, dtypes_)}
-
     if user_group == 0:
         # objectId search
         to_evaluate = "key:key:{}".format(request.json['objectId'])

--- a/apps/api.py
+++ b/apps/api.py
@@ -550,7 +550,7 @@ def query_db():
         results = client.scan(
             "",
             to_evaluate,
-            ",".join(colnames + colnames_added_values),
+            "*",
             0, True, True
         )
         schema_client = client.schema()
@@ -588,7 +588,7 @@ def query_db():
         results = clientP.scan(
             "",
             to_evaluate,
-            ",".join(colnames + colnames_added_values),
+            "*",
             0, True, True
         )
         schema_client = clientP.schema()
@@ -609,7 +609,7 @@ def query_db():
         results = clientT.scan(
             "",
             to_evaluate,
-            ",".join(colnames + colnames_added_values),
+            "*",
             0, True, True
         )
         schema_client = clientT.schema()

--- a/apps/api.py
+++ b/apps/api.py
@@ -115,6 +115,11 @@ Note that the fields should be comma-separated. Unknown field names are ignored.
 api_doc_explorer = """
 ## Query the Fink alert database
 
+This service allows you to search matching objects in the database.
+If several alerts from the same object match the query, we group information and
+only display the data from the last alert. To get a full history about an object,
+you should use the `Retrieve single object data` service instead.
+
 Currently, you cannot query using several conditions.
 You must choose among `Search by Object ID` (group 0), `Conesearch` (group 1), or `Search by Date` (group 2).
 In a future release, you will be able to combine searches.
@@ -129,7 +134,7 @@ Enter a valid object ID to access its data, e.g. try:
 In a unix shell, you would simply use
 
 ```bash
-# Get data for ZTF19acnjwgm and save it in a CSV file
+# Get data for ZTF19acnjwgm and save it in a JSON file
 curl -H "Content-Type: application/json" -X POST -d '{"objectId":"ZTF19acnjwgm"}' http://134.158.75.151:24000/api/v1/explorer -o search_ZTF19acnjwgm.json
 ```
 

--- a/apps/api.py
+++ b/apps/api.py
@@ -399,6 +399,7 @@ args_explorer = [
     {
         'name': 'output-format',
         'required': False,
+        'group': None,
         'description': 'Output format among json[default], csv, parquet'
     }
 ]
@@ -501,14 +502,11 @@ def query_db():
     """
     if 'output-format' in request.json:
         output_format = request.json['output-format']
-
-        # remove from the dict as it has no group
-        request.json.pop('output-format')
     else:
         output_format = 'json'
 
     # Check the user specifies only one group
-    all_groups = [i['group'] for i in args_explorer if i['name'] in request.json]
+    all_groups = [i['group'] for i in args_explorer if i['group'] is not None and i['name'] in request.json]
     if len(np.unique(all_groups)) != 1:
         rep = {
             'status': 'error',

--- a/apps/api.py
+++ b/apps/api.py
@@ -109,7 +109,7 @@ r = requests.post(
 )
 ```
 
-Note that the fields should be comma-separated **without** space. Unknown field names are ignored.
+Note that the fields should be comma-separated. Unknown field names are ignored.
 """
 
 api_doc_explorer = """
@@ -442,7 +442,7 @@ def return_object():
             return Response(str(rep), 400)
 
     if 'columns' in request.json:
-        cols = request.json['columns']
+        cols = request.json['columns'].replace(" ", "")
     else:
         cols = '*'
     to_evaluate = "key:key:{}".format(request.json['objectId'])
@@ -517,19 +517,6 @@ def query_db():
     # Columns of interest
     colnames = [
         'i:objectId', 'i:ra', 'i:dec', 'i:jd', 'd:cdsxmatch', 'i:ndethist'
-    ]
-
-    colnames_added_values = [
-        'd:cdsxmatch',
-        'd:roid',
-        'd:mulens_class_1',
-        'd:mulens_class_2',
-        'd:snn_snia_vs_nonia',
-        'd:snn_sn_vs_all',
-        'd:rfscore',
-        'i:ndethist',
-        'i:drb',
-        'i:classtar'
     ]
 
     # Column name to display

--- a/apps/api.py
+++ b/apps/api.py
@@ -92,6 +92,22 @@ r = ...
 
 pd.read_csv(io.BytesIO(r.content))
 ```
+
+By default, we transfer all available data fields (original ZTF fields and Fink science module outputs).
+But you can also choose to transfer only a subset of the fields:
+
+```python
+# select only jd, and magpsf
+r = requests.post(
+  'http://134.158.75.151:24000/api/v1/objects',
+  json={
+    'objectId': 'ZTF19acnjwgm',
+    'columns': 'i:jd,i:magpsf'
+  }
+)
+```
+
+Note that the fields should be comma-separated **without** space. Unknown field names are ignored.
 """
 
 api_doc_explorer = """
@@ -435,6 +451,9 @@ def return_object():
         0, True, True
     )
     pdf = pd.DataFrame.from_dict(results, orient='index')
+
+    if 'key:key' in pdfs.columns or 'key:time' in pdf.columns:
+        pdf = pdf.drop(columns=['key:key', 'key:time'])
 
     if 'withcutouts' in request.json and request.json['withcutouts'] == 'True':
         pdf['b:cutoutScience_stampData'] = pdf['b:cutoutScience_stampData'].apply(

--- a/apps/api.py
+++ b/apps/api.py
@@ -647,11 +647,6 @@ def query_db():
     pdfs = pdfs.sort_values('i:objectId')
     pdfs['v:r-g'] = extract_last_r_minus_g_each_object(pdfs, kind='last')
     pdfs['v:rate(r-g)'] = extract_last_r_minus_g_each_object(pdfs, kind='rate')
-    if alert_class is not None and alert_class != '' and alert_class != 'allclasses':
-        pdfs = pdfs[pdfs['v:classification'] == alert_class]
-
-    # Make clickable objectId
-    pdfs['i:objectId'] = pdfs['i:objectId'].apply(markdownify_objectid)
 
     # Display only the last alert
     pdfs['i:jd'] = pdfs['i:jd'].astype(float)

--- a/apps/api.py
+++ b/apps/api.py
@@ -21,6 +21,7 @@ from flask import request, jsonify, Response
 from app import client, clientP, clientT, clientS, nlimit
 from apps.utils import extract_fink_classification, convert_jd
 from apps.utils import hbase_type_converter
+from apps.utils import extract_last_r_minus_g_each_object
 
 import io
 import requests

--- a/apps/api.py
+++ b/apps/api.py
@@ -703,7 +703,8 @@ def latest_objects():
         )
         schema_client = clientT.schema()
 
-    pdfs = format_hbase_output(results, schema_client, group_alerts=True)
+    # We want to return alerts
+    pdfs = format_hbase_output(results, schema_client, group_alerts=False)
 
     if output_format == 'json':
         return pdfs.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -330,6 +330,11 @@ args_objects = [
         'description': 'If True, retrieve also gzipped FITS cutouts.'
     },
     {
+        'name': 'columns',
+        'required': False,
+        'description': 'Comma-separated data columns to transfer. Default is all columns. See http://134.158.75.151:24000/api/v1/columns for more information.'
+    },
+    {
         'name': 'output-format',
         'required': False,
         'description': 'Output format among json[default], csv, parquet'
@@ -418,11 +423,15 @@ def return_object():
             }
             return Response(str(rep), 400)
 
+    if 'columns' in request.json:
+        cols = request.json['columns']
+    else:
+        cols = '*'
     to_evaluate = "key:key:{}".format(request.json['objectId'])
     results = client.scan(
         "",
         to_evaluate,
-        "*",
+        cols,
         0, True, True
     )
     pdf = pd.DataFrame.from_dict(results, orient='index')

--- a/apps/api.py
+++ b/apps/api.py
@@ -452,7 +452,7 @@ def return_object():
     )
     pdf = pd.DataFrame.from_dict(results, orient='index')
 
-    if 'key:key' in pdfs.columns or 'key:time' in pdf.columns:
+    if 'key:key' in pdf.columns or 'key:time' in pdf.columns:
         pdf = pdf.drop(columns=['key:key', 'key:time'])
 
     if 'withcutouts' in request.json and request.json['withcutouts'] == 'True':

--- a/apps/api.py
+++ b/apps/api.py
@@ -458,12 +458,19 @@ def return_object():
     else:
         cols = '*'
     to_evaluate = "key:key:{}".format(request.json['objectId'])
+
+    # We do not want to perform full scan if the objectid is a wildcard
+    client.setLimit(1000)
+
     results = client.scan(
         "",
         to_evaluate,
         cols,
         0, True, True
     )
+
+    # reset the limit in case it has been changed above
+    client.setLimit(nlimit)
 
     pdf = format_hbase_output(results, schema_client, group_alerts=False)
 
@@ -533,12 +540,18 @@ def query_db():
         # objectId search
         to_evaluate = "key:key:{}".format(request.json['objectId'])
 
+        # Avoid a full scan
+        client.setLimit(1000)
+
         results = client.scan(
             "",
             to_evaluate,
             "*",
             0, True, True
         )
+        # reset the limit in case it has been changed above
+        client.setLimit(nlimit)
+
         schema_client = client.schema()
     if user_group == 1:
         clientP.setLimit(1000)

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -36,6 +36,57 @@ hbase_type_converter = {
     'fits/image': str
 }
 
+def format_hbase_output(hbase_output, schema_client, group_alerts: bool):
+    """
+    """
+    if hbase_output.isEmpty():
+        return pd.DataFrame({}).to_json()
+
+    # Construct the dataframe
+    pdfs = pd.DataFrame.from_dict(hbase_output, orient='index')
+
+    # Remove hbase specific fields
+    if 'key:key' in pdfs.columns or 'key:time' in pdfs.columns:
+        pdfs = pdfs.drop(columns=['key:key', 'key:time'])
+
+    # Type conversion
+    pdfs = pdfs.astype(
+        {i: hbase_type_converter[schema_client.type(i)] for i in pdfs.columns})
+
+    # Fink final classification
+    classifications = extract_fink_classification(
+        pdfs['d:cdsxmatch'],
+        pdfs['d:roid'],
+        pdfs['d:mulens_class_1'],
+        pdfs['d:mulens_class_2'],
+        pdfs['d:snn_snia_vs_nonia'],
+        pdfs['d:snn_sn_vs_all'],
+        pdfs['d:rfscore'],
+        pdfs['i:ndethist'],
+        pdfs['i:drb'],
+        pdfs['i:classtar']
+    )
+
+    pdfs['v:classification'] = classifications
+
+    # Extract color evolution
+    pdfs = pdfs.sort_values('i:objectId')
+    pdfs['v:r-g'] = extract_last_r_minus_g_each_object(pdfs, kind='last')
+    pdfs['v:rate(r-g)'] = extract_last_r_minus_g_each_object(pdfs, kind='rate')
+
+    # Display only the last alert
+    if group_alerts:
+        pdfs['i:jd'] = pdfs['i:jd'].astype(float)
+        pdfs = pdfs.loc[pdfs.groupby('i:objectId')['i:jd'].idxmax()]
+
+    # Human readable time
+    pdfs['v:lastdate'] = pdfs['i:jd'].apply(convert_jd)
+
+    # sort values by time
+    pdfs = pdfs.sort_values('i:jd', ascending=False)
+
+    return pdfs
+
 def markdownify_objectid(objectid):
     """
     """

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -27,6 +27,15 @@ from astropy.time import Time
 
 import java
 
+hbase_type_converter = {
+    'integer': int,
+    'long': int,
+    'float': float,
+    'double': float,
+    'string': str,
+    'fits/image': str
+}
+
 def markdownify_objectid(objectid):
     """
     """

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -40,7 +40,7 @@ def format_hbase_output(hbase_output, schema_client, group_alerts: bool):
     """
     """
     if hbase_output.isEmpty():
-        return pd.DataFrame({}).to_json()
+        return pd.DataFrame({})
 
     # Construct the dataframe
     pdfs = pd.DataFrame.from_dict(hbase_output, orient='index')


### PR DESCRIPTION
This PR allows the user to select only a subset of columns to be transfered. Default is:
- object data retrieval: all columns (ZTF original + Fink science modules + Fink derived values)
- conesearch: a subset of ZTF original + all Fink science modules + all Fink derived values
- date search: a subset of ZTF original + all Fink science modules + all Fink derived values
- latest alerts: a subset of ZTF original + all Fink science modules + all Fink derived values

In addition this PR clean a bit the data manipulation before transfer.