### PR TITLE
Allow searching by TNS tag

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -1074,7 +1074,7 @@ def latest_objects():
 
     # Search for latest alerts for a specific class
     tns_classes = pd.read_csv('assets/tns_types.csv', header=None)[0].values
-    is_tns = request.json['class'].startswith('TNS|') and (request.json['class'].split('|')[1] in tns_classes)
+    is_tns = request.json['class'].startswith('(TNS)') and (request.json['class'].split('(TNS) ')[1] in tns_classes)
     if is_tns:
         classname = request.json['class'].split('|')[1]
         clientTNS.setLimit(nalerts)
@@ -1093,7 +1093,8 @@ def latest_objects():
         )
         schema_client = clientTNS.schema()
         group_alerts = True
-    elif request.json['class'] != 'allclasses':
+    elif request.json['class'].startswith('(SIMBAD)'):
+        classname = request.json['class'].split('(SIMBAD) ')[1]
         clientS.setLimit(nalerts)
         clientS.setRangeScan(True)
         clientS.setReversed(True)
@@ -1101,9 +1102,9 @@ def latest_objects():
         results = clientS.scan(
             "",
             "key:key:{}_{},key:key:{}_{}".format(
-                request.json['class'],
+                classname,
                 jd_start,
-                request.json['class'],
+                classname,
                 jd_stop
             ),
             "*", 0, False, False
@@ -1151,10 +1152,12 @@ def class_arguments():
     # TNS
     tns_types = pd.read_csv('assets/tns_types.csv', header=None)[0].values
     tns_types = sorted(tns_types, key=lambda s: s.lower())
+    tns_types = ['(TNS) ' + x for x in tns_types]
 
     # SIMBAD
     simbad_types = pd.read_csv('assets/simbad_types.csv', header=None)[0].values
     simbad_types = sorted(simbad_types, key=lambda s: s.lower())
+    tns_types = ['(SIMBAD) ' + x for x in tns_types]
 
     # Fink science modules
     fink_types = pd.read_csv('assets/fink_types.csv', header=None)[0].values

--- a/apps/api.py
+++ b/apps/api.py
@@ -1076,7 +1076,7 @@ def latest_objects():
     tns_classes = pd.read_csv('assets/tns_types.csv', header=None)[0].values
     is_tns = request.json['class'].startswith('(TNS)') and (request.json['class'].split('(TNS) ')[1] in tns_classes)
     if is_tns:
-        classname = request.json['class'].split('|')[1]
+        classname = request.json['class'].split('(TNS) ')[1]
         clientTNS.setLimit(nalerts)
         clientTNS.setRangeScan(True)
         clientTNS.setReversed(True)

--- a/apps/api.py
+++ b/apps/api.py
@@ -1157,7 +1157,7 @@ def class_arguments():
     # SIMBAD
     simbad_types = pd.read_csv('assets/simbad_types.csv', header=None)[0].values
     simbad_types = sorted(simbad_types, key=lambda s: s.lower())
-    tns_types = ['(SIMBAD) ' + x for x in tns_types]
+    simbad_types = ['(SIMBAD) ' + x for x in simbad_types]
 
     # Fink science modules
     fink_types = pd.read_csv('assets/fink_types.csv', header=None)[0].values

--- a/apps/api.py
+++ b/apps/api.py
@@ -1053,7 +1053,7 @@ def latest_objects():
 
     # Search for latest alerts for a specific class
     tns_classes = pd.read_csv('assets/tns_types.csv', header=None)[0].values
-    if request.json['class'] in tns_classes:
+    if request.json['class'].startswith('TNS|') and request.json['class'].split('|')[1] in tns_classes:
         clientTNS.setLimit(nalerts)
         clientTNS.setRangeScan(True)
         clientTNS.setReversed(True)

--- a/apps/api.py
+++ b/apps/api.py
@@ -22,7 +22,7 @@ from flask import send_file
 from PIL import Image as im
 from matplotlib import cm
 
-from app import client, clientP, clientT, clientS, clientSSO, nlimit
+from app import client, clientP, clientT, clientS, clientSSO, clientTNS, nlimit
 from apps.utils import format_hbase_output
 from apps.utils import extract_cutouts
 from apps.plotting import legacy_normalizer, convolve, sigmoid_normalizer
@@ -1053,7 +1053,7 @@ def latest_objects():
 
     # Search for latest alerts for a specific class
     tns_classes = pd.read_csv('assets/tns_types.csv', header=None)[0].values
-    if request.json['class'].isin(tns_classes):
+    if request.json['class'] in tns_classes:
         clientTNS.setLimit(nalerts)
         clientTNS.setRangeScan(True)
         clientTNS.setReversed(True)

--- a/apps/api.py
+++ b/apps/api.py
@@ -1070,7 +1070,7 @@ def latest_objects():
     if 'stopdate' not in request.json:
         jd_stop = Time.now().jd
     else:
-        jd_start = Time(request.json['stopdate']).jd
+        jd_stop = Time(request.json['stopdate']).jd
 
     # Search for latest alerts for a specific class
     tns_classes = pd.read_csv('assets/tns_types.csv', header=None)[0].values

--- a/apps/api.py
+++ b/apps/api.py
@@ -1121,7 +1121,7 @@ def latest_objects():
 
     if is_tns:
         pdfs['key:key'] = pdfs['key:key'].apply(lambda x: x.split('_')[0])
-        pdf.rename(columns={'key:key': 'TNS'}, inplace=True)
+        pdfs.rename(columns={'key:key': 'TNS'}, inplace=True)
 
     if output_format == 'json':
         return pdfs.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -1054,6 +1054,7 @@ def latest_objects():
     # Search for latest alerts for a specific class
     tns_classes = pd.read_csv('assets/tns_types.csv', header=None)[0].values
     if request.json['class'].startswith('TNS|') and request.json['class'].split('|')[1] in tns_classes:
+        classname = request.json['class'].split('|')[1]
         clientTNS.setLimit(nalerts)
         clientTNS.setRangeScan(True)
         clientTNS.setReversed(True)
@@ -1065,9 +1066,9 @@ def latest_objects():
         results = clientTNS.scan(
             "",
             "key:key:{}_{},key:key:{}_{}".format(
-                request.json['class'],
+                classname,
                 jd_start,
-                request.json['class'],
+                classname,
                 jd_stop
             ),
             "*", 0, False, False

--- a/apps/api.py
+++ b/apps/api.py
@@ -1074,6 +1074,7 @@ def latest_objects():
             "*", 0, False, False
         )
         schema_client = clientTNS.schema()
+        group_alerts = True
     elif request.json['class'] != 'allclasses':
         clientS.setLimit(nalerts)
         clientS.setRangeScan(True)
@@ -1094,6 +1095,7 @@ def latest_objects():
             "*", 0, False, False
         )
         schema_client = clientS.schema()
