### PR TITLE
Add a bar to detail individual alert classification

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -368,11 +368,11 @@ The list of Fink class can be found at http://134.158.75.151:24000/api/v1/classe
 curl -H "Content-Type: application/json" -X GET http://134.158.75.151:24000/api/v1/classes -o finkclass.json
 ```
 
-To get the last 5 candidates of the class `Early SN candidate`, you would simply use in a unix shell:
+To get the last 5 candidates of the class `Early SN Ia candidate`, you would simply use in a unix shell:
 
 ```bash
-# Get latests 5 Early SN candidates
-curl -H "Content-Type: application/json" -X POST -d '{"class":"Early SN candidate", "n":"5"}' http://134.158.75.151:24000/api/v1/latests -o latest_five_sn_candidates.json
+# Get latests 5 Early SN Ia candidates
+curl -H "Content-Type: application/json" -X POST -d '{"class":"Early SN Ia candidate", "n":"5"}' http://134.158.75.151:24000/api/v1/latests -o latest_five_sn_candidates.json
 ```
 
 In python, you would use
@@ -381,11 +381,11 @@ In python, you would use
 import requests
 import pandas as pd
 
-# Get latests 5 Early SN candidates
+# Get latests 5 Early SN Ia candidates
 r = requests.post(
   'http://134.158.75.151:24000/api/v1/latests',
   json={
-    'class': 'Early SN candidate',
+    'class': 'Early SN Ia candidate',
     'n': '5'
   }
 )

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -97,9 +97,9 @@ def card_sn_scores() -> dbc.Card:
         - the alert has no known transient association (from catalogues)
         - the alert has at least one of a SuperNNova model trained to identify SNe Ia or SNe (`SN Ia score` or `SNe score`) with a probability higher than 50% of this alert being a SN.
 
-        In addition, the alert is considered as `Early SN candidate` if it also satisfies:
+        In addition, the alert is considered as `Early SN Ia candidate` if it also satisfies:
         - the alert is relatively new (number of previous detections < 20)
-        - the alert has the Random Forest model trained to select early supernovae (`Early SN Ia score`) with a probability higher than 50% of this alert being a SN.
+        - the alert has the Random Forest model trained to select early supernovae Ia (`Early SN Ia score`) with a probability higher than 50% of this alert being a SN.
         """
     )
     card = dbc.Card(
@@ -606,7 +606,7 @@ def card_sn_properties(clickData, object_data):
                 # SuperNNova classifiers
                 SN Ia score: {:.2f}
                 SNe score: {:.2f}
-                # Early SN classifier
+                # Early SN Ia classifier
                 RF score: {:.2f}
                 ```
                 ---

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -501,7 +501,7 @@ def card_id(pdf):
     card = dbc.Card(
         [
             html.H5("ObjectID: {}".format(id0), className="card-title"),
-            html.H6("Fink class: {}".format(classification), className="card-subtitle"),
+            # html.H6("Fink class: {}".format(classification), className="card-subtitle"),
             dcc.Markdown(
                 """
                 ```python

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -501,7 +501,7 @@ def card_id(pdf):
     card = dbc.Card(
         [
             html.H5("ObjectID: {}".format(id0), className="card-title"),
-            # html.H6("Fink class: {}".format(classification), className="card-subtitle"),
+            html.H6("Last class: {}".format(classification), className="card-subtitle"),
             dcc.Markdown(
                 """
                 ```python

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -289,10 +289,10 @@ def display_skymap(validation, data, columns):
             'SN candidate': 'orange',
             'Kilonova candidate': 'blue',
             'Microlensing candidate': 'green',
-            'Solar System MPC': 'white',
-            'Solar System candidate': 'grey',
-            'Ambiguous': 'purple',
-            'Unknown': 'yellow'
+            'Solar System MPC': "rgb(254,224,144)",
+            'Solar System candidate': "rgb(171,217,233)",
+            'Ambiguous': 'rgb(116,196,118)',
+            'Unknown': '#7f7f7f'
         }
         cats = []
         for ra, dec, fid, time_, title, mag, class_ in zip(ras, decs, filts, times, titles, mags, classes):

--- a/apps/explorer.py
+++ b/apps/explorer.py
@@ -285,7 +285,7 @@ def display_skymap(validation, data, columns):
         classes = pdf['v:classification'].values
         n_alert_per_class = pdf.groupby('v:classification').count().to_dict()['i:objectId']
         colors = {
-            'Early SN candidate': 'red',
+            'Early SN Ia candidate': 'red',
             'SN candidate': 'orange',
             'Kilonova candidate': 'blue',
             'Microlensing candidate': 'green',
@@ -384,7 +384,7 @@ def input_type(n1, n2, n3, n4, n5):
             {'label': 'All classes', 'value': 'allclasses'},
             {'label': 'Unknown', 'value': 'Unknown'},
             {'label': 'Fink derived classes', 'disabled': True, 'value': 'None'},
-            {'label': 'Early Supernova candidates', 'value': 'Early SN candidate'},
+            {'label': 'Early Supernova Ia candidates', 'value': 'Early SN candidate'},
             {'label': 'Supernova candidates', 'value': 'SN candidate'},
             {'label': 'Kilonova candidates', 'value': 'Kilonova candidate'},
             {'label': 'Microlensing candidates', 'value': 'Microlensing candidate'},

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -291,6 +291,7 @@ def plot_classbar(pdf):
 
     # descending date values
     top_labels = pdf['v:classification'].values[::-1]
+    customdata = pdf['i:jd'].apply(lambda x: convert_jd(float(x), to='iso'))
     x_data = [[1] * len(top_labels)]
     y_data = top_labels
     colors = {
@@ -323,13 +324,13 @@ def plot_classbar(pdf):
                     x=[xd[i]], y=[yd],
                     orientation='h',
                     width=0.3,
-                    hoverinfo='skip',
                     showlegend=showlegend,
                     legendgroup=top_labels[i],
                     name=top_labels[i] + ': {}%'.format(percent),
                     marker=dict(
                         color=colors[i],
-                    )
+                    ),
+                    hovertemplate='<b>Date</b>: %{customdata}'
                 )
             )
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -298,7 +298,7 @@ def plot_classbar(pdf):
         'Kilonova candidate': 'blue',
         'Microlensing candidate': 'green',
         'Solar System MPC': "rgb(254,224,144)",
-        'Solar System candidate': 'black',
+        'Solar System candidate': "rgb(69,117,180)",
         'Ambiguous': 'brown',
         'Unknown': '#7f7f7f'
     }

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -294,7 +294,7 @@ def plot_classbar(pdf):
     x_data = [[1] * len(top_labels)]
     y_data = top_labels
     colors = {
-        'Early SN candidate': 'red',
+        'Early SN Ia candidate': 'red',
         'SN candidate': 'orange',
         'Kilonova candidate': 'blue',
         'Microlensing candidate': 'green',

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -372,20 +372,26 @@ def plot_classbar(pathname, object_data):
 
     fig = go.Figure()
 
+    is_seen = []
     for i in range(0, len(x_data[0])):
         for xd, yd, label in zip(x_data, y_data, top_labels):
+            if top_labels[i] in is_seen:
+                showlegend = False
+            else:
+                showlegend = True
+            is_seen.append(top_labels[i])
             fig.add_trace(
                 go.Bar(
                     x=[xd[i]], y=[yd],
                     orientation='h',
                     width=0.3,
                     hoverinfo='skip',
-                    showlegend=True,
+                    showlegend=showlegend,
                     legendgroup=top_labels[i],
                     name=top_labels[i],# + ': {}%'.format(np.int(xd[i]/np.sum(xd)*100)),
                     marker=dict(
                         color=colors[i],
-                        line=dict(color='rgb(248, 248, 249)', width=1)
+                        line=dict(color='rgb(248, 248, 249)', width=0.1)
                     )
                 )
             )

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -361,6 +361,7 @@ def plot_classbar(pdf):
         plot_bgcolor='rgb(248, 248, 255, 0.0)',
         margin=dict(l=0, r=0, b=0, t=0)
     )
+    fig.update_layout(legend_title_text='Alerts classified as')
     return fig
 
 @app.callback(

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -304,13 +304,13 @@ def plot_classbar(pdf):
     # }
     colors = {
         'Early SN candidate': colors_[0],
-        'SN candidate': colors_[1],
         'Kilonova candidate': colors_[2],
         'Microlensing candidate': colors_[3],
         'Solar System MPC': colors_[4],
+        'SN candidate': colors_[1],
         'Solar System candidate': colors_[5],
         'Ambiguous': colors_[6],
-        'Unknown': colors_[7]
+        'Unknown': '#7f7f7f'
     }
 
     colors = [colors_[-1] if j not in colors.keys() else colors[j] for j in top_labels]

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -303,7 +303,7 @@ def plot_classbar(pdf):
         'Ambiguous': 'brown',
         'Unknown': '#7f7f7f'
     }
-    colors__ = px.colors.sequential.Viridis
+    colors__ = px.colors.sequential.Portland
     colors = {
         'Early SN candidate': colors__[0],
         'Solar System MPC': colors__[1],

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -298,7 +298,7 @@ def plot_classbar(pdf):
         'Kilonova candidate': 'blue',
         'Microlensing candidate': 'green',
         'Solar System MPC': "rgb(254,224,144)",
-        'Solar System candidate': "rgb(69,117,180)",
+        'Solar System candidate': "rgb(171,217,233)",
         'Ambiguous': 'brown',
         'Unknown': '#7f7f7f'
     }

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -303,7 +303,7 @@ def plot_classbar(pdf):
         'Ambiguous': 'brown',
         'Unknown': '#7f7f7f'
     }
-    colors__ = px.colors.diverging.Portland
+    colors__ = px.colors.diverging.Spectral
     colors = {
         'Early SN candidate': colors__[0],
         'Solar System MPC': colors__[1],

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -271,14 +271,7 @@ def extract_scores(data: java.util.TreeMap) -> pd.DataFrame:
         return pdfs
     return pdfs[values]
 
-@app.callback(
-    Output('classbar', 'figure'),
-    [
-        Input('url', 'pathname'),
-        Input('object-data', 'children')
-    ])
-def plot_classbar(pathname, object_data):
-    pdf = pd.read_json(object_data)
+def plot_classbar(pdf):
     grouped = pdf.groupby('v:classification').count()
     alert_per_class = grouped['i:objectId'].to_dict()
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -300,7 +300,7 @@ def plot_classbar(pdf):
         'Microlensing candidate': 'green',
         'Solar System MPC': "rgb(254,224,144)",
         'Solar System candidate': "rgb(171,217,233)",
-        'Ambiguous': 'rgb(149, 207, 216)',
+        'Ambiguous': 'rgb(199,233,192)',
         'Unknown': '#7f7f7f'
     }
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -304,10 +304,10 @@ def plot_classbar(pdf):
     # }
     colors = {
         'Early SN candidate': colors_[0],
-        'Kilonova candidate': colors_[2],
-        'Microlensing candidate': colors_[3],
-        'Solar System MPC': colors_[4],
-        'SN candidate': colors_[1],
+        'Kilonova candidate': colors_[1],
+        'Microlensing candidate': colors_[2],
+        'Solar System MPC': colors_[3],
+        'SN candidate': colors_[4],
         'Solar System candidate': colors_[5],
         'Ambiguous': colors_[6],
         'Unknown': '#7f7f7f'

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -291,7 +291,7 @@ def plot_classbar(pdf):
 
     # descending date values
     top_labels = pdf['v:classification'].values[::-1]
-    customdata = pdf['i:jd'].apply(lambda x: convert_jd(float(x), to='iso'))
+    customdata = pdf['i:jd'].apply(lambda x: convert_jd(float(x), to='iso'))[::-1]
     x_data = [[1] * len(top_labels)]
     y_data = top_labels
     colors = {
@@ -330,6 +330,7 @@ def plot_classbar(pdf):
                     marker=dict(
                         color=colors[i],
                     ),
+                    customdata=[customdata[i]],
                     hovertemplate='<b>Date</b>: %{customdata}'
                 )
             )

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -300,7 +300,7 @@ def plot_classbar(pdf):
         'Microlensing candidate': 'green',
         'Solar System MPC': "rgb(254,224,144)",
         'Solar System candidate': "rgb(171,217,233)",
-        'Ambiguous': 'rgb(199,233,192)',
+        'Ambiguous': 'rgb(116,196,118)',
         'Unknown': '#7f7f7f'
     }
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -23,6 +23,7 @@ from astropy.time import Time
 import dash
 from dash.dependencies import Input, Output
 import plotly.graph_objects as go
+import plotly.express as px
 import dash_core_components as dcc
 
 from apps.utils import convert_jd, readstamp, _data_stretch, convolve
@@ -302,7 +303,7 @@ def plot_classbar(pdf):
         'Ambiguous': 'brown',
         'Unknown': '#7f7f7f'
     }
-    colors__ = px.colors.sequential.Plasma
+    colors__ = px.colors.sequential.Viridis
     colors = {
         'Early SN candidate': colors__[0],
         'Solar System MPC': colors__[1],

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -277,7 +277,7 @@ def extract_scores(data: java.util.TreeMap) -> pd.DataFrame:
         Input('url', 'pathname'),
         Input('object-data', 'children')
     ])
-def plot_classbar(object_data):
+def plot_classbar(pathname, object_data):
     pdf = pd.read_json(object_data)
     grouped = pdf.groupby('v:classification').count()
     grouped = grouped.sort_values('i:objectId', ascending=False)

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -302,16 +302,17 @@ def plot_classbar(pdf):
         'Ambiguous': 'brown',
         'Unknown': '#7f7f7f'
     }
-    # colors = {
-    #     'Early SN candidate': colors_[0],
-    #     'Kilonova candidate': colors_[1],
-    #     'Microlensing candidate': colors_[2],
-    #     'Solar System MPC': colors_[3],
-    #     'SN candidate': colors_[4],
-    #     'Solar System candidate': colors_[5],
-    #     'Ambiguous': colors_[6],
-    #     'Unknown': '#7f7f7f'
-    # }
+    colors__ = px.colors.sequential.Plasma
+    colors = {
+        'Early SN candidate': colors__[0],
+        'Solar System MPC': colors__[1],
+        'Microlensing candidate': colors__[2],
+        'Kilonova candidate': colors__[3],
+        'Ambiguous': colors__[4],
+        'Solar System candidate': colors__[5],
+        'SN candidate': colors__[6],
+        'Unknown': '#7f7f7f'
+    }
 
     colors = [colors_[-1] if j not in colors.keys() else colors[j] for j in top_labels]
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -300,18 +300,7 @@ def plot_classbar(pdf):
         'Microlensing candidate': 'green',
         'Solar System MPC': "rgb(254,224,144)",
         'Solar System candidate': "rgb(171,217,233)",
-        'Ambiguous': 'brown',
-        'Unknown': '#7f7f7f'
-    }
-    colors__ = px.colors.diverging.Spectral
-    colors = {
-        'Early SN candidate': colors__[0],
-        'Solar System MPC': colors__[1],
-        'Microlensing candidate': colors__[2],
-        'Kilonova candidate': colors__[3],
-        'Ambiguous': colors__[4],
-        'Solar System candidate': colors__[5],
-        'SN candidate': colors__[6],
+        'Ambiguous': 'rgb(177, 77, 142)',
         'Unknown': '#7f7f7f'
     }
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -292,26 +292,26 @@ def plot_classbar(pdf):
     top_labels = pdf['v:classification'].values[::-1]
     x_data = [[1] * len(top_labels)]
     y_data = top_labels
-    # colors = {
-    #     'Early SN candidate': 'red',
-    #     'SN candidate': 'orange',
-    #     'Kilonova candidate': 'blue',
-    #     'Microlensing candidate': 'green',
-    #     'Solar System MPC': 'white',
-    #     'Solar System candidate': 'grey',
-    #     'Ambiguous': 'purple',
-    #     'Unknown': 'yellow'
-    # }
     colors = {
-        'Early SN candidate': colors_[0],
-        'Kilonova candidate': colors_[1],
-        'Microlensing candidate': colors_[2],
-        'Solar System MPC': colors_[3],
-        'SN candidate': colors_[4],
-        'Solar System candidate': colors_[5],
-        'Ambiguous': colors_[6],
+        'Early SN candidate': 'red',
+        'SN candidate': 'orange',
+        'Kilonova candidate': 'blue',
+        'Microlensing candidate': 'green',
+        'Solar System MPC': "rgb(254,224,144)",
+        'Solar System candidate': 'black',
+        'Ambiguous': 'purple',
         'Unknown': '#7f7f7f'
     }
+    # colors = {
+    #     'Early SN candidate': colors_[0],
+    #     'Kilonova candidate': colors_[1],
+    #     'Microlensing candidate': colors_[2],
+    #     'Solar System MPC': colors_[3],
+    #     'SN candidate': colors_[4],
+    #     'Solar System candidate': colors_[5],
+    #     'Ambiguous': colors_[6],
+    #     'Unknown': '#7f7f7f'
+    # }
 
     colors = [colors_[-1] if j not in colors.keys() else colors[j] for j in top_labels]
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -355,7 +355,8 @@ def plot_classbar(pathname, object_data):
     pdf = pd.read_json(object_data)
     # grouped = pdf.groupby('v:classification').count()
     # grouped = grouped.sort_values('i:objectId', ascending=False)
-    top_labels = pdf['v:classification'].values
+    # descending date values
+    top_labels = pdf['v:classification'].values[::-1]
     x_data = [[1] * len(top_labels)]
     y_data = top_labels
     colors = {

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -299,7 +299,7 @@ def plot_classbar(pdf):
         'Microlensing candidate': 'green',
         'Solar System MPC': "rgb(254,224,144)",
         'Solar System candidate': 'black',
-        'Ambiguous': 'purple',
+        'Ambiguous': 'brown',
         'Unknown': '#7f7f7f'
     }
     # colors = {

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -271,80 +271,6 @@ def extract_scores(data: java.util.TreeMap) -> pd.DataFrame:
         return pdfs
     return pdfs[values]
 
-# @app.callback(
-#     Output('classbar', 'figure'),
-#     [
-#         Input('url', 'pathname'),
-#         Input('object-data', 'children')
-#     ])
-# def plot_classbar(pathname, object_data):
-#     pdf = pd.read_json(object_data)
-#     grouped = pdf.groupby('v:classification').count()
-#     grouped = grouped.sort_values('i:objectId', ascending=False)
-#     top_labels = list(grouped['i:objectId'].to_dict().keys())
-#     x_data = [list(grouped['i:objectId'].to_dict().values())]
-#     y_data = top_labels
-#     colors = {
-#         'Early SN candidate': 'red',
-#         'SN candidate': 'orange',
-#         'Kilonova candidate': 'blue',
-#         'Microlensing candidate': 'green',
-#         'Solar System MPC': 'white',
-#         'Solar System candidate': 'grey',
-#         'Ambiguous': 'purple',
-#         'Unknown': 'yellow'
-#     }
-#     colors = ['#3C8DFF' if j not in colors.keys() else colors[j] for j in top_labels]
-#
-#     fig = go.Figure()
-#
-#     for i in range(0, len(x_data[0])):
-#         for xd, yd, label in zip(x_data, y_data, top_labels):
-#             fig.add_trace(
-#                 go.Bar(
-#                     x=[xd[i]], y=[yd],
-#                     orientation='h',
-#                     width=0.3,
-#                     hoverinfo='skip',
-#                     showlegend=True,
-#                     name=top_labels[i] + ': {}%'.format(np.int(xd[i]/np.sum(xd)*100)),
-#                     marker=dict(
-#                         color=colors[i],
-#                         line=dict(color='rgb(248, 248, 249)', width=1)
-#                     )
-#                 )
-#             )
-#
-#     fig.update_layout(
-#         xaxis=dict(
-#             showgrid=False,
-#             showline=False,
-#             showticklabels=False,
-#             zeroline=False,
-#         ),
-#         yaxis=dict(
-#             showgrid=False,
-#             showline=False,
-#             showticklabels=False,
-#             zeroline=False,
-#         ),
-#         legend=dict(
-#             bgcolor='rgba(255, 255, 255, 0)',
-#             bordercolor='rgba(255, 255, 255, 0)',
-#             orientation="h",
-#             traceorder="reversed",
-#             yanchor='bottom',
-#             itemclick=False,
-#             itemdoubleclick=False
-#         ),
-#         barmode='stack',
-#         dragmode=False,
-#         paper_bgcolor='rgb(248, 248, 255, 0.0)',
-#         plot_bgcolor='rgb(248, 248, 255, 0.0)',
-#         margin=dict(l=0, r=0, b=0, t=0)
-#     )
-#     return fig
-
 @app.callback(
     Output('classbar', 'figure'),
     [
@@ -360,17 +286,28 @@ def plot_classbar(pathname, object_data):
     top_labels = pdf['v:classification'].values[::-1]
     x_data = [[1] * len(top_labels)]
     y_data = top_labels
+    # colors = {
+    #     'Early SN candidate': 'red',
+    #     'SN candidate': 'orange',
+    #     'Kilonova candidate': 'blue',
+    #     'Microlensing candidate': 'green',
+    #     'Solar System MPC': 'white',
+    #     'Solar System candidate': 'grey',
+    #     'Ambiguous': 'purple',
+    #     'Unknown': 'yellow'
+    # }
     colors = {
-        'Early SN candidate': 'red',
-        'SN candidate': 'orange',
-        'Kilonova candidate': 'blue',
-        'Microlensing candidate': 'green',
-        'Solar System MPC': 'white',
-        'Solar System candidate': 'grey',
-        'Ambiguous': 'purple',
-        'Unknown': 'yellow'
+        'Early SN candidate': colors_[0],
+        'SN candidate': colors_[1],
+        'Kilonova candidate': colors_[2],
+        'Microlensing candidate': colors_[3],
+        'Solar System MPC': colors_[4],
+        'Solar System candidate': colors_[5],
+        'Ambiguous': colors_[6],
+        'Unknown': colors_[7]
     }
-    colors = ['#3C8DFF' if j not in colors.keys() else colors[j] for j in top_labels]
+
+    colors = [colors_[-1] if j not in colors.keys() else colors[j] for j in top_labels]
 
     fig = go.Figure()
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -353,8 +353,9 @@ def extract_scores(data: java.util.TreeMap) -> pd.DataFrame:
     ])
 def plot_classbar(pathname, object_data):
     pdf = pd.read_json(object_data)
-    # grouped = pdf.groupby('v:classification').count()
-    # grouped = grouped.sort_values('i:objectId', ascending=False)
+    grouped = pdf.groupby('v:classification').count()
+    alert_per_class = grouped['i:objectId'].to_dict()
+
     # descending date values
     top_labels = pdf['v:classification'].values[::-1]
     x_data = [[1] * len(top_labels)]
@@ -381,6 +382,8 @@ def plot_classbar(pathname, object_data):
             else:
                 showlegend = True
             is_seen.append(top_labels[i])
+
+            percent = int(alert_per_class[top_labels[i]] / len(pdf) * 100)
             fig.add_trace(
                 go.Bar(
                     x=[xd[i]], y=[yd],
@@ -389,10 +392,9 @@ def plot_classbar(pathname, object_data):
                     hoverinfo='skip',
                     showlegend=showlegend,
                     legendgroup=top_labels[i],
-                    name=top_labels[i],# + ': {}%'.format(np.int(xd[i]/np.sum(xd)*100)),
+                    name=top_labels[i] + ': {}%'.format(percent),
                     marker=dict(
                         color=colors[i],
-                        # line=dict(color='rgb(248, 248, 249)', width=0.1)
                     )
                 )
             )

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -392,7 +392,7 @@ def plot_classbar(pathname, object_data):
                     name=top_labels[i],# + ': {}%'.format(np.int(xd[i]/np.sum(xd)*100)),
                     marker=dict(
                         color=colors[i],
-                        line=dict(color='rgb(248, 248, 249)', width=0.1)
+                        # line=dict(color='rgb(248, 248, 249)', width=0.1)
                     )
                 )
             )

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -353,7 +353,8 @@ def plot_classbar(pdf):
             traceorder="reversed",
             yanchor='bottom',
             itemclick=False,
-            itemdoubleclick=False
+            itemdoubleclick=False,
+            x=0.2
         ),
         barmode='stack',
         dragmode=False,
@@ -361,7 +362,10 @@ def plot_classbar(pdf):
         plot_bgcolor='rgb(248, 248, 255, 0.0)',
         margin=dict(l=0, r=0, b=0, t=0)
     )
-    fig.update_layout(legend_title_text='Alerts classified as')
+    fig.update_layout(title_text='Individual alert classification')
+    fig.update_layout(title_y=0.15)
+    fig.update_layout(title_x=0.0)
+    fig.update_layout(title_font_size=12)
     return fig
 
 @app.callback(

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -320,7 +320,7 @@ def plot_classbar(pathname, object_data):
                 showlegend = True
             is_seen.append(top_labels[i])
 
-            percent = int(alert_per_class[top_labels[i]] / len(pdf) * 100)
+            percent = np.round(alert_per_class[top_labels[i]] / len(pdf) * 100).astype(int)
             fig.add_trace(
                 go.Bar(
                     x=[xd[i]], y=[yd],

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -303,7 +303,7 @@ def plot_classbar(pdf):
         'Ambiguous': 'brown',
         'Unknown': '#7f7f7f'
     }
-    colors__ = px.colors.sequential.Portland
+    colors__ = px.colors.diverging.Portland
     colors = {
         'Early SN candidate': colors__[0],
         'Solar System MPC': colors__[1],

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -271,6 +271,80 @@ def extract_scores(data: java.util.TreeMap) -> pd.DataFrame:
         return pdfs
     return pdfs[values]
 
+# @app.callback(
+#     Output('classbar', 'figure'),
+#     [
+#         Input('url', 'pathname'),
+#         Input('object-data', 'children')
+#     ])
+# def plot_classbar(pathname, object_data):
+#     pdf = pd.read_json(object_data)
+#     grouped = pdf.groupby('v:classification').count()
+#     grouped = grouped.sort_values('i:objectId', ascending=False)
+#     top_labels = list(grouped['i:objectId'].to_dict().keys())
+#     x_data = [list(grouped['i:objectId'].to_dict().values())]
+#     y_data = top_labels
+#     colors = {
+#         'Early SN candidate': 'red',
+#         'SN candidate': 'orange',
+#         'Kilonova candidate': 'blue',
+#         'Microlensing candidate': 'green',
+#         'Solar System MPC': 'white',
+#         'Solar System candidate': 'grey',
+#         'Ambiguous': 'purple',
+#         'Unknown': 'yellow'
+#     }
+#     colors = ['#3C8DFF' if j not in colors.keys() else colors[j] for j in top_labels]
+#
+#     fig = go.Figure()
+#
+#     for i in range(0, len(x_data[0])):
+#         for xd, yd, label in zip(x_data, y_data, top_labels):
+#             fig.add_trace(
+#                 go.Bar(
+#                     x=[xd[i]], y=[yd],
+#                     orientation='h',
+#                     width=0.3,
+#                     hoverinfo='skip',
+#                     showlegend=True,
+#                     name=top_labels[i] + ': {}%'.format(np.int(xd[i]/np.sum(xd)*100)),
+#                     marker=dict(
+#                         color=colors[i],
+#                         line=dict(color='rgb(248, 248, 249)', width=1)
+#                     )
+#                 )
+#             )
+#
+#     fig.update_layout(
+#         xaxis=dict(
+#             showgrid=False,
+#             showline=False,
+#             showticklabels=False,
+#             zeroline=False,
+#         ),
+#         yaxis=dict(
+#             showgrid=False,
+#             showline=False,
+#             showticklabels=False,
+#             zeroline=False,
+#         ),
+#         legend=dict(
+#             bgcolor='rgba(255, 255, 255, 0)',
+#             bordercolor='rgba(255, 255, 255, 0)',
+#             orientation="h",
+#             traceorder="reversed",
+#             yanchor='bottom',
+#             itemclick=False,
+#             itemdoubleclick=False
+#         ),
+#         barmode='stack',
+#         dragmode=False,
+#         paper_bgcolor='rgb(248, 248, 255, 0.0)',
+#         plot_bgcolor='rgb(248, 248, 255, 0.0)',
+#         margin=dict(l=0, r=0, b=0, t=0)
+#     )
+#     return fig
+
 @app.callback(
     Output('classbar', 'figure'),
     [
@@ -279,10 +353,10 @@ def extract_scores(data: java.util.TreeMap) -> pd.DataFrame:
     ])
 def plot_classbar(pathname, object_data):
     pdf = pd.read_json(object_data)
-    grouped = pdf.groupby('v:classification').count()
-    grouped = grouped.sort_values('i:objectId', ascending=False)
-    top_labels = list(grouped['i:objectId'].to_dict().keys())
-    x_data = [list(grouped['i:objectId'].to_dict().values())]
+    # grouped = pdf.groupby('v:classification').count()
+    # grouped = grouped.sort_values('i:objectId', ascending=False)
+    top_labels = pdf['v:classification'].values
+    x_data = [[1] * len(top_labels)]
     y_data = top_labels
     colors = {
         'Early SN candidate': 'red',
@@ -307,7 +381,8 @@ def plot_classbar(pathname, object_data):
                     width=0.3,
                     hoverinfo='skip',
                     showlegend=True,
-                    name=top_labels[i] + ': {}%'.format(np.int(xd[i]/np.sum(xd)*100)),
+                    legendgroup=top_labels[i],
+                    name=top_labels[i],# + ': {}%'.format(np.int(xd[i]/np.sum(xd)*100)),
                     marker=dict(
                         color=colors[i],
                         line=dict(color='rgb(248, 248, 249)', width=1)

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -35,17 +35,30 @@ from pyLIMA.microloutputs import create_the_fake_telescopes
 
 from app import client, app, clientSSO
 
+# colors_ = [
+#     '#1f77b4',  # muted blue
+#     '#ff7f0e',  # safety orange
+#     '#2ca02c',  # cooked asparagus green
+#     '#d62728',  # brick red
+#     '#9467bd',  # muted purple
+#     '#8c564b',  # chestnut brown
+#     '#e377c2',  # raspberry yogurt pink
+#     '#7f7f7f',  # middle gray
+#     '#bcbd22',  # curry yellow-green
+#     '#17becf'   # blue-teal
+# ]
+
 colors_ = [
-    '#1f77b4',  # muted blue
-    '#ff7f0e',  # safety orange
-    '#2ca02c',  # cooked asparagus green
-    '#d62728',  # brick red
-    '#9467bd',  # muted purple
-    '#8c564b',  # chestnut brown
-    '#e377c2',  # raspberry yogurt pink
-    '#7f7f7f',  # middle gray
-    '#bcbd22',  # curry yellow-green
-    '#17becf'   # blue-teal
+    "rgb(165,0,38)",
+    "rgb(215,48,39)",
+    "rgb(244,109,67)",
+    "rgb(253,174,97)",
+    "rgb(254,224,144)",
+    "rgb(224,243,248)",
+    "rgb(171,217,233)",
+    "rgb(116,173,209)",
+    "rgb(69,117,180)",
+    "rgb(49,54,149)"
 ]
 
 all_radio_options = {

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -291,7 +291,7 @@ def plot_classbar(pdf):
 
     # descending date values
     top_labels = pdf['v:classification'].values[::-1]
-    customdata = pdf['i:jd'].apply(lambda x: convert_jd(float(x), to='iso'))[::-1]
+    customdata = pdf['i:jd'].apply(lambda x: convert_jd(float(x), to='iso')).values[::-1]
     x_data = [[1] * len(top_labels)]
     y_data = top_labels
     colors = {

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -300,7 +300,7 @@ def plot_classbar(pdf):
         'Microlensing candidate': 'green',
         'Solar System MPC': "rgb(254,224,144)",
         'Solar System candidate': "rgb(171,217,233)",
-        'Ambiguous': 'rgb(177, 77, 142)',
+        'Ambiguous': 'rgb(149, 207, 216)',
         'Unknown': '#7f7f7f'
     }
 

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -181,6 +181,7 @@ def tab1_content(pdf):
             space += xd[i]
 
     fig.update_layout(annotations=annotations)
+    fig.update_layout(legend_traceorder="reversed")
 
     tab1_content_ = html.Div([
         dbc.Row(

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -102,7 +102,7 @@ def tab1_content(pdf):
         barmode='stack',
         paper_bgcolor='rgb(248, 248, 255, 0.0)',
         plot_bgcolor='rgb(248, 248, 255, 0.0)',
-        margin=dict(l=30, r=30, b=20, t=0)
+        margin=dict(l=30, r=30, b=20, t=20)
     )
 
     annotations = []

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -94,7 +94,7 @@ def tab1_content(pdf):
         ),
         legend=dict(
             x=0.1,
-            y=-0.5,
+            y=-1,
             bgcolor='rgba(255, 255, 255, 0)',
             bordercolor='rgba(255, 255, 255, 0)',
             orientation="h"
@@ -183,7 +183,6 @@ def tab1_content(pdf):
     fig.update_layout(annotations=annotations)
 
     tab1_content_ = html.Div([
-        html.Br(),
         dbc.Row(
             [
                 dbc.Col(

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -184,7 +184,7 @@ def tab1_content(pdf):
                         figure=fig,
                         style={
                             'width': '100%',
-                            'height': '2pc'
+                            'height': '10pc'
                         },
                         config={'displayModeBar': False}
                     ),

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -61,7 +61,7 @@ def tab1_content(pdf):
         'Ambiguous': 'purple',
         'Unknown': 'yellow'
     }
-    colors = [colors[j] for j in top_labels]
+    colors = ['#3C8DFF' if j not in colors.keys() else colors[j] for j in top_labels]
 
     fig = go.Figure()
 
@@ -91,6 +91,12 @@ def tab1_content(pdf):
             showline=False,
             showticklabels=False,
             zeroline=False,
+        ),
+        legend=dict(
+            x=0,
+            y=-0.1,
+            bgcolor='rgba(255, 255, 255, 0)',
+            bordercolor='rgba(255, 255, 255, 0)'
         ),
         barmode='stack',
         paper_bgcolor='rgb(248, 248, 255, 0.0)',

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -71,6 +71,9 @@ def tab1_content(pdf):
                 go.Bar(
                     x=[xd[i]], y=[yd],
                     orientation='h',
+                    width=0.3,
+                    hoverinfo='skip',
+                    name=top_labels[i] + ': {}%'.format(np.int(xd[i]/np.sum(xd)*100)),
                     marker=dict(
                         color=colors[i],
                         line=dict(color='rgb(248, 248, 249)', width=1)
@@ -93,95 +96,20 @@ def tab1_content(pdf):
             zeroline=False,
         ),
         legend=dict(
-            # x=0.1,
-            # y=1.02,
             bgcolor='rgba(255, 255, 255, 0)',
             bordercolor='rgba(255, 255, 255, 0)',
-            orientation="h"
+            orientation="h",
+            traceorder="reversed",
+            yanchor='bottom',
+            itemclick=False,
+            itemdoubleclick=False
         ),
         barmode='stack',
+        dragmode=False,
         paper_bgcolor='rgb(248, 248, 255, 0.0)',
         plot_bgcolor='rgb(248, 248, 255, 0.0)',
-        margin=dict(l=30, r=30, b=20, t=20)
+        margin=dict(l=0, r=0, b=0, t=0)
     )
-
-    annotations = []
-
-    for yd, xd in zip(y_data, x_data):
-        # labeling the y-axis
-        annotations.append(
-            dict(
-                xref='paper', yref='y',
-                x=0.14, y=yd,
-                xanchor='right',
-                text=str(yd),
-                font=dict(
-                    family='Arial', size=14,
-                    color='rgb(67, 67, 67)'
-                ),
-                showarrow=False, align='right'
-            )
-        )
-        # labeling the first percentage of each bar (x_axis)
-        annotations.append(
-            dict(
-                xref='x', yref='y',
-                x=xd[0] / 2, y=yd,
-                text=str(int(xd[0]/np.sum(xd)*100)) + '%',
-                font=dict(
-                    family='Arial', size=14,
-                    color='rgb(248, 248, 255)'
-                ),
-                showarrow=False
-            )
-        )
-        # labeling the first Likert scale (on the top)
-        if yd == y_data[-1]:
-            annotations.append(
-                dict(
-                    xref='x', yref='paper',
-                    x=xd[0] / 2, y=1.1,
-                    text=top_labels[0],
-                    font=dict(
-                        family='Arial', size=14,
-                        color='rgb(67, 67, 67)'
-                    ),
-                    showarrow=False
-                )
-            )
-        space = xd[0]
-        for i in range(1, len(xd)):
-            # labeling the rest of percentages for each bar (x_axis)
-            annotations.append(
-                dict(
-                    xref='x', yref='y',
-                    x=space + (xd[i]/2), y=yd,
-                    text=str(int(xd[i]/np.sum(xd)*100)) + '%',
-                    font=dict(
-                        family='Arial', size=14,
-                        color='rgb(248, 248, 255)'
-                    ),
-                    showarrow=False
-                )
-            )
-            # labeling the Likert scale
-            if yd == y_data[-1]:
-                annotations.append(
-                    dict(
-                        xref='x', yref='paper',
-                        x=space + (xd[i]/2), y=1.1,
-                        text=top_labels[i],
-                        font=dict(
-                            family='Arial', size=14,
-                            color='rgb(67, 67, 67)'
-                        ),
-                        showarrow=False
-                    )
-                )
-            space += xd[i]
-
-    fig.update_layout(annotations=annotations)
-    fig.update_layout(legend_traceorder="reversed")
 
     tab1_content_ = html.Div([
         dbc.Row(
@@ -191,13 +119,13 @@ def tab1_content(pdf):
                         figure=fig,
                         style={
                             'width': '100%',
-                            'height': '5pc'
+                            'height': '4pc'
                         },
                         config={'displayModeBar': False}
                     ),
                     width=12
                 )
-            ]
+            ], justify='around'
         ),
         dbc.Row([
             dbc.Col(card_cutouts(), width=8),

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -84,7 +84,7 @@ def tab1_content(pdf):
             showline=False,
             showticklabels=False,
             zeroline=False,
-            domain=[0.15, 1]
+            # domain=[0.15, 1]
         ),
         yaxis=dict(
             showgrid=False,
@@ -94,7 +94,7 @@ def tab1_content(pdf):
         ),
         legend=dict(
             x=0.1,
-            y=-1,
+            y=-2,
             bgcolor='rgba(255, 255, 255, 0)',
             bordercolor='rgba(255, 255, 255, 0)',
             orientation="h"

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -94,9 +94,10 @@ def tab1_content(pdf):
         ),
         legend=dict(
             x=0,
-            y=-0.1,
+            y=0,
             bgcolor='rgba(255, 255, 255, 0)',
-            bordercolor='rgba(255, 255, 255, 0)'
+            bordercolor='rgba(255, 255, 255, 0)',
+            orientation="h"
         ),
         barmode='stack',
         paper_bgcolor='rgb(248, 248, 255, 0.0)',

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -46,18 +46,6 @@ def tab1_content(pdf):
     pdf: pd.DataFrame
         Results from a HBase client query
     """
-    radioitems = dbc.FormGroup(
-        [
-            dbc.RadioItems(
-                options=[
-                    {"label": "Summary", "value": 1},
-                    {"label": "Timeline", "value": 2},
-                ],
-                value=1,
-                id="radioitems-input",
-            ),
-        ]
-    )
     tab1_content_ = html.Div([
         dbc.Row(
             [
@@ -70,9 +58,8 @@ def tab1_content(pdf):
                         config={'displayModeBar': False},
                         id='classbar'
                     ),
-                    width=10
+                    width=12
                 ),
-                dbc.Col(radioitems, width=2)
             ], justify='around'
         ),
         dbc.Row([

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -20,6 +20,7 @@ import visdcc
 import plotly.graph_objects as go
 
 import pandas as pd
+import numpy as np
 import requests
 
 from app import app, client, clientU, clientUV, clientSSO

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -121,7 +121,7 @@ def tab1_content(pdf):
             dict(
                 xref='x', yref='y',
                 x=xd[0] / 2, y=yd,
-                text=str(int(xd[0]/np.sum(xd))) + '%',
+                text=str(int(xd[0]/np.sum(xd))*100) + '%',
                 font=dict(
                     family='Arial', size=14,
                     color='rgb(248, 248, 255)'
@@ -150,7 +150,7 @@ def tab1_content(pdf):
                 dict(
                     xref='x', yref='y',
                     x=space + (xd[i]/2), y=yd,
-                    text=str(int(xd[i]/np.sum(xd))) + '%',
+                    text=str(int(xd[i]/np.sum(xd))*100) + '%',
                     font=dict(
                         family='Arial', size=14,
                         color='rgb(248, 248, 255)'

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -102,7 +102,7 @@ def tab1_content(pdf):
         barmode='stack',
         paper_bgcolor='rgb(248, 248, 255, 0.0)',
         plot_bgcolor='rgb(248, 248, 255, 0.0)',
-        margin=dict(l=50, r=30, b=0, t=0)
+        margin=dict(l=30, r=30, b=20, t=0)
     )
 
     annotations = []

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -191,7 +191,7 @@ def tab1_content(pdf):
                         figure=fig,
                         style={
                             'width': '100%',
-                            'height': '2pc'
+                            'height': '5pc'
                         },
                         config={'displayModeBar': False}
                     ),

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -120,7 +120,7 @@ def tab1_content(pdf):
             dict(
                 xref='x', yref='y',
                 x=xd[0] / 2, y=yd,
-                text=str(xd[0]) + 'alerts',
+                text=str(int(xd[0]/np.sum(xd))) + '%',
                 font=dict(
                     family='Arial', size=14,
                     color='rgb(248, 248, 255)'
@@ -149,7 +149,7 @@ def tab1_content(pdf):
                 dict(
                     xref='x', yref='y',
                     x=space + (xd[i]/2), y=yd,
-                    text=str(xd[i]) + '%',
+                    text=str(int(xd[i]/np.sum(xd))) + '%',
                     font=dict(
                         family='Arial', size=14,
                         color='rgb(248, 248, 255)'

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -50,7 +50,7 @@ def tab1_content(pdf):
         [
             dbc.Checklist(
                 options=[
-                    {"label": "See timeline", "value": 1}
+                    {"label": "Timeline", "value": 1}
                 ],
                 value=[],
                 id="switches-inline-input",
@@ -73,7 +73,7 @@ def tab1_content(pdf):
                     ),
                     width=10
                 ),
-                dbc.Col(inline_switches, width=2)
+                dbc.Col([html.Br(), inline_switches], width=2)
             ], justify='around'
         ),
         dbc.Row([

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -46,7 +46,7 @@ def tab1_content(pdf):
         Results from a HBase client query
     """
     grouped = pdf.groupby('v:classification').count()
-    grouped = grouped.sort_values('i:objectId', ascending=True)
+    grouped = grouped.sort_values('i:objectId', ascending=False)
     top_labels = list(grouped['i:objectId'].to_dict().keys())
     x_data = [list(grouped['i:objectId'].to_dict().values())]
     y_data = top_labels
@@ -68,7 +68,7 @@ def tab1_content(pdf):
         for xd, yd, label in zip(x_data, y_data, top_labels):
             fig.add_trace(
                 go.Bar(
-                    x=[xd[i]], y=[y_data[0]],
+                    x=[xd[i]], y=[y_data[-1]],
                     orientation='h',
                     marker=dict(
                         color=colors[i],

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -93,8 +93,8 @@ def tab1_content(pdf):
             zeroline=False,
         ),
         legend=dict(
-            x=0,
-            y=0,
+            x=0.3,
+            y=-0.1,
             bgcolor='rgba(255, 255, 255, 0)',
             bordercolor='rgba(255, 255, 255, 0)',
             orientation="h"

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -48,7 +48,6 @@ def tab1_content(pdf):
     """
     radioitems = dbc.FormGroup(
         [
-            dbc.Label("Choose one"),
             dbc.RadioItems(
                 options=[
                     {"label": "Summary", "value": 1},
@@ -73,7 +72,7 @@ def tab1_content(pdf):
                     ),
                     width=10
                 ),
-                dbc.Col([html.Br(), radioitems], width=2)
+                dbc.Col(radioitems, width=2)
             ], justify='around'
         ),
         dbc.Row([

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -46,6 +46,19 @@ def tab1_content(pdf):
     pdf: pd.DataFrame
         Results from a HBase client query
     """
+    inline_switches = dbc.FormGroup(
+        [
+            dbc.Checklist(
+                options=[
+                    {"label": "See timeline", "value": 1}
+                ],
+                value=[],
+                id="switches-inline-input",
+                inline=True,
+                switch=True,
+            ),
+        ]
+    )
     tab1_content_ = html.Div([
         dbc.Row(
             [
@@ -58,8 +71,9 @@ def tab1_content(pdf):
                         config={'displayModeBar': False},
                         id='classbar'
                     ),
-                    width=12
-                )
+                    width=10
+                ),
+                dbc.Col(inline_switches, width=2)
             ], justify='around'
         ),
         dbc.Row([

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -93,8 +93,8 @@ def tab1_content(pdf):
             zeroline=False,
         ),
         legend=dict(
-            x=0.1,
-            y=1.02,
+            # x=0.1,
+            # y=1.02,
             bgcolor='rgba(255, 255, 255, 0)',
             bordercolor='rgba(255, 255, 255, 0)',
             orientation="h"

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -32,6 +32,7 @@ from apps.cards import card_variable_plot, card_variable_button
 from apps.cards import card_explanation_variable, card_explanation_mulens
 from apps.cards import card_mulens_plot, card_mulens_button, card_mulens_param
 from apps.cards import card_sso_lightcurve, card_sso_radec, card_sso_mpc_params
+from apps.plotting import plot_classbar
 
 from apps.utils import format_hbase_output
 from apps.api import APIURL
@@ -51,6 +52,7 @@ def tab1_content(pdf):
             [
                 dbc.Col(
                     dcc.Graph(
+                        figure=plot_classbar(pdf),
                         style={
                             'width': '100%',
                             'height': '4pc'

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -46,16 +46,16 @@ def tab1_content(pdf):
     pdf: pd.DataFrame
         Results from a HBase client query
     """
-    inline_switches = dbc.FormGroup(
+    radioitems = dbc.FormGroup(
         [
-            dbc.Checklist(
+            dbc.Label("Choose one"),
+            dbc.RadioItems(
                 options=[
-                    {"label": "Timeline", "value": 1}
+                    {"label": "Summary", "value": 1},
+                    {"label": "Timeline", "value": 2},
                 ],
-                value=[],
-                id="switches-inline-input",
-                inline=True,
-                switch=True,
+                value=1,
+                id="radioitems-input",
             ),
         ]
     )
@@ -73,7 +73,7 @@ def tab1_content(pdf):
                     ),
                     width=10
                 ),
-                dbc.Col([html.Br(), inline_switches], width=2)
+                dbc.Col([html.Br(), radioitems], width=2)
             ], justify='around'
         ),
         dbc.Row([

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -93,8 +93,8 @@ def tab1_content(pdf):
             zeroline=False,
         ),
         legend=dict(
-            x=0.3,
-            y=-0.1,
+            x=0.1,
+            y=-0.5,
             bgcolor='rgba(255, 255, 255, 0)',
             bordercolor='rgba(255, 255, 255, 0)',
             orientation="h"

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -46,82 +46,17 @@ def tab1_content(pdf):
     pdf: pd.DataFrame
         Results from a HBase client query
     """
-    grouped = pdf.groupby('v:classification').count()
-    grouped = grouped.sort_values('i:objectId', ascending=False)
-    top_labels = list(grouped['i:objectId'].to_dict().keys())
-    x_data = [list(grouped['i:objectId'].to_dict().values())]
-    y_data = top_labels
-    colors = {
-        'Early SN candidate': 'red',
-        'SN candidate': 'orange',
-        'Kilonova candidate': 'blue',
-        'Microlensing candidate': 'green',
-        'Solar System MPC': 'white',
-        'Solar System candidate': 'grey',
-        'Ambiguous': 'purple',
-        'Unknown': 'yellow'
-    }
-    colors = ['#3C8DFF' if j not in colors.keys() else colors[j] for j in top_labels]
-
-    fig = go.Figure()
-
-    for i in range(0, len(x_data[0])):
-        for xd, yd, label in zip(x_data, y_data, top_labels):
-            fig.add_trace(
-                go.Bar(
-                    x=[xd[i]], y=[yd],
-                    orientation='h',
-                    width=0.3,
-                    hoverinfo='skip',
-                    showlegend=True,
-                    name=top_labels[i] + ': {}%'.format(np.int(xd[i]/np.sum(xd)*100)),
-                    marker=dict(
-                        color=colors[i],
-                        line=dict(color='rgb(248, 248, 249)', width=1)
-                    )
-                )
-            )
-
-    fig.update_layout(
-        xaxis=dict(
-            showgrid=False,
-            showline=False,
-            showticklabels=False,
-            zeroline=False,
-        ),
-        yaxis=dict(
-            showgrid=False,
-            showline=False,
-            showticklabels=False,
-            zeroline=False,
-        ),
-        legend=dict(
-            bgcolor='rgba(255, 255, 255, 0)',
-            bordercolor='rgba(255, 255, 255, 0)',
-            orientation="h",
-            traceorder="reversed",
-            yanchor='bottom',
-            itemclick=False,
-            itemdoubleclick=False
-        ),
-        barmode='stack',
-        dragmode=False,
-        paper_bgcolor='rgb(248, 248, 255, 0.0)',
-        plot_bgcolor='rgb(248, 248, 255, 0.0)',
-        margin=dict(l=0, r=0, b=0, t=0)
-    )
-
     tab1_content_ = html.Div([
         dbc.Row(
             [
                 dbc.Col(
                     dcc.Graph(
-                        figure=fig,
                         style={
                             'width': '100%',
                             'height': '4pc'
                         },
-                        config={'displayModeBar': False}
+                        config={'displayModeBar': False},
+                        id='classbar'
                     ),
                     width=12
                 )

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -102,8 +102,7 @@ def tab1_content(pdf):
         barmode='stack',
         paper_bgcolor='rgb(248, 248, 255, 0.0)',
         plot_bgcolor='rgb(248, 248, 255, 0.0)',
-        margin=dict(l=50, r=30, b=0, t=0),
-        showlegend=False,
+        margin=dict(l=50, r=30, b=0, t=0)
     )
 
     annotations = []

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -94,7 +94,7 @@ def tab1_content(pdf):
         ),
         legend=dict(
             x=0.1,
-            y=-0.02,
+            y=1.02,
             bgcolor='rgba(255, 255, 255, 0)',
             bordercolor='rgba(255, 255, 255, 0)',
             orientation="h"

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -127,7 +127,7 @@ def tab1_content(pdf):
             dict(
                 xref='x', yref='y',
                 x=xd[0] / 2, y=yd,
-                text=str(int(xd[0]/np.sum(xd))*100) + '%',
+                text=str(int(xd[0]/np.sum(xd)*100)) + '%',
                 font=dict(
                     family='Arial', size=14,
                     color='rgb(248, 248, 255)'
@@ -156,7 +156,7 @@ def tab1_content(pdf):
                 dict(
                     xref='x', yref='y',
                     x=space + (xd[i]/2), y=yd,
-                    text=str(int(xd[i]/np.sum(xd))*100) + '%',
+                    text=str(int(xd[i]/np.sum(xd)*100)) + '%',
                     font=dict(
                         family='Arial', size=14,
                         color='rgb(248, 248, 255)'

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -68,7 +68,7 @@ def tab1_content(pdf):
         for xd, yd, label in zip(x_data, y_data, top_labels):
             fig.add_trace(
                 go.Bar(
-                    x=[xd[i]], y=[y_data[-1]],
+                    x=[xd[i]], y=[yd],
                     orientation='h',
                     marker=dict(
                         color=colors[i],
@@ -120,7 +120,7 @@ def tab1_content(pdf):
             dict(
                 xref='x', yref='y',
                 x=xd[0] / 2, y=yd,
-                text=str(xd[0]) + '%',
+                text=str(xd[0]) + 'alerts',
                 font=dict(
                     family='Arial', size=14,
                     color='rgb(248, 248, 255)'
@@ -184,7 +184,7 @@ def tab1_content(pdf):
                         figure=fig,
                         style={
                             'width': '100%',
-                            'height': '10pc'
+                            'height': '2pc'
                         },
                         config={'displayModeBar': False}
                     ),

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -94,7 +94,7 @@ def tab1_content(pdf):
         ),
         legend=dict(
             x=0.1,
-            y=-2,
+            y=-0.02,
             bgcolor='rgba(255, 255, 255, 0)',
             bordercolor='rgba(255, 255, 255, 0)',
             orientation="h"

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -73,6 +73,7 @@ def tab1_content(pdf):
                     orientation='h',
                     width=0.3,
                     hoverinfo='skip',
+                    showlegend=True,
                     name=top_labels[i] + ': {}%'.format(np.int(xd[i]/np.sum(xd)*100)),
                     marker=dict(
                         color=colors[i],
@@ -87,7 +88,6 @@ def tab1_content(pdf):
             showline=False,
             showticklabels=False,
             zeroline=False,
-            # domain=[0.15, 1]
         ),
         yaxis=dict(
             showgrid=False,

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -312,7 +312,7 @@ def extract_fink_classification(
     high_knscore = knscore_.astype(float) > 0.5
 
     # Others
-    sn_history = jd.astype(float) - jdstarthist.astype(float) <= 21
+    sn_history = jd.astype(float) - jdstarthist.astype(float) <= 90
     high_drb = drb.astype(float) > 0.5
     high_classtar = classtar.astype(float) > 0.4
     early_ndethist = ndethist.astype(int) < 20

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -358,7 +358,7 @@ def extract_fink_classification(
 
     classification.mask(f_mulens.values, 'Microlensing candidate', inplace=True)
     classification.mask(f_sn.values, 'SN candidate', inplace=True)
-    classification.mask(f_sn_early.values, 'Early SN candidate', inplace=True)
+    classification.mask(f_sn_early.values, 'Early SN Ia candidate', inplace=True)
     classification.mask(f_kn.values, 'Kilonova candidate', inplace=True)
     classification.mask(f_roid_2.values, 'Solar System candidate', inplace=True)
     classification.mask(f_roid_3.values, 'Solar System MPC', inplace=True)

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -312,7 +312,7 @@ def extract_fink_classification(
     high_knscore = knscore_.astype(float) > 0.5
 
     # Others
-    low_ndethist = ndethist.astype(int) < 400
+    sn_history = jd.astype(float) - jdstarthist.astype(float) <= 21
     high_drb = drb.astype(float) > 0.5
     high_classtar = classtar.astype(float) > 0.4
     early_ndethist = ndethist.astype(int) < 20
@@ -339,7 +339,7 @@ def extract_fink_classification(
     keep_cds = \
         ["Unknown", "Candidate_SN*", "SN", "Transient", "Fail"] + list_simbad_galaxies
 
-    f_sn = (snn1 | snn2) & cdsxmatch.isin(keep_cds) & low_ndethist & high_drb & high_classtar
+    f_sn = (snn1 | snn2) & cdsxmatch.isin(keep_cds) & sn_history & high_drb & high_classtar
     f_sn_early = early_ndethist & active_learn & f_sn
 
     # Kilonova

--- a/assets/fink_types.csv
+++ b/assets/fink_types.csv
@@ -1,4 +1,4 @@
-Early SN candidate
+Early SN Ia candidate
 Kilonova candidate
 SN candidate
 Microlensing candidate

--- a/assets/simbad_types.csv
+++ b/assets/simbad_types.csv
@@ -21,6 +21,7 @@ gamma
 Inexistent
 LensingEv
 Candidate_LensSystem
+Candidate_LensSyste
 Candidate_Lens
 Possible_lensImage
 GravLens


### PR DESCRIPTION
This PR adds a new bar that displays individual alert classification, e.g.:

<img width="1421" alt="Screenshot 2021-05-27 at 22 46 42" src="https://user-images.githubusercontent.com/20426972/119894866-70203000-bf3d-11eb-83c4-ff9410bf81ca.png">

The idea behind this bar is to help users to take a decision on what is the _object_ classification (so far, we were using only the last alert classification)