### PR TITLE
Update the xmatch API

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -323,6 +323,11 @@ r = requests.post(
 pdf = pd.read_json(r.content)
 ```
 
+Maximum radius length is 18,000 arcseconds (5 degrees). Note that in case of
+several objects matching, the results will be sorted according to the column
+`v:separation_degree`, which is the angular separation in degree between
+the input (ra, dec) and the objects found.
+
 ### Search by Date
 
 Choose a starting date and a time window to see all alerts in this period.

--- a/apps/api.py
+++ b/apps/api.py
@@ -1814,7 +1814,6 @@ def xmatch_user():
         times = np.zeros_like(ras)
 
     radius = float(request.json['radius'])
-    radius_deg = radius / 3600.
 
     pdfs = pd.DataFrame(columns=unique_cols + [idname] + ['v:classification'])
     for oid, ra, dec, time_start in zip(ids, ras, decs, times):
@@ -1833,7 +1832,7 @@ def xmatch_user():
                 'dec': dec,
                 'radius': radius
             }
-        results = requests.post(
+        r = requests.post(
            '{}/api/v1/explorer'.format(APIURL),
            json=payload
         )

--- a/apps/api.py
+++ b/apps/api.py
@@ -1849,6 +1849,12 @@ def return_cutouts():
         as_attachment=True,
         attachment_filename=filename)
 
+@api_bp.route('/api/v1/xmatch', methods=['GET'])
+def cutouts_arguments():
+    """ Obtain information about the xmatch service
+    """
+    return jsonify({'args': args_xmatch})
+
 @api_bp.route('/api/v1/xmatch', methods=['POST'])
 def xmatch_user():
     """ Xmatch with user uploaded catalog

--- a/apps/api.py
+++ b/apps/api.py
@@ -1624,8 +1624,7 @@ def xmatch_user():
         'i:drb',
         'i:classtar',
         'd:knscore',
-        'i:jdstarthist',
-        'v:classification'
+        'i:jdstarthist'
     ]
 
     unique_cols = np.unique(colnames + colnames_added_values).tolist()
@@ -1654,7 +1653,7 @@ def xmatch_user():
     radius = 1.5
 
     count = 0
-    pdfs = pd.DataFrame(columns=unique_cols + [idname])
+    pdfs = pd.DataFrame(columns=unique_cols + [idname] + ['v:classification'])
     for oid, ra, dec in zip(ids, ras, decs):
         vec = hp.ang2vec(
             np.pi / 2.0 - np.pi / 180.0 * dec,
@@ -1697,5 +1696,4 @@ def xmatch_user():
         df,
         on=idname
     )
-
     return join_df.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -25,7 +25,7 @@ from matplotlib import cm
 from app import client
 from app import clientP128, clientP4096, clientP131072
 from app import clientT, clientS
-from app import clientSSO, clientTNS,
+from app import clientSSO, clientTNS
 from app import clientU, clientUV, nlimit
 from apps.utils import format_hbase_output
 from apps.utils import extract_cutouts

--- a/apps/api.py
+++ b/apps/api.py
@@ -1261,7 +1261,7 @@ def query_db():
     )
 
     # For conesearch, sort by distance
-    if (user_group == 1) and len(pdfs) > 0:
+    if (user_group == 1) and (len(pdfs) > 0):
         sep = coord.separation(
             SkyCoord(
                 pdfs['i:ra'],

--- a/apps/api.py
+++ b/apps/api.py
@@ -1603,6 +1603,6 @@ def return_cutouts():
 def xmatch_user():
     """ Xmatch with user uploaded catalog
     """
-    df = pd.read_csv(io.StringIO(csvfile))
+    df = pd.read_csv(io.StringIO(request.json['catalog']))
 
     return df.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -1206,13 +1206,14 @@ def query_db():
         pdf_ = pdf_.loc[pdf_.groupby('oid')['jd'].idxmax()]
 
         # Filter by time - logic to be improved...
-        if ':' in str(startdate):
-            jdstart = Time(startdate).jd
-        elif str(startdate).startswith('24'):
-            jdstart = Time(startdate, format='jd').jd
-        else:
-            jdstart = Time(startdate, format='mjd').jd
-        pdf_ = pdf_[(pdf_['jd'] >= jdstart) & (pdf_['jd'] < jdstart + window_days)]
+        if startdate is not None:
+            if ':' in str(startdate):
+                jdstart = Time(startdate).jd
+            elif str(startdate).startswith('24'):
+                jdstart = Time(startdate, format='jd').jd
+            else:
+                jdstart = Time(startdate, format='mjd').jd
+            pdf_ = pdf_[(pdf_['jd'] >= jdstart) & (pdf_['jd'] < jdstart + window_days)]
 
         # Get data from the main table
         results = java.util.TreeMap()

--- a/apps/api.py
+++ b/apps/api.py
@@ -1202,9 +1202,6 @@ def query_db():
         times = [float(i[1]['key:key'].split('_')[1]) for i in result.items()]
         pdf_ = pd.DataFrame({'oid': objectids, 'jd': times})
 
-        # groupby and keep only the last alert per objectId
-        pdf_ = pdf_.loc[pdf_.groupby('oid')['jd'].idxmax()]
-
         # Filter by time - logic to be improved...
         if startdate is not None:
             if ':' in str(startdate):
@@ -1214,6 +1211,9 @@ def query_db():
             else:
                 jdstart = Time(startdate, format='mjd').jd
             pdf_ = pdf_[(pdf_['jd'] >= jdstart) & (pdf_['jd'] < jdstart + window_days)]
+
+        # groupby and keep only the last alert per objectId
+        pdf_ = pdf_.loc[pdf_.groupby('oid')['jd'].idxmax()]
 
         # Get data from the main table
         results = java.util.TreeMap()

--- a/apps/api.py
+++ b/apps/api.py
@@ -1232,6 +1232,9 @@ def query_db():
         pdfs['v:separation_degree'] = sep
         pdfs = pdfs.sort_values('v:separation_degree', ascending=True)
 
+        mask = pdfs['separation_degree'] > radius_deg
+        pdfs = pdfs[~mask]
+
     if output_format == 'json':
         return pdfs.to_json(orient='records')
     elif output_format == 'csv':
@@ -1731,6 +1734,7 @@ def xmatch_user():
     times = df[timename].values
 
     radius = 1.5
+    radius_deg = radius / 3600.
 
     count = 0
     pdfs = pd.DataFrame(columns=unique_cols + [idname] + ['v:classification'])

--- a/apps/api.py
+++ b/apps/api.py
@@ -1232,7 +1232,7 @@ def query_db():
         pdfs['v:separation_degree'] = sep
         pdfs = pdfs.sort_values('v:separation_degree', ascending=True)
 
-        mask = pdfs['separation_degree'] > radius_deg
+        mask = pdfs['v:separation_degree'] > radius_deg
         pdfs = pdfs[~mask]
 
     if output_format == 'json':

--- a/apps/api.py
+++ b/apps/api.py
@@ -1261,7 +1261,7 @@ def query_db():
     )
 
     # For conesearch, sort by distance
-    if user_group == 1:
+    if (user_group == 1) and len(pdfs) > 1:
         sep = coord.separation(
             SkyCoord(
                 pdfs['i:ra'],

--- a/apps/api.py
+++ b/apps/api.py
@@ -1174,8 +1174,13 @@ def query_db():
         # groupby and keep only the last alert per objectId
         pdf_ = pdf_.loc[pdf_.groupby('oid')['jd'].idxmax()]
 
-        # Filter by time
-        jdstart = Time(startdate).jd
+        # Filter by time - to be improved
+        if ':' in str(startdate):
+            jdstart = Time(startdate).jd
+        elif str(startdate).startswith(24):
+            jdstart = Time(startdate, format='jd').jd
+        else:
+            jdstart = Time(startdate, format='mjd').jd
         pdf_ = pdf_[(pdf_['jd'] >= jdstart) & (pdf_['jd'] < jdstart + window_days)]
 
         # Get data from the main table

--- a/apps/api.py
+++ b/apps/api.py
@@ -1261,7 +1261,7 @@ def query_db():
     )
 
     # For conesearch, sort by distance
-    if (user_group == 1) and len(pdfs) > 1:
+    if (user_group == 1) and len(pdfs) > 0:
         sep = coord.separation(
             SkyCoord(
                 pdfs['i:ra'],

--- a/apps/api.py
+++ b/apps/api.py
@@ -1852,6 +1852,7 @@ def xmatch_user():
     )
 
     # reorganise columns order
-    cols = list(df.columns) + list(pdfs.columns)
+    no_duplicate = np.where(pdfs.columns != idname)[0]
+    cols = list(df.columns) + list(pdfs.columns[no_duplicate])
     join_df = join_df[cols]
     return join_df.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -874,7 +874,17 @@ layout = html.Div(
                                 ),
                             ], label="Get Image data"
                         ),
-                        dbc.Tab(label="Xmatch", disabled=True),
+                        dbc.Tab(
+                            [
+                                dbc.Card(
+                                    dbc.CardBody(
+                                        dcc.Markdown(api_doc_xmatch)
+                                    ), style={
+                                        'backgroundColor': 'rgb(248, 248, 248, .7)'
+                                    }
+                                ),
+                            ], label="Xmatch"
+                        ),
                     ]
                 )
             ], className="mb-8", fluid=True, style={'width': '80%'}

--- a/apps/api.py
+++ b/apps/api.py
@@ -843,7 +843,7 @@ args_explorer = [
         'name': 'radius',
         'required': True,
         'group': 1,
-        'description': 'Conesearch radius in arcsec. Maximum is 18,000 arcseconds (5 degrees).'
+        'description': 'Conesearch radius in arcsec. Maximum is 36,000 arcseconds (10 degrees).'
     },
     {
         'name': 'startdate_conesearch',
@@ -975,7 +975,22 @@ args_xmatch = [
     {
         'name': 'catalog',
         'required': True,
-        'description': 'External catalog'
+        'description': 'External catalog as CSV'
+    },
+    {
+        'name': 'header',
+        'required': True,
+        'description': 'Comma separated names of columns corresponding to RA, Dec, ID, Time[optional] in the input catalog.'
+    },
+    {
+        'name': 'radius',
+        'required': True,
+        'description': 'Conesearch radius in arcsec. Maximum is 36,000 arcseconds (10 degrees).'
+    },
+    {
+        'name': 'window',
+        'required': False,
+        'description': '[Optional] Time window in days.'
     },
 ]
 
@@ -1183,6 +1198,10 @@ def query_db():
             np.pi / 180 * radius_deg,
             inclusive=True
         )
+
+        # For the future: we could set clientP_.setRangeScan(True)
+        # and pass directly the time boundaries here instead of
+        # grouping by later.
         to_evaluate = ",".join(
             [
                 'key:key:{}'.format(i) for i in pixs
@@ -1726,11 +1745,27 @@ def xmatch_user():
     """ Xmatch with user uploaded catalog
     """
     df = pd.read_csv(io.StringIO(request.json['catalog']))
-    raname = 'RA'
-    decname = 'Dec'
-    idname = 'ID'
-    timename = 'Time'
-    # Columns of interest
+
+    header = request.json['header']
+
+    header = [i.strip() for i in header.split(',')]
+    if len(header) == 3:
+        raname, decname, idname = header
+    elif len(header) == 4:
+        raname, decname, idname, timename = header
+    else:
+        rep = {
+            'status': 'error',
+            'text': "Header should contain 3 or 4 entries from your catalog. E.g. RA,DEC,ID or RA,DEC,ID,Time\n"
+        }
+        return Response(str(rep), 400)
+
+    if 'window' in request.json:
+        window_days = request.json['window']
+    else:
+        window_days = None
+
+    # Fink columns of interest
     colnames = [
         'i:objectId', 'i:ra', 'i:dec', 'i:jd', 'd:cdsxmatch', 'i:ndethist'
     ]
@@ -1772,60 +1807,43 @@ def xmatch_user():
     ras = [coord.ra.deg for coord in coords]
     decs = [coord.dec.deg for coord in coords]
     ids = df[idname].values
-    times = df[timename].values
 
-    radius = 1.5
+    if len(header) == 4:
+        times = df[timename].values
+    else:
+        times = np.zeros_like(ras)
+
+    radius = float(request.json['radius'])
     radius_deg = radius / 3600.
 
-    count = 0
     pdfs = pd.DataFrame(columns=unique_cols + [idname] + ['v:classification'])
     for oid, ra, dec, time_start in zip(ids, ras, decs, times):
-        jd_start = Time(time_start).jd
-        jd_end = jd_start + 1. / 24
-        vec = hp.ang2vec(
-            np.pi / 2.0 - np.pi / 180.0 * dec,
-            np.pi / 180.0 * ra
+        if len(header) == 4:
+            payload = {
+                'ra': ra,
+                'dec': dec,
+                'radius': radius,
+                'startdate_conesearch': time_start,
+                'window_days_conesearch': window_days
+
+            }
+        else:
+            payload = {
+                'ra': ra,
+                'dec': dec,
+                'radius': radius
+            }
+        results = requests.post(
+           '{}/api/v1/explorer'.format(APIURL),
+           json=payload
         )
-        pixs = hp.query_disc(
-            131072,
-            vec,
-            np.pi / 180 * radius / 3600.,
-            inclusive=True
-        )
-
-        clientP.setRangeScan(True)
-        # to_search = ",".join(['key:key:{}'.format(i) for i in pixs])
-        for pix in pixs:
-            to_search = "key:key:{}_{},key:key:{}_{}".format(pix, jd_start, pix, jd_end)
-            results = clientP.scan(
-                "",
-                to_search,
-                ",".join(unique_cols),
-                0, True, True
-            )
-
-            # to_search = ",".join(['key:key:{}'.format(i) for i in pixs])
-            # results = clientP.scan(
-            #     "",
-            #     to_search,
-            #     ",".join(unique_cols),
-            #     0, True, True
-            # )
-
-            # Loop over results and construct the dataframe
-            if not results.isEmpty():
-                schema_client = clientP.schema()
-                pdf = format_hbase_output(
-                    results,
-                    schema_client,
-                    group_alerts=True,
-                    extract_color=False
-                )
-                # pdf = pd.DataFrame.from_dict(results, orient='index')[unique_cols]
-                pdf[idname] = [oid] * len(pdf)
-                if 'd:knscore' not in pdf.columns:
-                    pdf['d:knscore'] = np.zeros(len(pdf), dtype=float)
-                pdfs = pd.concat((pdfs, pdf), ignore_index=True)
+        pdf = pd.read_json(r.content)
+        # Loop over results and construct the dataframe
+        if not pdf.empty:
+            pdf[idname] = [oid] * len(pdf)
+            if 'd:knscore' not in pdf.columns:
+                pdf['d:knscore'] = np.zeros(len(pdf), dtype=float)
+            pdfs = pd.concat((pdfs, pdf), ignore_index=True)
 
     # Final join
     join_df = pd.merge(

--- a/apps/api.py
+++ b/apps/api.py
@@ -1603,6 +1603,6 @@ def return_cutouts():
 def xmatch_user():
     """ Xmatch with user uploaded catalog
     """
-    df = parse_contents(request.json['catalog'], 'toto.csv')
+    df = pd.read_csv(io.StringIO(csvfile))
 
     return df.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -810,7 +810,7 @@ args_explorer = [
         'name': 'radius',
         'required': False,
         'group': 1,
-        'description': 'Conesearch radius in arcsec. Maximum is 60 arcseconds.'
+        'description': 'Conesearch radius in arcsec. Maximum is 18,000 arcseconds (5 degrees).'
     },
     {
         'name': 'startdate',
@@ -1213,6 +1213,20 @@ def query_db():
         group_alerts=True,
         extract_color=False
     )
+
+    # For conesearch, sort by distance
+    if user_group == 1:
+        sep = coord.separation(
+            SkyCoord(
+                pdfs['ra'],
+                pdfs['dec'],
+                unit='deg'
+            )
+        ).deg
+
+        pdfs['v:separation_degree'] = sep
+        pdfs = pdfs.sort_values('v:separation_degree', ascending=True)
+
 
     if output_format == 'json':
         return pdfs.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -1177,7 +1177,7 @@ def query_db():
         # Filter by time - to be improved
         if ':' in str(startdate):
             jdstart = Time(startdate).jd
-        elif str(startdate).startswith(24):
+        elif str(startdate).startswith('24'):
             jdstart = Time(startdate, format='jd').jd
         else:
             jdstart = Time(startdate, format='mjd').jd

--- a/apps/api.py
+++ b/apps/api.py
@@ -1218,15 +1218,14 @@ def query_db():
     if user_group == 1:
         sep = coord.separation(
             SkyCoord(
-                pdfs['ra'],
-                pdfs['dec'],
+                pdfs['i:ra'],
+                pdfs['i:dec'],
                 unit='deg'
             )
         ).deg
 
         pdfs['v:separation_degree'] = sep
         pdfs = pdfs.sort_values('v:separation_degree', ascending=True)
-
 
     if output_format == 'json':
         return pdfs.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -1846,7 +1846,7 @@ def xmatch_user():
 
     # Final join
     join_df = pd.merge(
-        pdfs[['i:objectId', 'v:classification', idname]],
+        pdfs[['i:objectId', 'v:classification', 'v:separation_degree', idname]],
         df,
         on=idname
     )

--- a/apps/api.py
+++ b/apps/api.py
@@ -823,6 +823,18 @@ args_explorer = [
         'description': 'Conesearch radius in arcsec. Maximum is 18,000 arcseconds (5 degrees).'
     },
     {
+        'name': 'startdate_conesearch',
+        'required': False,
+        'group': 1,
+        'description': 'Starting date in UTC for the conesearch query.'
+    },
+    {
+        'name': 'window_days_conesearch',
+        'required': False,
+        'group': 1,
+        'description': 'Time window in days for the conesearch query.'
+    },
+    {
         'name': 'startdate',
         'required': False,
         'group': 2,
@@ -1099,6 +1111,8 @@ def query_db():
         # Interpret user input
         ra, dec = request.json['ra'], request.json['dec']
         radius = request.json['radius']
+        startdate = request.json['startdate_conesearch']
+        window_days = request.json['window_days_conesearch']
 
         if float(radius) > 36000.:
             rep = {
@@ -1107,9 +1121,9 @@ def query_db():
             }
             return Response(str(rep), 400)
 
-        if 'h' in ra:
+        if 'h' in str(ra):
             coord = SkyCoord(ra, dec, frame='icrs')
-        elif ':' in ra or ' ' in ra:
+        elif ':' in str(ra) or ' ' in str(ra):
             coord = SkyCoord(ra, dec, frame='icrs', unit=(u.hourangle, u.deg))
         else:
             coord = SkyCoord(ra, dec, frame='icrs', unit='deg')
@@ -1140,7 +1154,7 @@ def query_db():
         )
         to_evaluate = ",".join(
             [
-                 'key:key:{}'.format(i) for i in pixs
+                'key:key:{}'.format(i) for i in pixs
             ]
         )
 
@@ -1161,8 +1175,8 @@ def query_db():
         pdf_ = pdf_.loc[pdf_.groupby('oid')['jd'].idxmax()]
 
         # Filter by time
-        # jdstart = Time(startdate).jd
-        # pdf_ = pdf_[(pdf_['jd'] >= jdstart) & (pdf_['jd'] < jdstart + window_days)]
+        jdstart = Time(startdate).jd
+        pdf_ = pdf_[(pdf_['jd'] >= jdstart) & (pdf_['jd'] < jdstart + window_days)]
 
         # Get data from the main table
         results = java.util.TreeMap()

--- a/apps/api.py
+++ b/apps/api.py
@@ -1846,7 +1846,7 @@ def xmatch_user():
 
     # Final join
     join_df = pd.merge(
-        pdfs[['i:objectId', 'v:classification', 'v:separation_degree', idname]],
+        pdfs,
         df,
         on=idname
     )

--- a/apps/api.py
+++ b/apps/api.py
@@ -1091,12 +1091,14 @@ def query_db():
         # Interpret user input
         ra, dec = request.json['ra'], request.json['dec']
         radius = request.json['radius']
-        # if int(radius) > 60:
-        #     rep = {
-        #         'status': 'error',
-        #         'text': "`radius` cannot be bigger than 60 arcseconds.\n"
-        #     }
-        #     return Response(str(rep), 400)
+
+        if int(radius) > 18000:
+            rep = {
+                'status': 'error',
+                'text': "`radius` cannot be bigger than 18,000 arcseconds.\n"
+            }
+            return Response(str(rep), 400)
+
         if 'h' in ra:
             coord = SkyCoord(ra, dec, frame='icrs')
         elif ':' in ra or ' ' in ra:
@@ -1114,7 +1116,6 @@ def query_db():
         # Send request
         if int(radius) <= 30:
             # arcsecond scale
-            # arcmin scale
             # get arcmin scale pixels
             pixs_arcsec = hp.query_disc(
                 131072,
@@ -1174,7 +1175,6 @@ def query_db():
                     'key:key:{}'.format(i) for i in pixs
                 ]
             )
-        # to_evaluate = ",".join(['key:key:{}'.format(i) for i in pixs])
         results = clientP.scan(
             "",
             to_evaluate,

--- a/apps/api.py
+++ b/apps/api.py
@@ -1852,6 +1852,6 @@ def xmatch_user():
     )
 
     # reorganise columns order
-    cols = df.columns + pdfs.columns
+    cols = list(df.columns) + list(pdfs.columns)
     join_df = join_df[cols]
     return join_df.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -1176,7 +1176,7 @@ def query_db():
                 0, True, True
             )
             results.putAll(result)
-        schema_client = clientP_.schema()
+        schema_client = client.schema()
     elif user_group == 2:
         if int(request.json['window']) > 180:
             rep = {

--- a/apps/api.py
+++ b/apps/api.py
@@ -1850,7 +1850,7 @@ def return_cutouts():
         attachment_filename=filename)
 
 @api_bp.route('/api/v1/xmatch', methods=['GET'])
-def cutouts_arguments():
+def xmatch_arguments():
     """ Obtain information about the xmatch service
     """
     return jsonify({'args': args_xmatch})

--- a/apps/api.py
+++ b/apps/api.py
@@ -925,13 +925,13 @@ args_cutouts = [
     }
 ]
 
-args_xmatch = {
+args_xmatch = [
     {
         'name': 'catalog',
         'required': True,
         'description': 'External catalog'
     },
-}
+]
 
 @api_bp.route('/api/v1/objects', methods=['GET'])
 def return_object_arguments():

--- a/apps/api.py
+++ b/apps/api.py
@@ -1091,7 +1091,7 @@ def query_db():
 
         schema_client = client.schema()
     if user_group == 1:
-        clientP.setLimit(1000)
+        clientP.setLimit(10000)
 
         # Interpret user input
         ra, dec = request.json['ra'], request.json['dec']
@@ -1144,7 +1144,7 @@ def query_db():
                     'key:key:{}'.format(i) for i in pixs
                 ]
             )
-        elif (int(radius) > 30) & (int(radius) <= 1800):
+        elif (int(radius) > 30) & (int(radius) <= 1000):
             # arcmin scale
             # get arcmin scale pixels
             pixs_am = hp.query_disc(

--- a/apps/api.py
+++ b/apps/api.py
@@ -1106,8 +1106,8 @@ def query_db():
     user_group = np.unique(all_groups)[0]
     required_args = [i['name'] for i in args_explorer if i['group'] == user_group]
     required = [i['required'] for i in args_explorer if i['group'] == user_group]
-    for required_arg in required_args:
-        if (required_arg not in request.json) and required:
+    for required_arg, required_ in zip(required_args, required):
+        if (required_arg not in request.json) and required_:
             rep = {
                 'status': 'error',
                 'text': "A value for `{}` is required for group {}. Use GET to check arguments.\n".format(required_arg, user_group)

--- a/apps/api.py
+++ b/apps/api.py
@@ -823,25 +823,25 @@ args_objects = [
 args_explorer = [
     {
         'name': 'objectId',
-        'required': False,
+        'required': True,
         'group': 0,
         'description': 'ZTF Object ID'
     },
     {
         'name': 'ra',
-        'required': False,
+        'required': True,
         'group': 1,
         'description': 'Right Ascension'
     },
     {
         'name': 'dec',
-        'required': False,
+        'required': True,
         'group': 1,
         'description': 'Declination'
     },
     {
         'name': 'radius',
-        'required': False,
+        'required': True,
         'group': 1,
         'description': 'Conesearch radius in arcsec. Maximum is 18,000 arcseconds (5 degrees).'
     },
@@ -859,13 +859,13 @@ args_explorer = [
     },
     {
         'name': 'startdate',
-        'required': False,
+        'required': True,
         'group': 2,
         'description': 'Starting date in UTC'
     },
     {
         'name': 'window',
-        'required': False,
+        'required': True,
         'group': 2,
         'description': 'Time window in minutes. Maximum is 180 minutes.'
     },
@@ -1105,8 +1105,9 @@ def query_db():
     # Check the user specifies all parameters within a group
     user_group = np.unique(all_groups)[0]
     required_args = [i['name'] for i in args_explorer if i['group'] == user_group]
+    required = [i['required'] for i in args_explorer if i['group'] == user_group]
     for required_arg in required_args:
-        if required_arg not in request.json:
+        if (required_arg not in request.json) and required:
             rep = {
                 'status': 'error',
                 'text': "A value for `{}` is required for group {}. Use GET to check arguments.\n".format(required_arg, user_group)

--- a/apps/api.py
+++ b/apps/api.py
@@ -1078,7 +1078,7 @@ args_xmatch = [
     {
         'name': 'radius',
         'required': True,
-        'description': 'Conesearch radius in arcsec. Maximum is 36,000 arcseconds (10 degrees).'
+        'description': 'Conesearch radius in arcsec. Maximum is 18,000 arcseconds (5 degrees).'
     },
     {
         'name': 'window',

--- a/apps/api.py
+++ b/apps/api.py
@@ -1624,7 +1624,8 @@ def xmatch_user():
         'i:drb',
         'i:classtar',
         'd:knscore',
-        'i:jdstarthist'
+        'i:jdstarthist',
+        'v:classification'
     ]
 
     unique_cols = np.unique(colnames + colnames_added_values).tolist()

--- a/apps/api.py
+++ b/apps/api.py
@@ -360,6 +360,7 @@ Here is the current performance of the service for querying a
 single object (1.3TB, about 40 million alerts):
 
 ![conesearch](https://user-images.githubusercontent.com/20426972/123047697-e493a500-d3fd-11eb-9f30-216dce9cbf43.png)
+
 _circle marks with dashed lines are results for a full scan search
 (~2 years of data, 40 million alerts), while the upper triangles with
 dotted lines are results when restraining to 7 days search.
@@ -744,6 +745,7 @@ Here is the current performance of the service for querying a
 single object (1.3TB, about 40 million alerts):
 
 ![conesearch](https://user-images.githubusercontent.com/20426972/123047697-e493a500-d3fd-11eb-9f30-216dce9cbf43.png)
+
 _circle marks with dashed lines are results for a full scan search
 (~2 years of data, 40 million alerts), while the upper triangles with
 dotted lines are results when restraining to 7 days search.

--- a/apps/api.py
+++ b/apps/api.py
@@ -26,6 +26,7 @@ from app import client, clientP, clientT, clientS, clientSSO, clientTNS, clientU
 from apps.utils import format_hbase_output
 from apps.utils import extract_cutouts
 from apps.plotting import legacy_normalizer, convolve, sigmoid_normalizer
+from apps.xmatch import parse_contents
 
 import io
 import requests
@@ -924,6 +925,14 @@ args_cutouts = [
     }
 ]
 
+args_xmatch = {
+    {
+        'name': 'catalog',
+        'required': True,
+        'description': 'External catalog'
+    },
+}
+
 @api_bp.route('/api/v1/objects', methods=['GET'])
 def return_object_arguments():
     """ Obtain information about retrieving object data
@@ -1589,3 +1598,11 @@ def return_cutouts():
         mimetype='image/png',
         as_attachment=True,
         attachment_filename=filename)
+
+@api_bp.route('/api/v1/xmatch', methods=['POST'])
+def xmatch_user():
+    """ Xmatch with user uploaded catalog
+    """
+    df = parse_contents(request.json['catalog'], 'toto.csv')
+
+    return df.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -1850,4 +1850,8 @@ def xmatch_user():
         df,
         on=idname
     )
+
+    # reorganise columns order
+    cols = df.columns + pdfs.columns
+    join_df = join_df[cols]
     return join_df.to_json(orient='records')

--- a/apps/api.py
+++ b/apps/api.py
@@ -1692,7 +1692,7 @@ def xmatch_user():
 
     # Final join
     join_df = pd.merge(
-        pdfs[['objectId', 'classification', idname]],
+        pdfs[['i:objectId', 'v:classification', idname]],
         df,
         on=idname
     )

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -664,7 +664,7 @@ def results(ns, query, query_type, dropdown_option, results):
 
         if query_type == 'Conesearch':
             data = pdf.sort_values(
-                'v:separation_degree', ascending=False
+                'v:separation_degree', ascending=True
             ).to_dict('records')
         else:
             data = pdf.sort_values('i:jd', ascending=False).to_dict('records')

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -44,6 +44,11 @@ The following ways of initializing a conesearch are all equivalent (radius in ar
 * 18 05 33.942, +45 15 16.25, 5
 * 18:05:33.942, 45:15:16.25, 5
 
+Maximum radius length is 18,000 arcseconds (5 degrees). Note that in case of
+several objects matching, the results will be sorted according to the column
+`v:separation_degree`, which is the angular separation in degree between
+the input (ra, dec) and the objects found.
+
 ##### Date search
 
 Choose a starting date and a time window to see all processed alerts in this period.

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -664,7 +664,7 @@ def results(ns, query, query_type, dropdown_option, results):
 
         if query_type == 'Conesearch':
             data = pdf.sort_values(
-                'v:separation', ascending=False
+                'v:separation_degree', ascending=False
             ).to_dict('records')
         else:
             data = pdf.sort_values('i:jd', ascending=False).to_dict('records')

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -662,7 +662,12 @@ def results(ns, query, query_type, dropdown_option, results):
         # Make clickable objectId
         pdf['i:objectId'] = pdf['i:objectId'].apply(markdownify_objectid)
 
-        data = pdf.sort_values('i:jd', ascending=False).to_dict('records')
+        if query_type == 'Conesearch':
+            data = pdf.sort_values(
+                'v:separation', ascending=False
+            ).to_dict('records')
+        else:
+            data = pdf.sort_values('i:jd', ascending=False).to_dict('records')
 
         columns = [
             {

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import healpy as hp
 import numpy as np
 import pandas as pd
 import gzip
@@ -25,8 +26,6 @@ from astropy.convolution import Box2DKernel
 
 from astropy.visualization import AsymmetricPercentileInterval, simple_norm
 from astropy.time import Time
-
-
 
 hbase_type_converter = {
     'integer': int,
@@ -767,3 +766,26 @@ def convert_mpc_type(index):
         10: "Distant Objects",
     }
     return dic[index]
+
+def get_superpixels(idx, nside_subpix, nside_superpix, nest=False):
+    """ Compute the indices of superpixels that contain a subpixel.
+
+    Note that nside_subpix > nside_superpix
+    """
+    idx = np.array(idx)
+    nside_superpix = np.asarray(nside_superpix)
+    nside_subpix = np.asarray(nside_subpix)
+
+    if not nest:
+        idx = hp.ring2nest(nside_subpix, idx)
+
+    ratio = np.array((nside_subpix // nside_superpix) ** 2, ndmin=1)
+    idx //= ratio
+
+    if not nest:
+        m = idx == -1
+        idx[m] = 0
+        idx = hp.nest2ring(nside_superpix, idx)
+        idx[m] = -1
+
+    return idx

--- a/apps/xmatch.py
+++ b/apps/xmatch.py
@@ -193,7 +193,8 @@ def update_output(contents, filename):
     decs = [coord.dec.deg for coord in coords]
     ids = df[idname].values
 
-    radius_deg = 1.5 / 3600.
+    radius = 1.5
+    radius_deg = radius / 3600.
 
     # loop over rows
     #clientP.setLimit(10)

--- a/apps/xmatch.py
+++ b/apps/xmatch.py
@@ -197,7 +197,7 @@ def update_output(contents, filename):
     radius_deg = radius / 3600.
 
     # loop over rows
-    #clientP.setLimit(10)
+    clientP.setLimit(10000)
     count = 0
     pdfs = pd.DataFrame(columns=unique_cols + [idname])
     for oid, ra, dec, coord in zip(ids, ras, decs, coords):
@@ -230,7 +230,7 @@ def update_output(contents, filename):
                     'key:key:{}'.format(i) for i in pixs
                 ]
             )
-        elif (int(radius) > 30) & (int(radius) <= 1800):
+        elif (int(radius) > 30) & (int(radius) <= 1000):
             # arcmin scale
             # get arcmin scale pixels
             pixs_am = hp.query_disc(

--- a/apps/xmatch.py
+++ b/apps/xmatch.py
@@ -308,8 +308,8 @@ def update_output(contents, filename):
                 )
             ).deg
 
-            pdf['v:separation_degree'] = sep
-            pdf = pdf.sort_values('v:separation_degree', ascending=True)
+            pdf['separation_degree'] = sep
+            pdf = pdf.sort_values('separation_degree', ascending=True)
 
             pdfs = pd.concat((pdfs, pdf), ignore_index=True)
 
@@ -349,6 +349,10 @@ def update_output(contents, filename):
     colnames_to_display.append(idname)
     dtypes.update({idname: type(df[idname].values[0])})
 
+    colnames.append('separation_degree')
+    colnames_to_display.append('separation_degree')
+    dtypes.update({'separation_degree': type(df['v:separation_degree'].values[0])})
+
     pdfs_fink = pdfs[colnames]
 
     # Make clickable objectId
@@ -371,10 +375,11 @@ def update_output(contents, filename):
 
     # Final join
     join_df = pd.merge(
-        pdfs_fink[['objectId', 'classification', idname]],
+        pdfs_fink[['objectId', idname, 'separation_degree', 'classification']],
         df,
         on=idname
     )
+
     data = join_df.to_dict('records')
     columns = [
         {

--- a/apps/xmatch.py
+++ b/apps/xmatch.py
@@ -363,7 +363,7 @@ def update_output(contents, filename):
     )
 
     # Display only the last alert
-    # pdfs_fink = pdfs_fink.loc[pdfs_fink.groupby('objectId')['last seen'].idxmax()]
+    pdfs_fink = pdfs_fink.loc[pdfs_fink.groupby('objectId')['last seen'].idxmax()]
     pdfs_fink['last seen'] = pdfs_fink['last seen'].apply(convert_jd)
 
     # round numeric values for better display

--- a/apps/xmatch.py
+++ b/apps/xmatch.py
@@ -351,7 +351,7 @@ def update_output(contents, filename):
 
     colnames.append('separation_degree')
     colnames_to_display.append('separation_degree')
-    dtypes.update({'separation_degree': type(df['separation_degree'].values[0])})
+    dtypes.update({'separation_degree': type(pdfs['separation_degree'].values[0])})
 
     pdfs_fink = pdfs[colnames]
 

--- a/apps/xmatch.py
+++ b/apps/xmatch.py
@@ -363,7 +363,7 @@ def update_output(contents, filename):
     )
 
     # Display only the last alert
-    pdfs_fink = pdfs_fink.loc[pdfs_fink.groupby('objectId')['last seen'].idxmax()]
+    # pdfs_fink = pdfs_fink.loc[pdfs_fink.groupby('objectId')['last seen'].idxmax()]
     pdfs_fink['last seen'] = pdfs_fink['last seen'].apply(convert_jd)
 
     # round numeric values for better display

--- a/apps/xmatch.py
+++ b/apps/xmatch.py
@@ -351,7 +351,7 @@ def update_output(contents, filename):
 
     colnames.append('separation_degree')
     colnames_to_display.append('separation_degree')
-    dtypes.update({'separation_degree': type(pdfs['separation_degree'].values[0])})
+    dtypes.update({'separation_degree': np.float})
 
     pdfs_fink = pdfs[colnames]
 

--- a/apps/xmatch.py
+++ b/apps/xmatch.py
@@ -201,26 +201,6 @@ def update_output(contents, filename):
     count = 0
     pdfs = pd.DataFrame(columns=unique_cols + [idname])
     for oid, ra, dec, coord in zip(ids, ras, decs, coords):
-        # vec = hp.ang2vec(
-        #     np.pi / 2.0 - np.pi / 180.0 * dec,
-        #     np.pi / 180.0 * ra
-        # )
-        # pixs = hp.query_disc(
-        #     131072,
-        #     vec,
-        #     np.pi / 180 * radius / 3600.,
-        #     inclusive=True
-        # )
-        #
-        # to_search = ",".join(['key:key:{}'.format(i) for i in pixs])
-        #
-        # results = clientP.scan(
-        #     "",
-        #     to_search,
-        #     ",".join(unique_cols),
-        #     0, True, True
-        # )
-
         # angle to vec conversion
         vec = hp.ang2vec(np.pi / 2.0 - np.pi / 180.0 * dec, np.pi / 180.0 * ra)
 
@@ -310,6 +290,9 @@ def update_output(contents, filename):
 
             pdf['separation_degree'] = sep
             pdf = pdf.sort_values('separation_degree', ascending=True)
+
+            mask = pdf['separation_degree'] > radius_deg
+            pdf = pdf[~mask]
 
             pdfs = pd.concat((pdfs, pdf), ignore_index=True)
 

--- a/apps/xmatch.py
+++ b/apps/xmatch.py
@@ -351,7 +351,7 @@ def update_output(contents, filename):
 
     colnames.append('separation_degree')
     colnames_to_display.append('separation_degree')
-    dtypes.update({'separation_degree': type(df['v:separation_degree'].values[0])})
+    dtypes.update({'separation_degree': type(df['separation_degree'].values[0])})
 
     pdfs_fink = pdfs[colnames]
 


### PR DESCRIPTION
This PR updates the conesearch & xmatch API. 

## Conesearch

The new conesearch is now multiresolution: nside=128 (degree scale), nside=4096 (arcmin scale), nside=131072 (arcsec scale). For this purpose, a new index table was created, indexed on various nsides (plus the date). Note, with this implementation we can perform conesearch from arcsecond radius to degree radius within a minute. Here is a rough scaling:

![conesearch_bench](https://user-images.githubusercontent.com/20426972/119670620-54336600-be39-11eb-91e8-f137cef96485.png)

Note that we limit the query to retrieve only the first 10,000 alerts (i.e. less objects). In practice, this happens when radius > 1 degree. Note also that if you target radius around 1000 arcsecond (17 arcmin), you better choose a radius slightly bigger to enter the degree scale map, and boost the query time (see the transition on the plot). The transition between arcmin and degree might change in the future to improve performances.

## xmatch

The xmatch service is based on the new conesearch implementation. Currently, at arcsecond scale, it does 2 sources/second which is quite low... we need to improve it.


Todo:
- [ ] time the conesearch vs xmatch with one source -- do you see differences?
- [ ] redo the plot with new transition arcmin/degree
- [ ] change the transition between arcmin and degree might change in the future to improve performances.
- [ ] improve performance of the xmatch service.