+        group_alerts = False
     elif request.json['class'] == 'allclasses':
         clientT.setLimit(nalerts)
         clientT.setRangeScan(True)
@@ -1111,9 +1113,10 @@ def latest_objects():
             0, True, True
         )
         schema_client = clientT.schema()
+        group_alerts = False
 
     # We want to return alerts
-    pdfs = format_hbase_output(results, schema_client, group_alerts=False)
+    pdfs = format_hbase_output(results, schema_client, group_alerts=group_alerts)
 
     if output_format == 'json':
         return pdfs.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -1128,10 +1128,6 @@ def latest_objects():
     # We want to return alerts
     pdfs = format_hbase_output(results, schema_client, group_alerts=group_alerts)
 
-    if is_tns:
-        pdfs['key:key'] = pdfs['key:key'].apply(lambda x: x.split('_')[0])
-        pdfs.rename(columns={'key:key': 'TNS'}, inplace=True)
-
     if output_format == 'json':
         return pdfs.to_json(orient='records')
     elif output_format == 'csv':

--- a/apps/api.py
+++ b/apps/api.py
@@ -354,7 +354,8 @@ r = requests.post(
 # Format output in a DataFrame
 pdf = pd.read_json(r.content)
 ```
-
+There is no limit of time, but you will be limited by the
+number of alerts retrieve on the server side `n` (current max is 1000).
 """
 
 api_doc_sso = """

--- a/apps/api.py
+++ b/apps/api.py
@@ -299,7 +299,7 @@ The list of Fink class can be found at http://134.158.75.151:24000/api/v1/classe
 curl -H "Content-Type: application/json" -X GET http://134.158.75.151:24000/api/v1/classes -o finkclass.json
 ```
 
-In a unix shell, you would simply use
+To get the last 5 candidates of the class `Early SN candidate`, you would simply use in a unix shell:
 
 ```bash
 # Get latests 5 Early SN candidates
@@ -333,6 +333,28 @@ r = ...
 
 pd.read_csv(io.BytesIO(r.content))
 ```
+
+You can also specify `startdate` and `stopdate` for your search:
+
+```python
+import requests
+import pandas as pd
+
+# Get all classified SN Ia from TNS between March 1st 2021 and March 5th 2021
+r = requests.post(
+  'http://134.158.75.151:24000/api/v1/latests',
+  json={
+    'class': '(TNS) SN Ia',
+    'n': '100',
+    'startdate': '2021-03-01',
+    'stopdate': '2021-03-05'
+  }
+)
+
+# Format output in a DataFrame
+pdf = pd.read_json(r.content)
+```
+
 """
 
 api_doc_sso = """

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -389,9 +389,9 @@ def input_type(n1, n2, n3, n4, n5):
             {'label': 'Solar System Object candidates', 'value': 'Solar System'},
             {'label': 'Ambiguous', 'value': 'Ambiguous'},
             {'label': 'TNS classified data', 'disabled': True, 'value': 'None'},
-            *[{'label': '(TNS) ' + simtype, 'value': 'TNS|' + simtype} for simtype in tns_types],
+            *[{'label': '(TNS) ' + simtype, 'value': '(TNS) ' + simtype} for simtype in tns_types],
             {'label': 'Simbad crossmatch', 'disabled': True, 'value': 'None'},
-            *[{'label': '(CDS) ' + simtype, 'value': simtype} for simtype in simbad_types]
+            *[{'label': '(SIMBAD) ' + simtype, 'value': '(SIMBAD) ' + simtype} for simtype in simbad_types]
         ]
         placeholder = "Start typing or choose a class. We will display the last 100 alerts for this class."
         return {}, options, placeholder

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -389,9 +389,9 @@ def input_type(n1, n2, n3, n4, n5):
             {'label': 'Solar System Object candidates', 'value': 'Solar System'},
             {'label': 'Ambiguous', 'value': 'Ambiguous'},
             {'label': 'TNS classified data', 'disabled': True, 'value': 'None'},
