### PR TITLE
Cutout service: online!

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -1208,7 +1208,7 @@ def return_cutouts():
     # send the array
     elif output_format == 'array':
         return send_file(
-            return pdf[['b:cutout{}_stampData'.format(request.json['kind'])]].to_json(orient='records'),
+            pdf[['b:cutout{}_stampData'.format(request.json['kind'])]].to_json(orient='records'),
             mimetype='application/octet-stream'
         )
 

--- a/apps/api.py
+++ b/apps/api.py
@@ -438,7 +438,7 @@ curl -H "Content-Type: application/json" \\
     http://134.158.75.151:24000/api/v1/cutouts -o cutoutScience.png
 ```
 
-This will retrieve the `science` image and save it on `cutoutScience.png`.
+This will retrieve the `Science` image and save it on `cutoutScience.png`.
 In Python, the equivalent script would be:
 
 ```python
@@ -782,7 +782,7 @@ args_cutouts = [
     {
         'name': 'output-format',
         'required': False,
-        'description': 'PNG[default], JPEG, FITS, array'
+        'description': 'PNG[default], FITS, array'
     },
     {
         'name': 'candid',

--- a/apps/api.py
+++ b/apps/api.py
@@ -477,6 +477,7 @@ r = requests.post(
         'colormap': 'viridis', # Valid matplotlib colormap name (see matplotlib.cm). Default is grayscale.
         'pmin': 0.5, # The percentile value used to determine the pixel value of minimum cut level. Default is 0.5. No effect for sigmoid.
         'pmax': 99.5, # The percentile value used to determine the pixel value of maximum cut level. Default is 99.5. No effect for sigmoid.
+        'convolution_kernel': 'gauss' # Convolve the image with a kernel (gauss or box). Default is None (not specified).
     }
 )
 

--- a/apps/api.py
+++ b/apps/api.py
@@ -1207,10 +1207,7 @@ def return_cutouts():
         )
     # send the array
     elif output_format == 'array':
-        return send_file(
-            pdf[['b:cutout{}_stampData'.format(request.json['kind'])]].to_json(orient='records'),
-            mimetype='application/octet-stream'
-        )
+        return pdf[['b:cutout{}_stampData'.format(request.json['kind'])]].to_json(orient='records')
 
     if stretch == 'sigmoid':
         array = sigmoid_normalizer(array, 0, 1)

--- a/apps/api.py
+++ b/apps/api.py
@@ -432,9 +432,9 @@ The list of arguments for retrieving cutout data can be found at http://134.158.
 In a unix shell, you can retrieve the last cutout of an object by simply using
 
 ```bash
-curl -H "Content-Type: application/json" \
-    -X POST -d \
-    '{"objectId":"ZTF19acnjwgm", "kind":"Science"}' \
+curl -H "Content-Type: application/json" \\
+    -X POST -d \\
+    '{"objectId":"ZTF19acnjwgm", "kind":"Science"}' \\
     http://134.158.75.151:24000/api/v1/cutouts -o cutoutScience.png
 ```
 
@@ -525,9 +525,9 @@ image.save('mysupercutout_firstalert.png')
 You can also retrieve the original FITS file stored in the alert:
 
 ```bash
-curl -H "Content-Type: application/json" \
-    -X POST -d \
-    '{"objectId":"ZTF19acnjwgm", "kind":"Science", "output-format": "FITS"}' \
+curl -H "Content-Type: application/json" \\
+    -X POST -d \\
+    '{"objectId":"ZTF19acnjwgm", "kind":"Science", "output-format": "FITS"}' \\
     http://134.158.75.151:24001/api/v1/cutouts -o cutoutScience.fits
 ```
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -618,7 +618,7 @@ def sigmoid_normalizer(img: list, vmin: float, vmax: float) -> list:
     """
     return (vmax - vmin) * sigmoid(img) + vmin
 
-def legacy_normalizer(data: list) -> list:
+def legacy_normalizer(data: list, stretch='asinh', pmin=0.5, pmax=99.5) -> list:
     """ Old cutout normalizer which use the central pixel
 
     Parameters
@@ -633,7 +633,7 @@ def legacy_normalizer(data: list) -> list:
     size = len(data)
     vmax = data[int(size / 2), int(size / 2)]
     vmin = np.min(data) + 0.2 * np.median(np.abs(data - np.median(data)))
-    return _data_stretch(data, vmin=vmin, vmax=vmax, stretch='asinh')
+    return _data_stretch(data, vmin=vmin, vmax=vmax, pmin=pmin, pmax=pmax, stretch=stretch)
 
 def draw_cutout(data, title, lower_bound=0, upper_bound=1):
     """ Draw a cutout data

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -165,20 +165,22 @@ def readstamp(stamp: str, return_type='array') -> np.array:
     field: string
         Name of the stamps: cutoutScience, cutoutTemplate, cutoutDifference
     return_type: str
-        Data block of HDU 0 (`array`) or original FITS uncompressed (`FITS`).
+        Data block of HDU 0 (`array`) or original FITS uncompressed (`FITS`) as file-object.
         Default is `array`.
 
     Returns
     ----------
     data: np.array
-        2D array containing image data (`array`) or FITS file uncompressed (`FITS`)
+        2D array containing image data (`array`) or FITS file uncompressed as file-object (`FITS`)
     """
     with gzip.open(io.BytesIO(stamp), 'rb') as f:
         with fits.open(io.BytesIO(f.read())) as hdul:
             if return_type == 'array':
                 data = hdul[0].data
             elif return_type == 'FITS':
