### PR TITLE
[API] Add Solar System Objects

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -432,6 +432,17 @@ layout = html.Div(
                                 ),
                             ], label="Get latest alerts"
                         ),
+                        dbc.Tab(
+                            [
+                                dbc.Card(
+                                    dbc.CardBody(
+                                        dcc.Markdown(api_doc_sso)
+                                    ), style={
+                                        'backgroundColor': 'rgb(248, 248, 248, .7)'
+                                    }
+                                ),
+                            ], label="Get Solar System Objects"
+                        ),
                         dbc.Tab(label="Xmatch", disabled=True),
                     ]
                 )

--- a/apps/api.py
+++ b/apps/api.py
@@ -52,10 +52,11 @@ api_doc_summary = """
 | POST/GET | {}/api/v1/objects| Retrieve single object data from the Fink database | &#x2611;&#xFE0F; |
 | POST/GET | {}/api/v1/explorer | Query the Fink alert database | &#x2611;&#xFE0F; |
 | POST/GET | {}/api/v1/latests | Get latest alerts by class | &#x2611;&#xFE0F; |
+| POST/GET | {}/api/v1/sso | Get Solar System Object data | &#x2611;&#xFE0F; |
 | POST/GET | {}/api/v1/xmatch | Cross-match user-defined catalog with Fink alert data| &#x274C; |
 | GET  | {}/api/v1/classes  | Display all Fink derived classification | &#x2611;&#xFE0F; |
 | GET  | {}/api/v1/columns  | Display all available alert fields and their type | &#x2611;&#xFE0F; |
-""".format(APIURL, APIURL, APIURL, APIURL, APIURL, APIURL)
+""".format(APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL)
 
 api_doc_object = """
 ## Retrieve single object data

--- a/apps/api.py
+++ b/apps/api.py
@@ -949,7 +949,7 @@ def return_sso():
         output_format = 'json'
 
     # Check at least (and at most) a number or a designation is there
-    args = [i['name'] for i in args_objects]
+    args = [i['name'] for i in args_sso]
     if ('number' in args) and ('designation' in args):
         rep = {
             'status': 'error',

--- a/apps/api.py
+++ b/apps/api.py
@@ -586,8 +586,10 @@ def return_object():
 
     if 'columns' in request.json:
         cols = request.json['columns'].replace(" ", "")
+        truncated = True
     else:
         cols = '*'
+        truncated = False
     to_evaluate = "key:key:{}".format(request.json['objectId'])
 
     # We do not want to perform full scan if the objectid is a wildcard
@@ -605,7 +607,9 @@ def return_object():
     # reset the limit in case it has been changed above
     client.setLimit(nlimit)
 
-    pdf = format_hbase_output(results, schema_client, group_alerts=False)
+    pdf = format_hbase_output(
+        results, schema_client, group_alerts=False, truncated=truncated
+    )
 
     if 'withcutouts' in request.json and request.json['withcutouts'] == 'True':
         pdf['b:cutoutScience_stampData'] = pdf['b:cutoutScience_stampData'].apply(
@@ -957,8 +961,10 @@ def return_sso():
 
     if 'columns' in request.json:
         cols = request.json['columns'].replace(" ", "")
+        truncated = True
     else:
         cols = '*'
+        truncated = False
 
     payload = request.json['n_or_d'].replace(' ', '')
 
@@ -980,7 +986,9 @@ def return_sso():
     # reset the limit in case it has been changed above
     clientSSO.setLimit(nlimit)
 
-    pdf = format_hbase_output(results, schema_client, group_alerts=False)
+    pdf = format_hbase_output(
+        results, schema_client, group_alerts=False, truncated=truncated
+    )
 
     if output_format == 'json':
         return pdf.to_json(orient='records')

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -600,19 +600,11 @@ def results(ns, query, query_type, dropdown_option, results):
         # strip from spaces
         query_ = str(query.replace(' ', ''))
 
-        if query_.isnumeric() or query_.endswith('P'):
-            # asteroid or comet / number
-            payload = {
-                'number': query_
-            }
-        elif query_.startswith('C') or query_.isalnum():
-            # comet or asteroid designation
-            payload = {
-                'designation': query_
-            }
         r = requests.post(
             '{}/api/v1/sso'.format(APIURL),
-            json=payload
+            json={
+                'n_or_d': query_
+            }
         )
     elif query_type == 'Conesearch':
         ra, dec, radius = query.split(',')

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -55,6 +55,28 @@ Among several, you can choose YYYY-MM-DD hh:mm:ss, Julian Date, or Modified Juli
 
 Choose a class of interest using the drop-down menu to see the 100 latest alerts processed by Fink.
 
+##### Solar System Objects (SSO)
+
+Search for Solar System Object in the Fink database.
+The numbers or designations are taken from the MPC archive.
+When searching for a particular asteroid or comet, it is best to use the IAU number,
+as in 4209 for asteroid "4209 Briggs". You can also try for numbered comet (e.g. 10P),
+or interstellar object (none so far...). If the number does not yet exist, you can search for designation.
+Here are some examples of valid queries:
+
+* Asteroids by number (default)
+  * Asteroids (Main Belt): 4209, 1922
+  * Asteroids (Hungarians): 18582, 77799
+  * Asteroids (Jupiter Trojans): 4501, 1583
+  * Asteroids (Mars Crossers): 302530
+* Asteroids by designation (if number does not exist yet)
+  * 2010JO69, 2017AD19, 2012XK111
+* Comets by number (default)
+  * 10P, 249P, 124P
+* Comets by designation (if number does no exist yet)
+  * C/2020V2, C/2020R2
+
+Note for designation, you can also use space (2010 JO69 or C/2020 V2).
 """
 
 msg_info = """
@@ -118,7 +140,8 @@ dropdown_menu_items = [
     dbc.DropdownMenuItem("ZTF Object ID", id="dropdown-menu-item-1"),
     dbc.DropdownMenuItem("Conesearch", id="dropdown-menu-item-2"),
     dbc.DropdownMenuItem("Date Search", id="dropdown-menu-item-3"),
-    dbc.DropdownMenuItem("Class search", id="dropdown-menu-item-4")
+    dbc.DropdownMenuItem("Class search", id="dropdown-menu-item-4"),
+    dbc.DropdownMenuItem("SSO search", id="dropdown-menu-item-5")
 ]
 
 
@@ -323,9 +346,10 @@ def display_skymap():
         Input("dropdown-menu-item-2", "n_clicks"),
         Input("dropdown-menu-item-3", "n_clicks"),
         Input("dropdown-menu-item-4", "n_clicks"),
+        Input("dropdown-menu-item-5", "n_clicks")
     ]
 )