-            *[{'label': simtype, 'value': simtype} for simtype in tns_types],
+            *[{'label': '(TNS) ' + simtype, 'value': 'TNS|' + simtype} for simtype in tns_types],
             {'label': 'Simbad crossmatch', 'disabled': True, 'value': 'None'},
-            *[{'label': simtype, 'value': simtype} for simtype in simbad_types]
+            *[{'label': '(CDS)' + simtype, 'value': simtype} for simtype in simbad_types]
         ]
         placeholder = "Start typing or choose a class. We will display the last 100 alerts for this class."
         return {}, options, placeholder

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -391,7 +391,7 @@ def input_type(n1, n2, n3, n4, n5):
             {'label': 'TNS classified data', 'disabled': True, 'value': 'None'},
             *[{'label': '(TNS) ' + simtype, 'value': 'TNS|' + simtype} for simtype in tns_types],
             {'label': 'Simbad crossmatch', 'disabled': True, 'value': 'None'},
-            *[{'label': '(CDS)' + simtype, 'value': simtype} for simtype in simbad_types]
+            *[{'label': '(CDS) ' + simtype, 'value': simtype} for simtype in simbad_types]
         ]
         placeholder = "Start typing or choose a class. We will display the last 100 alerts for this class."
         return {}, options, placeholder

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -389,7 +389,7 @@ def input_type(n1, n2, n3, n4, n5):
             {'label': 'Solar System Object candidates', 'value': 'Solar System'},
             {'label': 'Ambiguous', 'value': 'Ambiguous'},
             {'label': 'TNS classified data', 'disabled': True, 'value': 'None'},
-            *[{'label': simtype, 'value': simtype} for simtype in tns_types]
+            *[{'label': simtype, 'value': simtype} for simtype in tns_types],
             {'label': 'Simbad crossmatch', 'disabled': True, 'value': 'None'},
             *[{'label': simtype, 'value': simtype} for simtype in simbad_types]
         ]

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -22,6 +22,9 @@ from astropy.time import Time, TimeDelta
 simbad_types = pd.read_csv('assets/simbad_types.csv', header=None)[0].values
 simbad_types = sorted(simbad_types, key=lambda s: s.lower())
 