-                data = hdul
+                data = io.BytesIO()
+                hdul.writeto(data)
+                data.seek(0)
     return data
 
 def extract_cutouts(pdf: pd.DataFrame, client, col=None, return_type='array') -> pd.DataFrame:


### PR DESCRIPTION
This PR adds a new service to retrieve cutout data. 

## Retrieve cutout data from the Fink database

The list of arguments for retrieving cutout data can be found at http://134.158.75.151:24000/api/v1/cutouts.

### PNG

In a unix shell, you can retrieve the last cutout of an object by simply using

```bash
curl -H "Content-Type: application/json" \
    -X POST -d \
    '{"objectId":"ZTF19acnjwgm", "kind":"Science"}' \
    http://134.158.75.151:24000/api/v1/cutouts -o cutoutScience.png
```

This will retrieve the `Science` image and save it on `cutoutScience.png`.
In Python, the equivalent script would be:

```python
import io
import requests
from PIL import Image as im

# get data for ZTF19acnjwgm
r = requests.post(
    'http://134.158.75.151:24001/api/v1/cutouts',
    json={
        'objectId': 'ZTF19acnjwgm',
        'kind': 'Science',
    }
)

image = im.open(io.BytesIO(r.content))
image.save('cutoutScience.png')
```

Note you can choose between the `Science`, `Template`, or `Difference` images.
You can also customise the image treatment by

```python
import io
import requests
from PIL import Image as im

# get data for ZTF19acnjwgm
r = requests.post(
    'http://134.158.75.151:24001/api/v1/cutouts',
    json={
        'objectId': 'ZTF19acnjwgm',
        'kind': 'Science', # Science, Template, Difference
        'stretch': 'sigmoid', # sigmoid[default], linear, sqrt, power, log, asinh
        'colormap': 'viridis', # Valid matplotlib colormap name (see matplotlib.cm). Default is grayscale.
        'pmin': 0.5, # The percentile value used to determine the pixel value of minimum cut level. Default is 0.5. No effect for sigmoid.
        'pmax': 99.5, # The percentile value used to determine the pixel value of maximum cut level. Default is 99.5. No effect for sigmoid.
    }
)

image = im.open(io.BytesIO(r.content))
image.save('mysupercutout.png')
```

By default, you will retrieve the cutout of the last alert emitted for the object `objectId`.
You can also access cutouts of other alerts from this object by specifying their candidate ID:

```python
import io
import requests
import pandas as pd
from PIL import Image as im

# Get all candidate ID with JD for ZTF19acnjwgm
r = requests.post(
    'http://134.158.75.151:24001/api/v1/objects',
    json={
        'objectId': 'ZTF19acnjwgm',
        'columns': 'i:candid,i:jd'
    }
)

pdf_candid = pd.read_json(r.content)
# Get the first alert
first_alert = pdf_candid['i:candid'].values[-1]

# get data for ZTF19acnjwgm
r = requests.post(
    'http://134.158.75.151:24001/api/v1/cutouts',
    json={
        'objectId': 'ZTF19acnjwgm',
        'kind': 'Science',
        'candid': first_alert
    }
)

image = im.open(io.BytesIO(r.content))
image.save('mysupercutout_firstalert.png')
```

### FITS

You can also retrieve the original FITS file stored in the alert:

```bash
curl -H "Content-Type: application/json" \
    -X POST -d \
    '{"objectId":"ZTF19acnjwgm", "kind":"Science", "output-format": "FITS"}' \
    http://134.158.75.151:24001/api/v1/cutouts -o cutoutScience.fits
```

or equivalently in Python:

```python
import io
from astropy.io import fits
import requests
import pandas as pd

# get data for ZTF19acnjwgm
r = requests.post(
    'http://134.158.75.151:24001/api/v1/cutouts',
    json={
        'objectId': 'ZTF19acnjwgm',
        'kind': 'Science',
        'output-format': 'FITS'
    }
)

data = fits.open(io.BytesIO(r.content))
data.writeto('cutoutScience.fits')
```

### Numpy array

You can also retrieve only the data block stored in the alert:

```python
import requests
import pandas as pd

# get data for ZTF19acnjwgm
r = requests.post(
    'http://134.158.75.151:24001/api/v1/cutouts',
    json={
        'objectId': 'ZTF19acnjwgm',
        'kind': 'Science',
        'output-format': 'array'
    }
)

pdf = pd.read_json(r.content)
array = pdf['b:cutoutScience_stampData'].values[0]
```