### PR TITLE
Add Fail to the cdsxmatch categories for SN classification

### DIFF
--- a/apps/utils.py
+++ b/apps/utils.py
@@ -258,7 +258,7 @@ def extract_fink_classification(
         "PartofG",
     ]
     keep_cds = \
-        ["Unknown", "Candidate_SN*", "SN", "Transient"] + list_simbad_galaxies
+        ["Unknown", "Fail", "Candidate_SN*", "SN", "Transient"] + list_simbad_galaxies
 
     f_sn = (snn1 | snn2) & cdsxmatch.isin(keep_cds) & low_ndethist & high_drb & high_classtar
     f_sn_early = early_ndethist & active_learn & f_sn


### PR DESCRIPTION
In that case, the classification is less constrained, but I checked it does not really introduce more objects.