+tns_types = pd.read_csv('assets/tns_types.csv', header=None)[0].values
+tns_types = sorted(tns_types, key=lambda s: s.lower())
+
 message_help = """
 ##### Object ID
 
@@ -313,80 +316,6 @@ def display_skymap(validation, data, columns):
     else:
         return ""
 
-@app.callback(
-    Output('aladin-lite-div-skymap_sso', 'run'),
-    [
-        Input('object-sso', 'children')
-    ],
-)
-def display_skymap_sso(object_sso):
-    """ Display explorer result on a sky map (Aladin lite). Limited to 1000 sources total.
-
-    TODO: image is not displayed correctly the first time
-
-    the default parameters are:
-        * PanSTARRS colors
-        * FoV = 360 deg
-        * Fink alerts overlayed
-
-    Callbacks
-    ----------
-    Input: takes the object data
-    Output: Display a sky image with all SSO position from aladin.
-    """
-    pdf = pd.read_json(object_sso)
-
-    # Coordinate of the first alert
-    ra0 = pdf['i:ra'].values[0]
-    dec0 = pdf['i:dec'].values[0]
-
-    # Javascript. Note the use {{}} for dictionary
-    # Force redraw of the Aladin lite window
-    img = """var container = document.getElementById('aladin-lite-div-skymap_sso');var txt = ''; container.innerHTML = txt;"""
-
-    # Aladin lite
-    img += """var a = A.aladin('#aladin-lite-div-skymap_sso', {{target: '{} {}', survey: 'P/PanSTARRS/DR1/color/z/zg/g', showReticle: true, allowFullZoomout: true, fov: 360}});""".format(ra0, dec0)
-
-    ras = pdf['i:ra'].values
-    decs = pdf['i:dec'].values
-    filts = pdf['i:fid'].values
-    filts_dic = {1: 'g', 2: 'r'}
-    times = pdf['v:lastdate'].values
-    link = '<a target="_blank" href="{}/{}">{}</a>'
-    titles = [link.format(APIURL, i, i) for i in pdf['i:objectId'].values]
-    mags = pdf['i:magpsf'].values
-    classes = pdf['v:classification'].values
-    colors = {
-        'Early SN candidate': 'red',
-        'SN candidate': 'orange',
-        'Kilonova candidate': 'blue',
-        'Microlensing candidate': 'green',
-        'Solar System': 'white',
-        'Ambiguous': 'purple',
-        'Unknown': 'yellow'
-    }
-    cats = []
-    for ra, dec, fid, time_, title, mag, class_ in zip(ras, decs, filts, times, titles, mags, classes):
-        if class_ in simbad_types:
-            cat = 'cat_{}'.format(simbad_types.index(class_))
-            color = '#3C8DFF'
-        else:
-            cat = 'cat_{}'.format(class_.replace(' ', '_'))
-            color = colors[class_]
-        if cat not in cats:
-            img += """var {} = A.catalog({{name: '{}', sourceSize: 15, shape: 'circle', color: '{}', onClick: 'showPopup', limit: 1000}});""".format(cat, class_, color)
-            cats.append(cat)
-        img += """{}.addSources([A.source({}, {}, {{objectId: '{}', mag: {:.2f}, filter: '{}', time: '{}', Classification: '{}'}})]);""".format(cat, ra, dec, title, mag, filts_dic[fid], time_, class_)
-
-    for cat in sorted(cats):
-        img += """a.addCatalog({});""".format(cat)
-
-    # img cannot be executed directly because of formatting
-    # We split line-by-line and remove comments
-    img_to_show = [i for i in img.split('\n') if '// ' not in i]
-
-    return " ".join(img_to_show)
-
 def display_skymap():
     """ Display the sky map in the explorer tab results (Aladin lite)
 
@@ -459,6 +388,8 @@ def input_type(n1, n2, n3, n4, n5):
             {'label': 'Microlensing candidates', 'value': 'Microlensing candidate'},
             {'label': 'Solar System Object candidates', 'value': 'Solar System'},
             {'label': 'Ambiguous', 'value': 'Ambiguous'},
