### PR TITLE
Update the frontend with new SSO classes

### DIFF
--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -93,7 +93,7 @@ By default, the table shows:
 - i:ra: Right Ascension of candidate; J2000 (deg)
 - i:dec: Declination of candidate; J2000 (deg)
 - v:lastdate: last date the object has been seen by Fink
-- v:classification: Classification inferred by Fink (Supernova candidate, Microlensing candidate, Solar System Object, SIMBAD class, ...)
+- v:classification: Classification inferred by Fink (Supernova candidate, Microlensing candidate, Solar System, SIMBAD class, ...)
 - i:ndethist: Number of spatially coincident detections falling within 1.5 arcsec going back to the beginning of the survey; only detections that fell on the same field and readout-channel ID where the input candidate was observed are counted. All raw detections down to a photometric S/N of ~ 3 are included.
 
 You can also add more columns using the dropdown button above the result table. Full documentation of all available fields can be found at https://fink-portal.ijclab.in2p3.fr:24000/api/v1/columns.
@@ -288,7 +288,8 @@ def display_skymap(validation, data, columns):
             'SN candidate': 'orange',
             'Kilonova candidate': 'blue',
             'Microlensing candidate': 'green',
-            'Solar System': 'white',
+            'Solar System MPC': 'white',
+            'Solar System candidate': 'grey',
             'Ambiguous': 'purple',
             'Unknown': 'yellow'
         }
@@ -386,7 +387,8 @@ def input_type(n1, n2, n3, n4, n5):
             {'label': 'Supernova candidates', 'value': 'SN candidate'},
             {'label': 'Kilonova candidates', 'value': 'Kilonova candidate'},
             {'label': 'Microlensing candidates', 'value': 'Microlensing candidate'},
-            {'label': 'Solar System Object candidates', 'value': 'Solar System'},
+            {'label': 'Solar System (MPC)', 'value': 'Solar System MPC'},
+            {'label': 'Solar System (candidates)', 'value': 'Solar System candidate'},
             {'label': 'Ambiguous', 'value': 'Ambiguous'},
             {'label': 'TNS classified data', 'disabled': True, 'value': 'None'},
             *[{'label': '(TNS) ' + simtype, 'value': '(TNS) ' + simtype} for simtype in tns_types],

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -345,7 +345,8 @@ def extract_fink_classification(
     f_kn = f_kn & early_ndethist & cdsxmatch.isin(keep_cds)
 
     # Solar System Objects
-    f_roid = roid.astype(int).isin([2, 3])
+    f_roid_2 = roid.astype(int) == 2
+    f_roid_3 = roid.astype(int) == 3
 
     # Simbad xmatch
     f_simbad = ~cdsxmatch.isin(['Unknown', 'Transient', 'Fail'])
@@ -354,12 +355,14 @@ def extract_fink_classification(
     classification.mask(f_sn.values, 'SN candidate', inplace=True)
     classification.mask(f_sn_early.values, 'Early SN candidate', inplace=True)
     classification.mask(f_kn.values, 'Kilonova candidate', inplace=True)
-    classification.mask(f_roid.values, 'Solar System', inplace=True)
+    classification.mask(f_roid_2.values, 'Solar System candidate', inplace=True)
+    classification.mask(f_roid_3.values, 'Solar System MPC', inplace=True)
 
     # If several flags are up, we cannot rely on the classification
     ambiguity[f_mulens.values] += 1
     ambiguity[f_sn.values] += 1
-    ambiguity[f_roid.values] += 1
+    ambiguity[f_roid_2.values] += 1
+    ambiguity[f_roid_3.values] += 1
     f_ambiguity = ambiguity > 1
     classification.mask(f_ambiguity.values, 'Ambiguous', inplace=True)
 

--- a/assets/fink_types.csv
+++ b/assets/fink_types.csv
@@ -2,5 +2,6 @@ Early SN candidate
 Kilonova candidate
 SN candidate
 Microlensing candidate
-Solar System
+Solar System MPC
+Solar System candidate
 Ambiguous


### PR DESCRIPTION
Following #135 and https://github.com/astrolabsoftware/fink-broker/issues/441, SSO are now categorized into 2 classes: known objects from MPC (`Solar System MPC`) and new candidates (`Solar System candidate`)