### PR TITLE
Start to introduce VOTable

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -34,6 +34,7 @@ import numpy as np
 import astropy.units as u
 from astropy.time import Time, TimeDelta
 from astropy.coordinates import SkyCoord
+from astropy.table import Table
 
 from flask import Blueprint
 
@@ -363,7 +364,7 @@ args_objects = [
     {
         'name': 'output-format',
         'required': False,
-        'description': 'Output format among json[default], csv, parquet'
+        'description': 'Output format among json[default], csv, votable, parquet'
     }
 ]
 
@@ -408,7 +409,7 @@ args_explorer = [
         'name': 'output-format',
         'required': False,
         'group': None,
-        'description': 'Output format among json[default], csv, parquet'
+        'description': 'Output format among json[default], csv, votable, parquet'
     }
 ]
 
@@ -426,7 +427,7 @@ args_latest = [
     {
         'name': 'output-format',
         'required': False,
-        'description': 'Output format among json[default], csv, parquet'
+        'description': 'Output format among json[default], csv, votable, parquet'
     }
 ]
 
@@ -493,6 +494,8 @@ def return_object():
         return pdf.to_json(orient='records')
     elif output_format == 'csv':
         return pdf.to_csv(index=False)
+    elif output_format == 'votable':
+        return Table.from_pandas(pdf)
     elif output_format == 'parquet':
         f = io.BytesIO()
         pdf.to_parquet(f)
@@ -626,6 +629,8 @@ def query_db():
         return pdfs.to_json(orient='records')
     elif output_format == 'csv':
         return pdfs.to_csv(index=False)
+    elif output_format == 'votable':
+        return Table.from_pandas(pdf)
     elif output_format == 'parquet':
         f = io.BytesIO()
         pdfs.to_parquet(f)
@@ -714,6 +719,8 @@ def latest_objects():
         return pdfs.to_json(orient='records')
     elif output_format == 'csv':
         return pdfs.to_csv(index=False)
+    elif output_format == 'votable':
+        return Table.from_pandas(pdf)
     elif output_format == 'parquet':
         f = io.BytesIO()
         pdfs.to_parquet(f)

--- a/apps/api.py
+++ b/apps/api.py
@@ -97,6 +97,17 @@ r = ...
 pd.read_csv(io.BytesIO(r.content))
 ```
 
+You can also get a votable using the json output format:
+
+```python
+from astropy.table import Table
+
+# get data for ZTF19acnjwgm in JSON format...
+r = ...
+
+t = Table(r.json())
+```
+
 By default, we transfer all available data fields (original ZTF fields and Fink science module outputs).
 But you can also choose to transfer only a subset of the fields:
 
@@ -364,7 +375,7 @@ args_objects = [
     {
         'name': 'output-format',
         'required': False,
-        'description': 'Output format among json[default], csv, votable, parquet'
+        'description': 'Output format among json[default], csv, parquet'
     }
 ]
 
@@ -409,7 +420,7 @@ args_explorer = [
         'name': 'output-format',
         'required': False,
         'group': None,
-        'description': 'Output format among json[default], csv, votable, parquet'
+        'description': 'Output format among json[default], csv, parquet'
     }
 ]
 
@@ -427,7 +438,7 @@ args_latest = [
     {
         'name': 'output-format',
         'required': False,
-        'description': 'Output format among json[default], csv, votable, parquet'
+        'description': 'Output format among json[default], csv, parquet'
     }
 ]
 
@@ -494,8 +505,6 @@ def return_object():
         return pdf.to_json(orient='records')
     elif output_format == 'csv':
         return pdf.to_csv(index=False)
-    elif output_format == 'votable':
-        return Table.from_pandas(pdf)
     elif output_format == 'parquet':
         f = io.BytesIO()
         pdf.to_parquet(f)
@@ -629,8 +638,6 @@ def query_db():
         return pdfs.to_json(orient='records')
     elif output_format == 'csv':
         return pdfs.to_csv(index=False)
-    elif output_format == 'votable':
-        return Table.from_pandas(pdf)
     elif output_format == 'parquet':
         f = io.BytesIO()
         pdfs.to_parquet(f)
@@ -719,8 +726,6 @@ def latest_objects():
         return pdfs.to_json(orient='records')
     elif output_format == 'csv':
         return pdfs.to_csv(index=False)
-    elif output_format == 'votable':
-        return Table.from_pandas(pdf)
     elif output_format == 'parquet':
         f = io.BytesIO()
         pdfs.to_parquet(f)


### PR DESCRIPTION
We do not currently support VOTable output format in the API, but we show how to easily get the output in voformat using the json serialisation

```python
from astropy.table import Table
import requests

# get data for ZTF19acnjwgm
r = requests.post(
  'http://134.158.75.151:24000/api/v1/objects',
  json={
    'objectId': 'ZTF19acnjwgm',
    'output-format': 'json'
  }
)

t = Table(r.json())
```