+            {'label': 'TNS classified data', 'disabled': True, 'value': 'None'},
+            *[{'label': simtype, 'value': simtype} for simtype in tns_types]
             {'label': 'Simbad crossmatch', 'disabled': True, 'value': 'None'},
             *[{'label': simtype, 'value': simtype} for simtype in simbad_types]
         ]

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -50,8 +50,10 @@ def format_hbase_output(hbase_output, schema_client, group_alerts: bool, truncat
         pdfs['d:knscore'] = np.zeros(len(pdfs), dtype=float)
 
     # Remove hbase specific fields
-    if 'key:key' in pdfs.columns or 'key:time' in pdfs.columns:
-        pdfs = pdfs.drop(columns=['key:key', 'key:time'])
+    # if 'key:key' in pdfs.columns or 'key:time' in pdfs.columns:
+    #     pdfs = pdfs.drop(columns=['key:key', 'key:time'])
+    if 'key:time' in pdfs.columns:
+        pdfs = pdfs.drop(columns=['key:time'])
 
     # Type conversion
     pdfs = pdfs.astype(

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -50,16 +50,12 @@ def format_hbase_output(hbase_output, schema_client, group_alerts: bool, truncat
         pdfs['d:knscore'] = np.zeros(len(pdfs), dtype=float)
 
     # Remove hbase specific fields
-    keys = pdfs['key:key']
     if 'key:key' in pdfs.columns or 'key:time' in pdfs.columns:
         pdfs = pdfs.drop(columns=['key:key', 'key:time'])
 
     # Type conversion
     pdfs = pdfs.astype(
         {i: hbase_type_converter[schema_client.type(i)] for i in pdfs.columns})
-
-    # restore HBase key
-    pdfs['key:key'] = keys
 
     if not truncated:
         # Fink final classification

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -50,14 +50,16 @@ def format_hbase_output(hbase_output, schema_client, group_alerts: bool, truncat
         pdfs['d:knscore'] = np.zeros(len(pdfs), dtype=float)
 
     # Remove hbase specific fields
-    # if 'key:key' in pdfs.columns or 'key:time' in pdfs.columns:
-    #     pdfs = pdfs.drop(columns=['key:key', 'key:time'])
-    if 'key:time' in pdfs.columns:
-        pdfs = pdfs.drop(columns=['key:time'])
+    keys = pdfs['key:key']
+    if 'key:key' in pdfs.columns or 'key:time' in pdfs.columns:
+        pdfs = pdfs.drop(columns=['key:key', 'key:time'])
 
     # Type conversion
     pdfs = pdfs.astype(
         {i: hbase_type_converter[schema_client.type(i)] for i in pdfs.columns})
+
+    # restore HBase key
+    pdfs['key:key'] = keys
 
     if not truncated:
         # Fink final classification

--- a/assets/tns_types.csv
+++ b/assets/tns_types.csv
@@ -1,0 +1,43 @@
+AGN
+Afterglow
+CV
+FRB
+Galaxy
+ILRT
+Impostor-SN
+Kilonova
+LBV
+LRN
+Light-Echo
+M dwarf
+Nova
+Other
+QSO
+SLSN-I
+SLSN-II
+SN
+SN I
+SN II
+SN II-pec
+SN IIL
+SN IIP
+SN IIb
+SN IIn
+SN IIn-pec
+SN Ia
+SN Ia-91T-like
+SN Ia-91bg-like
+SN Ia-CSM
+SN Ia-pec
+SN Iax[02cx-like]
+SN Ib
+SN Ib-Ca-rich
+SN Ib-pec
+SN Ib/c
+SN Ibn
+SN Ic
+SN Ic-BL
+SN Ic-pec
+SN Icn
+TDE
+Varstar


### PR DESCRIPTION
This  PR allows to search Fink data labelled in TNS (#123 ). In addition, this PR introduces some other modifications:

- the API service Class Search gets two new arguments: `startdate` and `stopdate`. You can search for alerts of a particular class between these dates.
- the class name for SIMBAD and TNS are now prefixed -- i.e. you would no more search for `Blazar` but `(CDS) Blazar`. All class  names are available at http://134.158.75.151:24000/api/v1/classes

Example of usage:

```python
import requests
import pandas as pd

# Get all classified SN Ia from TNS between March 1st 2021 and March 5th 2021
r = requests.post(
  'http://134.158.75.151:24000/api/v1/latests',
  json={
    'class': '(TNS) SN Ia',
    'n': '100',
    'startdate': '2021-03-01',
    'stopdate': '2021-03-05'
  }
)

# Format output in a DataFrame
pdf = pd.read_json(r.content)
```
There is no limit of time, but you will be limited by the number of alerts retrieve on the server side `n` (current max is 1000).