### PR TITLE
Add links to the SNAD viewer

### DIFF
--- a/apps/cards.py
+++ b/apps/cards.py
@@ -276,6 +276,16 @@ def card_variable_button(pdf):
                     target="_blank",
                     href='https://asas-sn.osu.edu/variables?ra={}&dec={}&radius=0.5&vmag_min=&vmag_max=&amplitude_min=&amplitude_max=&period_min=&period_max=&lksl_min=&lksl_max=&class_prob_min=&class_prob_max=&parallax_over_err_min=&parallax_over_err_max=&name=&references[]=I&references[]=II&references[]=III&references[]=IV&references[]=V&references[]=VI&sort_by=raj2000&sort_order=asc&show_non_periodic=true&show_without_class=true&asassn_discov_only=false&'.format(ra0, dec0)
                 )
+            ),
+            dbc.Row(
+                dbc.Button(
+                    'Search in SNAD ZTF-DR4',
+                    id='SNAD-var-star',
+                    style={'width': '100%', 'display': 'inline-block'},
+                    block=True,
+                    target="_blank",
+                    href='https://ztf.snad.space/dr4/search/{} {}/{}'.format(ra0, dec0, 5)
+                )
             )
         ],
         className="mt-3", body=True

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -279,12 +279,12 @@ def card_variable_button(pdf):
             ),
             dbc.Row(
                 dbc.Button(
-                    'Search in SNAD ZTF-DR4',
+                    'Search in SNAD',
                     id='SNAD-var-star',
                     style={'width': '100%', 'display': 'inline-block'},
                     block=True,
                     target="_blank",
-                    href='https://ztf.snad.space/dr4/search/{} {}/{}'.format(ra0, dec0, 5)
+                    href='https://ztf.snad.space/search/{} {}/{}'.format(ra0, dec0, 5)
                 )
             )
         ],
