### PR TITLE
Enable cutout data transfer

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -738,6 +738,7 @@ def query_db():
         client.setLimit(nlimit)
 
         schema_client = client.schema()
+        client_ = client
     if user_group == 1:
         clientP.setLimit(1000)
 
@@ -776,6 +777,7 @@ def query_db():
             0, True, True
         )
         schema_client = clientP.schema()
+        client_ = clientP
     elif user_group == 2:
         if int(request.json['window']) > 180:
             rep = {
@@ -797,6 +799,7 @@ def query_db():
             0, True, True
         )
         schema_client = clientT.schema()
+        client_ = clientT
 
     # reset the limit in case it has been changed above
     client.setLimit(nlimit)
@@ -804,7 +807,7 @@ def query_db():
     pdfs = format_hbase_output(results, schema_client, group_alerts=True)
 
     if 'withcutouts' in request.json and request.json['withcutouts'] == 'True':
-        pdfs = extract_cutouts(pdfs, client)
+        pdfs = extract_cutouts(pdfs, client_)
 
     if output_format == 'json':
         return pdfs.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -738,7 +738,6 @@ def query_db():
         client.setLimit(nlimit)
 
         schema_client = client.schema()
-        client_ = client
     if user_group == 1:
         clientP.setLimit(1000)
 
@@ -777,7 +776,6 @@ def query_db():
             0, True, True
         )
         schema_client = clientP.schema()
-        client_ = clientP
     elif user_group == 2:
         if int(request.json['window']) > 180:
             rep = {
@@ -799,7 +797,6 @@ def query_db():
             0, True, True
         )
         schema_client = clientT.schema()
-        client_ = clientT
 
     # reset the limit in case it has been changed above
     client.setLimit(nlimit)
@@ -807,7 +804,7 @@ def query_db():
     pdfs = format_hbase_output(results, schema_client, group_alerts=True)
 
     if 'withcutouts' in request.json and request.json['withcutouts'] == 'True':