-def input_type(n1, n2, n3, n4):
+def input_type(n1, n2, n3, n4, n5):
     """ Decide if the dropdown below the search bar should be shown
 
     Only some query types need to have a dropdown (Date & Class search). In
@@ -377,10 +401,11 @@ def input_type(n1, n2, n3, n4):
         Input("dropdown-menu-item-2", "n_clicks"),
         Input("dropdown-menu-item-3", "n_clicks"),
         Input("dropdown-menu-item-4", "n_clicks"),
+        Input("dropdown-menu-item-5", "n_clicks")
     ],
     State("search_bar_input", "value")
 )
-def on_button_click(n1, n2, n3, n4, val):
+def on_button_click(n1, n2, n3, n4, n5, val):
     """ Change the placeholder value of the search bar based on the query type
     """
     ctx = dash.callback_context
@@ -399,6 +424,8 @@ def on_button_click(n1, n2, n3, n4, val):
         return "Search alerts inside a time window. See Help for the syntax", "Date", val
     elif button_id == "dropdown-menu-item-4":
         return "Show last 100 alerts for a particular class", "Class", val
+    elif button_id == "dropdown-menu-item-5":
+        return "Enter a valid IAU number. See Help for more information", "SSO", val
     else:
         return "Valid object ID", "objectID", ""
 
@@ -569,6 +596,24 @@ def results(ns, query, query_type, dropdown_option, results):
                 'objectId': query,
             }
         )
+    elif query_type == 'SSO':
+        # strip from spaces
+        query_ = str(query.replace(' ', ''))
+
+        if query_.isnumeric() or query_.endswith('P'):
+            # asteroid or comet / number
+            payload = {
+                'number': query_
+            }
+        elif query_.startswith('C') or query_.isalnum():
+            # comet or asteroid designation
+            payload = {
+                'designation': query_
+            }
+        r = requests.post(
+            '{}/api/v1/sso'.format(APIURL),
+            json=payload
+        )
     elif query_type == 'Conesearch':
         ra, dec, radius = query.split(',')
         r = requests.post(
@@ -678,6 +723,9 @@ def open_noresults(n, results, query, query_type, dropdown_option):
         if query_type == 'objectID':
             header = "Search by Object ID"
             text = "{} not found".format(query)
+        elif query_type == 'SSO':
+            header = "Search by Solar System Object ID"
+            text = "{} ({}) not found".format(query, str(query).replace(' ', ''))
         elif query_type == 'Conesearch':
             header = "Conesearch"
             text = "No alerts found for (RA, Dec, radius) = {}".format(

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -36,7 +36,7 @@ hbase_type_converter = {
     'fits/image': str
 }
 
-def format_hbase_output(hbase_output, schema_client, group_alerts: bool, truncated: bool):
+def format_hbase_output(hbase_output, schema_client, group_alerts: bool, truncated: bool = False):
     """
     """
     if hbase_output.isEmpty():


### PR DESCRIPTION
One of the big category of alerts concerns the Solar System Objects (SSO). They can represent up to 10% of the processed stream each night. They are different from other alerts as their brightness changes, but also their position on the sky. 

At the highest level, there are 2 types of SSO candidates: the alerts that are within 5'' of a reported objects in the Minor Planet Center (MPC) database, and the other alerts that pass Fink-specific cuts for SSO. We focus here on the first kind.

Among the MPC-known objects, there are two main types: asteroids and comets (no interstellar objects have been found in Fink so far). According to MPC, they can have either a number (best), or a designation (before being numbered). We handle both here.

The list of arguments for retrieving SSO data can be found at http://134.158.75.151:24000/api/v1/sso. When searching for a particular asteroid or comet, it is best to use the IAU number, as in 4209 for asteroid "4209 Briggs". You can also try for numbered comet (e.g. 10P), or interstellar object (none so far...). If the number does not yet exist, you can search for designation. Here are some examples of valid queries:

* Asteroids by number (default)
  * Asteroids (Main Belt): 4209, 1922
  * Asteroids (Hungarians): 18582, 77799
  * Asteroids (Jupiter Trojans): 4501, 1583
  * Asteroids (Mars Crossers): 302530
* Asteroids by designation (if number does not exist yet)
  * 2010JO69, 2017AD19, 2012XK111
* Comets by number (default)
  * 10P, 249P, 124P
* Comets by designation (if number does no exist yet)
  * C/2020V2, C/2020R2

Note for designation, you can also use space (2010 JO69 or C/2020 V2).

The associated index table is sorted along the `ssnamenr_jd` axis (MPC number + Julian Date).

Note that this PR focuses on extending the API (+ explorer search bar). The SSO view will be created on another PR.