@@ -547,7 +547,7 @@ def card_id(pdf):
             ),
             dbc.ButtonGroup([
                 dbc.Button('TNS', id='TNS', target="_blank", href='https://www.wis-tns.org/search?ra={}&decl={}&radius=5&coords_unit=arcsec'.format(ra0, dec0), color='light'),
-                dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{} {}/{}'.format(ra0, dec0, 5), color='light'),
+                dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/search/{} {}/{}'.format(ra0, dec0, 5), color='light'),
                 dbc.Button('OAC', id='OAC', target="_blank", href='https://api.astrocats.space/catalog?ra={}&dec={}&radius=2'.format(ra0, dec0), color='light'),
             ]),
             dbc.ButtonGroup([
@@ -653,7 +653,7 @@ def card_sn_properties(clickData, object_data):
             html.Br(),
             dbc.ButtonGroup([
                 dbc.Button('TNS', id='TNS', target="_blank", href='https://www.wis-tns.org/search?ra={}&decl={}&radius=5&coords_unit=arcsec'.format(ra0, dec0), color='light'),
-                dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{} {}/{}'.format(ra0, dec0, 5), color='light'),
+                dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/search/{} {}/{}'.format(ra0, dec0, 5), color='light'),
                 dbc.Button('OAC', id='OAC', target="_blank", href='https://api.astrocats.space/catalog?ra={}&dec={}&radius=2'.format(ra0, dec0), color='light'),
             ]),
             dbc.ButtonGroup([

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -537,7 +537,7 @@ def card_id(pdf):
             ),
             dbc.ButtonGroup([
                 dbc.Button('TNS', id='TNS', target="_blank", href='https://www.wis-tns.org/search?ra={}&decl={}&radius=5&coords_unit=arcsec'.format(ra0, dec0), color='light'),
-                dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{}%{}/{}'.format(ra0, dec0, 5), color='light'),
+                dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{} {}/{}'.format(ra0, dec0, 5), color='light'),
                 dbc.Button('OAC', id='OAC', target="_blank", href='https://api.astrocats.space/catalog?ra={}&dec={}&radius=2'.format(ra0, dec0), color='light'),
             ]),
             dbc.ButtonGroup([
@@ -643,7 +643,7 @@ def card_sn_properties(clickData, object_data):
             html.Br(),
             dbc.ButtonGroup([
                 dbc.Button('TNS', id='TNS', target="_blank", href='https://www.wis-tns.org/search?ra={}&decl={}&radius=5&coords_unit=arcsec'.format(ra0, dec0), color='light'),
-                dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{}%{}/{}'.format(ra0, dec0, 5), color='link'),
+                dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{} {}/{}'.format(ra0, dec0, 5), color='link'),
                 dbc.Button('OAC', id='OAC', target="_blank", href='https://api.astrocats.space/catalog?ra={}&dec={}&radius=2'.format(ra0, dec0), color='light'),
             ]),
             dbc.ButtonGroup([

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -537,6 +537,7 @@ def card_id(pdf):
             ),
             dbc.ButtonGroup([
                 dbc.Button('TNS', id='TNS', target="_blank", href='https://www.wis-tns.org/search?ra={}&decl={}&radius=5&coords_unit=arcsec'.format(ra0, dec0), color='light'),
+                dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{}%{}/{}'.format(ra0, dec0, 5), color='light'),
                 dbc.Button('OAC', id='OAC', target="_blank", href='https://api.astrocats.space/catalog?ra={}&dec={}&radius=2'.format(ra0, dec0), color='light'),
             ]),
             dbc.ButtonGroup([
@@ -642,6 +643,7 @@ def card_sn_properties(clickData, object_data):
             html.Br(),
             dbc.ButtonGroup([
                 dbc.Button('TNS', id='TNS', target="_blank", href='https://www.wis-tns.org/search?ra={}&decl={}&radius=5&coords_unit=arcsec'.format(ra0, dec0), color='light'),
+                dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{}%{}/{}'.format(ra0, dec0, 5), color='link'),
                 dbc.Button('OAC', id='OAC', target="_blank", href='https://api.astrocats.space/catalog?ra={}&dec={}&radius=2'.format(ra0, dec0), color='light'),
             ]),
             dbc.ButtonGroup([

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -653,7 +653,7 @@ def card_sn_properties(clickData, object_data):
             html.Br(),
             dbc.ButtonGroup([
                 dbc.Button('TNS', id='TNS', target="_blank", href='https://www.wis-tns.org/search?ra={}&decl={}&radius=5&coords_unit=arcsec'.format(ra0, dec0), color='light'),
-                dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{} {}/{}'.format(ra0, dec0, 5), color='link'),
+                dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{} {}/{}'.format(ra0, dec0, 5), color='light'),
                 dbc.Button('OAC', id='OAC', target="_blank", href='https://api.astrocats.space/catalog?ra={}&dec={}&radius=2'.format(ra0, dec0), color='light'),
             ]),
             dbc.ButtonGroup([

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -210,7 +210,7 @@ def create_external_links(object_data):
             [
                 dbc.Col(
                     [
-                        dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{}%{}/{}'.format(ra0, dec0, 5), color='link'),
+                        dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{} {}/{}'.format(ra0, dec0, 5), color='link'),
                     ], width=6
                 )
             ]

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -210,6 +210,15 @@ def create_external_links(object_data):
             [
                 dbc.Col(
                     [
+                        dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{}%{}/{}'.format(ra0, dec0, 5), color='link'),
+                    ], width=6
+                )
+            ]
+        ),
+        dbc.Row(
+            [
+                dbc.Col(
+                    [
                         dbc.Button('SIMBAD', id='SIMBAD', target="_blank", href="http://simbad.u-strasbg.fr/simbad/sim-coo?Coord={}%20{}&Radius=0.08".format(ra0, dec0), color="link"),
                     ], width=6
                 )

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -210,7 +210,7 @@ def create_external_links(object_data):
             [
                 dbc.Col(
                     [
-                        dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/dr4/search/{} {}/{}'.format(ra0, dec0, 5), color='link'),
+                        dbc.Button('SNAD', id='SNAD', target="_blank", href='https://ztf.snad.space/search/{} {}/{}'.format(ra0, dec0, 5), color='link'),
                     ], width=6
                 )
             ]


### PR DESCRIPTION
This PR adds 3 links in the Science Portal to the SNAD (ZTF-DR4) viewer:

- In the `Summary` view of an object for the desktop/laptop application

<img width="1426" alt="Screenshot 2021-07-09 at 15 47 58" src="https://user-images.githubusercontent.com/20426972/125088637-ea5fda80-e0cd-11eb-9f2b-e496222bec62.png">

- In the `Variable Star` view of an object for the desktop/laptop application

<img width="1440" alt="Screenshot 2021-07-09 at 15 50 16" src="https://user-images.githubusercontent.com/20426972/125088662-f055bb80-e0cd-11eb-89d8-bf2f438fbee8.png">

- In the External tab of an object for the mobile application

<img width="289" alt="Screenshot 2021-07-09 at 15 50 54" src="https://user-images.githubusercontent.com/20426972/125088687-f51a6f80-e0cd-11eb-8726-3bfbc89d8c56.png">

Each button will redirect to a conesearch in the SNAD viewer, centered on the coordinates of the object, and with a radius of 5 arcseconds:

<img width="1438" alt="Screenshot 2021-07-09 at 15 56 16" src="https://user-images.githubusercontent.com/20426972/125088961-37dc4780-e0ce-11eb-8c84-bd343d05abe2.png">

@emilleishida @hombit