-        pdfs = extract_cutouts(pdfs, client_)
+        pdfs = extract_cutouts(pdfs, client)
 
     if output_format == 'json':
         return pdfs.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -125,6 +125,45 @@ r = requests.post(
 ```
 
 Note that the fields should be comma-separated. Unknown field names are ignored.
+
+Finally, you can also request data from cutouts stored in alerts (science, template and difference).
+Simply set `withcutouts` in the json payload (string):
+
+```python
+import requests
+import pandas as pd
+import matplotlib.pyplot as plt
+
+# transfer cutout data
+r = requests.post(
+  'http://134.158.75.151:24000/api/v1/objects',
+  json={
+    'objectId': 'ZTF19acnjwgm',
+    'withcutouts': 'True'
+  }
+)
+
+# Format output in a DataFrame
+pdf = pd.read_json(r.content)
+
+columns = [
+    'b:cutoutScience_stampData',
+    'b:cutoutTemplate_stampData',
+    'b:cutoutDifference_stampData'
+]
+
+for col in columns:
+    # 2D array
+    data = pdf[col].values[0]
+
+    # do whatever plotting
+
+plt.show()
+```
+
+See [here](https://github.com/astrolabsoftware/fink-science-portal/blob/1dea22170449f120d92f404ac20bbb856e1e77fc/apps/plotting.py#L463-L625) how we do in the Science Portal to display cutouts.
+Note that you need to flip the array to get the correct orientation on sky (`data[::-1]`).
+
 """
 
 api_doc_explorer = """

--- a/apps/api.py
+++ b/apps/api.py
@@ -161,7 +161,7 @@ for col in columns:
 plt.show()
 ```
 
-See [here](https://github.com/astrolabsoftware/fink-science-portal/blob/1dea22170449f120d92f404ac20bbb856e1e77fc/apps/plotting.py#L463-L625) how we do in the Science Portal to display cutouts.
+See [here](https://github.com/astrolabsoftware/fink-science-portal/blob/1dea22170449f120d92f404ac20bbb856e1e77fc/apps/plotting.py#L584-L593) how we do in the Science Portal to display cutouts.
 Note that you need to flip the array to get the correct orientation on sky (`data[::-1]`).
 
 """
@@ -556,12 +556,6 @@ args_explorer = [
         'description': 'Time window in minutes. Maximum is 180 minutes.'
     },
     {
-        'name': 'withcutouts',
-        'required': False,
-        'group': None,
-        'description': 'If True, retrieve also uncompressed FITS cutout data (2D array).'
-    },
-    {
         'name': 'output-format',
         'required': False,
         'group': None,
@@ -581,11 +575,6 @@ args_latest = [
         'description': 'Last N alerts to transfer. Default is 10, max is 1000.'
     },
     {
-        'name': 'withcutouts',
-        'required': False,
-        'description': 'If True, retrieve also uncompressed FITS cutout data (2D array).'
-    },
-    {
         'name': 'output-format',
         'required': False,
         'description': 'Output format among json[default], csv, parquet'
@@ -602,11 +591,6 @@ args_sso = [
         'name': 'columns',
         'required': False,
         'description': 'Comma-separated data columns to transfer. Default is all columns. See {}/api/v1/columns for more information.'.format(APIURL)
-    },
-    {
-        'name': 'withcutouts',
-        'required': False,
-        'description': 'If True, retrieve also uncompressed FITS cutout data (2D array).'
     },
     {
         'name': 'output-format',
@@ -803,9 +787,6 @@ def query_db():
 
     pdfs = format_hbase_output(results, schema_client, group_alerts=True)
 
-    if 'withcutouts' in request.json and request.json['withcutouts'] == 'True':
-        pdfs = extract_cutouts(pdfs, client)
-
     if output_format == 'json':
         return pdfs.to_json(orient='records')
     elif output_format == 'csv':
@@ -893,9 +874,6 @@ def latest_objects():
 
     # We want to return alerts
     pdfs = format_hbase_output(results, schema_client, group_alerts=False)
-
-    if 'withcutouts' in request.json and request.json['withcutouts'] == 'True':
-        pdfs = extract_cutouts(pdfs, client)
 
     if output_format == 'json':
         return pdfs.to_json(orient='records')
@@ -1068,9 +1046,6 @@ def return_sso():
     pdf = format_hbase_output(
         results, schema_client, group_alerts=False, truncated=truncated
     )
-
-    if 'withcutouts' in request.json and request.json['withcutouts'] == 'True':
-        pdf = extract_cutouts(pdf, client)
 
     if output_format == 'json':
         return pdf.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -23,6 +23,7 @@ from apps.utils import extract_fink_classification, convert_jd
 from apps.utils import hbase_type_converter
 from apps.utils import extract_last_r_minus_g_each_object
 from apps.utils import format_hbase_output
+from apps.utils import extract_cutouts
 
 import io
 import requests
@@ -464,7 +465,7 @@ args_objects = [
     {
         'name': 'withcutouts',
         'required': False,
-        'description': 'If True, retrieve also gzipped FITS cutouts.'
+        'description': 'If True, retrieve also uncompressed FITS cutout data (2D array).'
     },
     {
         'name': 'columns',
@@ -612,15 +613,7 @@ def return_object():
     )
 
     if 'withcutouts' in request.json and request.json['withcutouts'] == 'True':
-        pdf['b:cutoutScience_stampData'] = pdf['b:cutoutScience_stampData'].apply(
-            lambda x: str(client.repository().get(x))
-        )
-        pdf['b:cutoutTemplate_stampData'] = pdf['b:cutoutTemplate_stampData'].apply(
-            lambda x: str(client.repository().get(x))
-        )
-        pdf['b:cutoutDifference_stampData'] = pdf['b:cutoutDifference_stampData'].apply(
-            lambda x: str(client.repository().get(x))
-        )
+        pdf = extract_cutouts(pdf, client)
 
     if output_format == 'json':
         return pdf.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -804,7 +804,7 @@ def query_db():
     pdfs = format_hbase_output(results, schema_client, group_alerts=True)
 
     if 'withcutouts' in request.json and request.json['withcutouts'] == 'True':
-        pdf = extract_cutouts(pdf, client)
+        pdfs = extract_cutouts(pdfs, client)
 
     if output_format == 'json':
         return pdfs.to_json(orient='records')
@@ -895,7 +895,7 @@ def latest_objects():
     pdfs = format_hbase_output(results, schema_client, group_alerts=False)
 
     if 'withcutouts' in request.json and request.json['withcutouts'] == 'True':
-        pdf = extract_cutouts(pdf, client)
+        pdfs = extract_cutouts(pdfs, client)
 
     if output_format == 'json':
         return pdfs.to_json(orient='records')

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -187,9 +187,9 @@ def extract_cutouts(pdf: pd.DataFrame, client) -> pd.DataFrame:
         Modified original DataFrame with cutout data uncompressed (2D array)
     """
     if 'b:cutoutScience_stampData' not in pdf.columns:
-        pdf['b:cutoutScience_stampData'] = 'binary:' + pdf['objectId'] + '_' + pdf['jd'].astype('str') + ':cutoutScience_stampData'
-        pdf['b:cutoutTemplate_stampData'] = 'binary:' + pdf['objectId'] + '_' + pdf['jd'].astype('str') + ':cutoutTemplate_stampData'
-        pdf['b:cutoutDifference_stampData'] = 'binary:' + pdf['objectId'] + '_' + pdf['jd'].astype('str') + ':cutoutDifference_stampData'
+        pdf['b:cutoutScience_stampData'] = 'binary:' + pdf['i:objectId'] + '_' + pdf['i:jd'].astype('str') + ':cutoutScience_stampData'
+        pdf['b:cutoutTemplate_stampData'] = 'binary:' + pdf['i:objectId'] + '_' + pdf['i:jd'].astype('str') + ':cutoutTemplate_stampData'
+        pdf['b:cutoutDifference_stampData'] = 'binary:' + pdf['i:objectId'] + '_' + pdf['i:jd'].astype('str') + ':cutoutDifference_stampData'
 
     pdf['b:cutoutScience_stampData'] = pdf['b:cutoutScience_stampData'].apply(
         lambda x: readstamp(client.repository().get(x))

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -186,6 +186,11 @@ def extract_cutouts(pdf: pd.DataFrame, client) -> pd.DataFrame:
     pdf: Pandas DataFrame
         Modified original DataFrame with cutout data uncompressed (2D array)
     """
+    if 'b:cutoutScience_stampData' not in pdf.columns:
+        pdf['b:cutoutScience_stampData'] = 'binary:' + pdf['objectId'] + '_' + pdf['jd'].astype('str') + ':cutoutScience_stampData'
+        pdf['b:cutoutTemplate_stampData'] = 'binary:' + pdf['objectId'] + '_' + pdf['jd'].astype('str') + ':cutoutTemplate_stampData'
+        pdf['b:cutoutDifference_stampData'] = 'binary:' + pdf['objectId'] + '_' + pdf['jd'].astype('str') + ':cutoutDifference_stampData'
+
     pdf['b:cutoutScience_stampData'] = pdf['b:cutoutScience_stampData'].apply(
         lambda x: readstamp(client.repository().get(x))
     )

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -169,6 +169,34 @@ def readstamp(stamp: str) -> np.array:
             data = hdul[0].data
     return data
 
+def extract_cutouts(pdf: pd.DataFrame, client) -> pd.DataFrame:
+    """ Query and uncompress cutout data from the HBase table
+
+    Inplace modifications
+
+    Parameters
+    ----------
+    pdf: Pandas DataFrame
+        DataFrame returned by `format_hbase_output` (see api.py)
+    client: com.Lomikel.HBaser.HBaseClient
+        HBase client used to query the database
+
+    Returns
+    ----------
+    pdf: Pandas DataFrame
+        Modified original DataFrame with cutout data uncompressed (2D array)
+    """
+    pdf['b:cutoutScience_stampData'] = pdf['b:cutoutScience_stampData'].apply(
+        lambda x: readstamp(client.repository().get(x))
+    )
+    pdf['b:cutoutTemplate_stampData'] = pdf['b:cutoutTemplate_stampData'].apply(
+        lambda x: readstamp(client.repository().get(x))
+    )
+    pdf['b:cutoutDifference_stampData'] = pdf['b:cutoutDifference_stampData'].apply(
+        lambda x: readstamp(client.repository().get(x))
+    )
+    return pdf
+
 def extract_properties(data: str, fieldnames: list):
     """
     """


### PR DESCRIPTION
This PR enables to download cutout data from the REST API. This is only restricted to `objectId` query for the moment. You would simply do:

```python
import requests
import pandas as pd
import matplotlib.pyplot as plt

# transfer cutout data
r = requests.post(
  'http://134.158.75.151:24000/api/v1/objects',
  json={
    'objectId': 'ZTF19acnjwgm',
    'withcutouts': 'True'
  }
)

# Format output in a DataFrame
pdf = pd.read_json(r.content)

columns = [
    'b:cutoutScience_stampData',
    'b:cutoutTemplate_stampData',
    'b:cutoutDifference_stampData'
]

for col in columns:
    # 2D array
    data = pdf[col].values[0]

    # do whatever plotting

plt.show()
```

See [here](https://github.com/astrolabsoftware/fink-science-portal/blob/1dea22170449f120d92f404ac20bbb856e1e77fc/apps/plotting.py#L584-L593) how we do in the Science Portal to display cutouts.
Note that you need to flip the array to get the correct orientation on sky (`data[::-1]`).

Before merging the PR, there is a test server online to try this PR: http://134.158.75.151:24001 (use this URL in your query)

@anaismoller @FusRoman @karpov-sv do not hesitate to give your feedback