### PR TITLE
Add a preview of table results in the Explorer page

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,8 @@ import jpype
 import jpype.imports
 from jpype import JImplements, JOverride, JImplementationFor
 
+APIURL = "http://134.158.75.151:24000"
+
 # bootstrap theme
 # https://bootswatch.com/spacelab/
 external_stylesheets = [

--- a/apps/api.py
+++ b/apps/api.py
@@ -27,6 +27,7 @@ from app import clientP128, clientP4096, clientP131072
 from app import clientT, clientS
 from app import clientSSO, clientTNS
 from app import clientU, clientUV, nlimit
+from app import APIURL
 from apps.utils import format_hbase_output
 from apps.utils import extract_cutouts
 from apps.utils import get_superpixels
@@ -47,8 +48,6 @@ from astropy.coordinates import SkyCoord
 from astropy.table import Table
 
 from flask import Blueprint
-
-APIURL = "http://134.158.75.151:24000"
 
 api_bp = Blueprint('', __name__)
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -986,7 +986,7 @@ def draw_color_rate(object_data) -> dict:
     }
     return figure
 
-def extract_cutout(object_data, time0, kind, taken_from='summary'):
+def extract_cutout(object_data, time0, kind):
     """ Extract cutout data from the alert
 
     Parameters
@@ -1008,10 +1008,7 @@ def extract_cutout(object_data, time0, kind, taken_from='summary'):
         'i:fid',
         'b:cutout{}_stampData'.format(kind.capitalize()),
     ]
-    if taken_from == 'summary':
-        pdf_ = pd.read_json(object_data)
-    elif taken_from == 'explorer':
-        pdf_ = pd.DataFrame(object_data)
+    pdf_ = pd.read_json(object_data)
     pdfs = pdf_.loc[:, values]
     pdfs = pdfs.sort_values('i:jd', ascending=False)
 
@@ -1086,7 +1083,7 @@ def draw_cutouts_quickview(name):
                 }
             )
             object_data = r.content
-            data = extract_cutout(object_data, None, kind=kind, taken_from='explorer')
+            data = extract_cutout(object_data, None, kind=kind)
             figs.append(draw_cutout(data, kind, is_mobile=True))
         except OSError:
             data = dcc.Markdown("Load fail, refresh the page")

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -30,7 +30,7 @@ import dash_core_components as dcc
 
 from apps.utils import convert_jd, readstamp, _data_stretch, convolve
 from apps.utils import apparent_flux, dc_mag
-from apps.api import APIURL
+from app import APIURL
 
 from pyLIMA import event
 from pyLIMA import telescopes

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -19,6 +19,7 @@ from gatspy import periodic
 import java
 import copy
 from astropy.time import Time
+import requests
 
 import dash
 import dash_table
@@ -29,6 +30,7 @@ import dash_core_components as dcc
 
 from apps.utils import convert_jd, readstamp, _data_stretch, convolve
 from apps.utils import apparent_flux, dc_mag
+from apps.api import APIURL
 
 from pyLIMA import event
 from pyLIMA import telescopes
@@ -1071,17 +1073,19 @@ def draw_cutouts_mobile(object_data, is_mobile):
             figs.append(data)
     return figs
 
-@app.callback(
-    Output("stamps_quickview", "children"),
-    [
-        Input("result_table", "data")
-    ])
-def draw_cutouts_quickview(object_data):
+def draw_cutouts_quickview(name):
     """ Draw cutouts data based on lightcurve data
     """
     figs = []
     for kind in ['science', 'template', 'difference']:
         try:
+            r = requests.post(
+                '{}/api/v1/explorer'.format(APIURL),
+                json={
+                    'objectId': name,
+                }
+            )
+            object_data = r.content
             data = extract_cutout(object_data, None, kind=kind, taken_from='explorer')
             figs.append(draw_cutout(data, kind, is_mobile=True))
         except OSError:

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1074,7 +1074,7 @@ def draw_cutouts_quickview(name):
     """ Draw cutouts data based on lightcurve data
     """
     figs = []
-    for kind in ['science', 'template', 'difference']:
+    for kind in ['science']:
         try:
             r = requests.post(
                 '{}/api/v1/explorer'.format(APIURL),

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1068,6 +1068,24 @@ def draw_cutouts_mobile(object_data, is_mobile):
             figs.append(data)
     return figs
 
+@app.callback(
+    Output("stamps_quickview", "children"),
+    [
+        Input("result_table", "data")
+    ])
+def draw_cutouts_quickview(object_data):
+    """ Draw cutouts data based on lightcurve data
+    """
+    figs = []
+    for kind in ['science', 'template', 'difference']:
+        try:
+            data = extract_cutout(object_data, None, kind=kind)
+            figs.append(draw_cutout(data, kind, is_mobile=True))
+        except OSError:
+            data = dcc.Markdown("Load fail, refresh the page")
+            figs.append(data)
+    return figs
+
 def create_circular_mask(h, w, center=None, radius=None):
 
     if center is None: # use the middle of the image

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -714,19 +714,20 @@ def draw_lightcurve_preview(name) -> dict:
     ----------
     figure: dict
     """
+    cols = [
+        'i:jd', 'i:magpsf', 'i:sigmapsf', 'i:fid',
+        'i:magnr', 'i:sigmagnr', 'i:magzpsci', 'i:isdiffpos', 'i:candid'
+    ]
     r = requests.post(
       '{}/api/v1/objects'.format(APIURL),
       json={
         'objectId': name,
         'withupperlim': 'True',
+        'columns': ",".join(cols),
         'output-format': 'json'
       }
     )
     pdf_ = pd.read_json(r.content)
-    cols = [
-        'i:jd', 'i:magpsf', 'i:sigmapsf', 'i:fid',
-        'i:magnr', 'i:sigmagnr', 'i:magzpsci', 'i:isdiffpos', 'i:candid'
-    ]
     pdf = pdf_.loc[:, cols]
 
     # Mask upper-limits (but keep measurements with bad quality)

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1173,7 +1173,7 @@ def draw_cutouts_quickview(name):
                 'b:cutout{}_stampData'.format(kind.capitalize()),
             ]
             r = requests.post(
-                '{}/api/v1/explorer'.format(APIURL),
+                '{}/api/v1/objects'.format(APIURL),
                 json={
                     'objectId': name,
                     'columns': ','.join(cols)

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1082,7 +1082,7 @@ def draw_cutouts_quickview(object_data):
     figs = []
     for kind in ['science', 'template', 'difference']:
         try:
-            data = extract_cutout(object_data, None, kind=kind)
+            data = extract_cutout(object_data, None, kind=kind, taken_from='explorer')
             figs.append(draw_cutout(data, kind, is_mobile=True))
         except OSError:
             data = dcc.Markdown("Load fail, refresh the page")

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -636,20 +636,20 @@ def draw_lightcurve_sn(pathname: str, object_data, object_upper, object_upperval
     # shortcuts
     mag = pdf['i:magpsf']
     err = pdf['i:sigmapsf']
-    # inplace replacement
-    mag, err = np.transpose(
-        [
-            dc_mag(*args) for args in zip(
-                pdf['i:fid'].values,
-                mag.astype(float).values,
-                err.astype(float).values,
-                pdf['i:magnr'].astype(float).values,
-                pdf['i:sigmagnr'].astype(float).values,
-                pdf['i:magzpsci'].astype(float).values,
-                pdf['i:isdiffpos'].values
-            )
-        ]
-    )
+    # # inplace replacement
+    # mag, err = np.transpose(
+    #     [
+    #         dc_mag(*args) for args in zip(
+    #             pdf['i:fid'].values,
+    #             mag.astype(float).values,
+    #             err.astype(float).values,
+    #             pdf['i:magnr'].astype(float).values,
+    #             pdf['i:sigmagnr'].astype(float).values,
+    #             pdf['i:magzpsci'].astype(float).values,
+    #             pdf['i:isdiffpos'].values
+    #         )
+    #     ]
+    # )
     layout_lightcurve['yaxis']['title'] = 'Apparent DC magnitude'
     layout_lightcurve['yaxis']['autorange'] = 'reversed'
 
@@ -718,6 +718,7 @@ def draw_lightcurve_preview(name) -> dict:
       '{}/api/v1/objects'.format(APIURL),
       json={
         'objectId': name,
+        'withupperlim': 'True',
         'output-format': 'json'
       }
     )

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -984,7 +984,7 @@ def draw_color_rate(object_data) -> dict:
     }
     return figure
 
-def extract_cutout(object_data, time0, kind):
+def extract_cutout(object_data, time0, kind, taken_from='summary'):
     """ Extract cutout data from the alert
 
     Parameters
@@ -1006,7 +1006,10 @@ def extract_cutout(object_data, time0, kind):
         'i:fid',
         'b:cutout{}_stampData'.format(kind.capitalize()),
     ]
-    pdf_ = pd.read_json(object_data)
+    if taken_from == 'summary':
+        pdf_ = pd.read_json(object_data)
+    elif taken_from == 'explorer':
+        pdf_ = pd.DataFrame(object_data)
     pdfs = pdf_.loc[:, values]
     pdfs = pdfs.sort_values('i:jd', ascending=False)
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -729,26 +729,19 @@ def draw_lightcurve_preview(name) -> dict:
     ]
     pdf = pdf_.loc[:, cols]
 
+    # Mask upper-limits (but keep measurements with bad quality)
+    mag_ = pdf['i:magpsf']
+    mask = ~np.isnan(mag_)
+    pdf = pdf[mask]
+
     # type conversion
     dates = pdf['i:jd'].apply(lambda x: convert_jd(float(x), to='iso'))
 
     # shortcuts
     mag = pdf['i:magpsf']
     err = pdf['i:sigmapsf']
-    # inplace replacement
-    # mag, err = np.transpose(
-    #     [
-    #         dc_mag(*args) for args in zip(
-    #             pdf['i:fid'].values,
-    #             mag.astype(float).values,
-    #             err.astype(float).values,
-    #             pdf['i:magnr'].astype(float).values,
-    #             pdf['i:sigmagnr'].astype(float).values,
-    #             pdf['i:magzpsci'].astype(float).values,
-    #             pdf['i:isdiffpos'].values
-    #         )
-    #     ]
-    # )
+
+
     layout_lightcurve['yaxis']['title'] = 'Apparent DC magnitude'
     layout_lightcurve['yaxis']['autorange'] = 'reversed'
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -636,20 +636,20 @@ def draw_lightcurve_sn(pathname: str, object_data, object_upper, object_upperval
     # shortcuts
     mag = pdf['i:magpsf']
     err = pdf['i:sigmapsf']
-    # # inplace replacement
-    # mag, err = np.transpose(
-    #     [
-    #         dc_mag(*args) for args in zip(
-    #             pdf['i:fid'].values,
-    #             mag.astype(float).values,
-    #             err.astype(float).values,
-    #             pdf['i:magnr'].astype(float).values,
-    #             pdf['i:sigmagnr'].astype(float).values,
-    #             pdf['i:magzpsci'].astype(float).values,
-    #             pdf['i:isdiffpos'].values
-    #         )
-    #     ]
-    # )
+    # inplace replacement
+    mag, err = np.transpose(
+        [
+            dc_mag(*args) for args in zip(
+                pdf['i:fid'].values,
+                mag.astype(float).values,
+                err.astype(float).values,
+                pdf['i:magnr'].astype(float).values,
+                pdf['i:sigmagnr'].astype(float).values,
+                pdf['i:magzpsci'].astype(float).values,
+                pdf['i:isdiffpos'].values
+            )
+        ]
+    )
     layout_lightcurve['yaxis']['title'] = 'Apparent DC magnitude'
     layout_lightcurve['yaxis']['autorange'] = 'reversed'
 
@@ -736,19 +736,19 @@ def draw_lightcurve_preview(name) -> dict:
     mag = pdf['i:magpsf']
     err = pdf['i:sigmapsf']
     # inplace replacement
-    mag, err = np.transpose(
-        [
-            dc_mag(*args) for args in zip(
-                pdf['i:fid'].values,
-                mag.astype(float).values,
-                err.astype(float).values,
-                pdf['i:magnr'].astype(float).values,
-                pdf['i:sigmagnr'].astype(float).values,
-                pdf['i:magzpsci'].astype(float).values,
-                pdf['i:isdiffpos'].values
-            )
-        ]
-    )
+    # mag, err = np.transpose(
+    #     [
+    #         dc_mag(*args) for args in zip(
+    #             pdf['i:fid'].values,
+    #             mag.astype(float).values,
+    #             err.astype(float).values,
+    #             pdf['i:magnr'].astype(float).values,
+    #             pdf['i:sigmagnr'].astype(float).values,
+    #             pdf['i:magzpsci'].astype(float).values,
+    #             pdf['i:isdiffpos'].values
+    #         )
+    #     ]
+    # )
     layout_lightcurve['yaxis']['title'] = 'Apparent DC magnitude'
     layout_lightcurve['yaxis']['autorange'] = 'reversed'
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1168,10 +1168,12 @@ def draw_cutouts_quickview(name):
     figs = []
     for kind in ['science']:
         try:
+            # transfer only necessary columns
             cols = [
                 'i:jd',
                 'b:cutout{}_stampData'.format(kind.capitalize()),
             ]
+            # Transfer cutout name data
             r = requests.post(
                 '{}/api/v1/objects'.format(APIURL),
                 json={

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -742,7 +742,7 @@ def draw_lightcurve_preview(name) -> dict:
     err = pdf['i:sigmapsf']
 
 
-    layout_lightcurve['yaxis']['title'] = 'Apparent DC magnitude'
+    layout_lightcurve['yaxis']['title'] = 'Difference magnitude'
     layout_lightcurve['yaxis']['autorange'] = 'reversed'
 
     hovertemplate = r"""

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1098,7 +1098,6 @@ def extract_cutout(object_data, time0, kind):
     """
     values = [
         'i:jd',
-        'i:fid',
         'b:cutout{}_stampData'.format(kind.capitalize()),
     ]
     pdf_ = pd.read_json(object_data)
@@ -1164,15 +1163,20 @@ def draw_cutouts_mobile(object_data, is_mobile):
     return figs
 
 def draw_cutouts_quickview(name):
-    """ Draw cutouts data based on lightcurve data
+    """ Draw Science cutout data for the preview service
     """
     figs = []
     for kind in ['science']:
         try:
+            cols = [
+                'i:jd',
+                'b:cutout{}_stampData'.format(kind.capitalize()),
+            ]
             r = requests.post(
                 '{}/api/v1/explorer'.format(APIURL),
                 json={
                     'objectId': name,
+                    'columns': ','.join(cols)
                 }
             )
             object_data = r.content

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -37,7 +37,7 @@ from apps.plotting import plot_classbar
 from apps.plotting import all_radio_options
 
 from apps.utils import format_hbase_output
-from apps.api import APIURL
+from app import APIURL
 
 dcc.Location(id='url', refresh=False)
 

--- a/index.py
+++ b/index.py
@@ -283,7 +283,7 @@ modal_quickview = html.Div(
         dbc.Modal(
             [
                 dbc.ModalHeader("10 first alerts"),
-                dbc.ModalBody(dbc.Container(id='carousel')),
+                dbc.ModalBody([dbc.Container(id='carousel'), html.Br()]),
                 # dbc.ModalFooter(
                 #     dbc.Button(
                 #         "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0

--- a/index.py
+++ b/index.py
@@ -408,29 +408,23 @@ def display_table_results(table, is_mobile):
     )
 
     if is_mobile:
-        return dbc.Container([
-            html.Br(),
-            dbc.Row(
-                [
-                    dbc.Col(dropdown, width=6),
-                    dbc.Col(modal_quickview, width=6)
-                ]
-            ),
-            html.Br(),
-            table
-        ], fluid=True)
+        width_dropdown = 9
+        width_preview = 3
     else:
-        return dbc.Container([
-            html.Br(),
-            dbc.Row(
-                [
-                    dbc.Col(dropdown, width=10),
-                    dbc.Col(modal_quickview, width=2)
-                ]
-            ),
-            html.Br(),
-            table
-        ], fluid=True)
+        width_dropdown = 10
+        width_preview = 2
+
+    return dbc.Container([
+        html.Br(),
+        dbc.Row(
+            [
+                dbc.Col(dropdown, width=width_dropdown),
+                dbc.Col(modal_quickview, width=width_preview)
+            ]
+        ),
+        html.Br(),
+        table
+    ], fluid=True)
 
 @app.callback(
     Output('aladin-lite-div-skymap', 'run'),

--- a/index.py
+++ b/index.py
@@ -263,7 +263,7 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, 
         cardbody = dbc.CardBody(
             [
                 html.H4("{}".format(finkclass), className="card-title"),
-                dcc.Graph(draw_lightcurve_preview(name))
+                dcc.Graph(figure=draw_lightcurve_preview(name))
             ]
         )
 

--- a/index.py
+++ b/index.py
@@ -222,6 +222,12 @@ def print_msg_info():
 
 def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, is_mobile):
     dic_band = {1: 'g', 2: 'r'}
+
+    if is_mobile:
+        fontsize = '75%'
+    else:
+        fontsize = '100%'
+
     l1 = html.P(
         [
             html.Strong("Last emission date: ", style={'font-size': fontsize}),
@@ -250,7 +256,6 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, 
     )
 
     if is_mobile:
-        fontsize = '75%'
         cardbody = dbc.CardBody(
             [
                 html.H4("{}".format(finkclass), className="card-title"),
@@ -268,7 +273,6 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, 
             )
         )
     else:
-        fontsize = '100%'
         cardbody = dbc.CardBody(
             [
                 html.H4("{}".format(finkclass), className="card-title"),

--- a/index.py
+++ b/index.py
@@ -129,6 +129,10 @@ By default, the table shows:
 - i:ndethist: Number of spatially coincident detections falling within 1.5 arcsec going back to the beginning of the survey; only detections that fell on the same field and readout-channel ID where the input candidate was observed are counted. All raw detections down to a photometric S/N of ~ 3 are included.
 
 You can also add more columns using the dropdown button above the result table. Full documentation of all available fields can be found at https://fink-portal.ijclab.in2p3.fr:24000/api/v1/columns.
+
+Finally, you can hit the button `Preview`. This will show you more information
+about the first 10 alerts (science cutout, and basic information). Note you can
+swipe between alerts (or use arrows on a laptop).
 """
 
 modal = html.Div(

--- a/index.py
+++ b/index.py
@@ -264,7 +264,7 @@ def carousel(nclick, data):
             autoplay=False,
             speed=10,
             variable_width=False,
-            center_mode=True
+            center_mode=False
         )
     else:
         carousel = html.Div("")

--- a/index.py
+++ b/index.py
@@ -262,7 +262,7 @@ def carousel(nclick, data):
             slides_to_show=1,
             swipe_to_slide=True,
             autoplay=False,
-            speed=1000,
+            speed=800,
             variable_width=False,
             center_mode=False
         )

--- a/index.py
+++ b/index.py
@@ -319,7 +319,13 @@ modal_quickview = html.Div(
         ),
         dbc.Modal(
             [
-                dbc.ModalBody(dbc.Container(id='carousel', fluid=True, style={'width': '95%'})),
+                dbc.ModalBody(
+                    dbc.Container(
+                        id='carousel',
+                        fluid=True,
+                        style={'width': '95%'}
+                    ), style={'background-image': 'linear-gradient(rgba(0,0,0,0.3), rgba(255,255,255,0.3)), url(/assets/background.png)'}
+                ),
                 dbc.ModalFooter(
                     dbc.Button(
                         "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0

--- a/index.py
+++ b/index.py
@@ -412,12 +412,8 @@ def display_table_results(table, is_mobile):
             html.Br(),
             dbc.Row(
                 [
-                    dbc.Col(dropdown, width=12)
-                ]
-            ),
-            dbc.Row(
-                [
-                    dbc.Col(modal_quickview)
+                    dbc.Col(dropdown, width=6),
+                    dbc.Col(modal_quickview, width=6)
                 ]
             ),
             html.Br(),

--- a/index.py
+++ b/index.py
@@ -219,8 +219,8 @@ def print_msg_info():
 def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist):
     dic_band = {1: 'g', 2: 'r'}
     l1 = "Last emission date: "
-    l2 = "Apparent magnitude (band {}): ".format(dic_band[fid])
-    l3 = "Time since first detection: "
+    l2 = "Last magnitude (band {}): ".format(dic_band[fid])
+    l3 = "Days since first detection: "
     l4 = "Total number of detections: "
     simple_card_ = dbc.Card(
         [
@@ -236,25 +236,25 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist):
                     html.H4("{}".format(finkclass), className="card-title"),
                     html.P(
                         [
-                            html.Strong(l1),
+                            html.Strong(l1, style={'font-size': '75%'}),
                             html.P(lastdate)
                         ]
                     ),
                     html.P(
                         [
-                            html.Strong(l2),
+                            html.Strong(l2, style={'font-size': '75%'}),
                             html.P("{:.2f}".format(mag))
                         ]
                     ),
                     html.P(
                         [
-                            html.Strong(l3),
+                            html.Strong(l3, style={'font-size': '75%'}),
                             html.P('{}'.format(int(jd - jdstarthist)))
                         ]
                     ),
                     html.P(
                         [
-                            html.Strong(l4),
+                            html.Strong(l4, style={'font-size': '75%'}),
                             html.P('{}'.format(ndethist))
                         ]
                     ),
@@ -312,7 +312,6 @@ modal_quickview = html.Div(
         ),
         dbc.Modal(
             [
-                dbc.ModalHeader("10 first alerts"),
                 dbc.ModalBody(dbc.Container(id='carousel', fluid=True, style={'width': '95%'})),
                 dbc.ModalFooter(
                     dbc.Button(

--- a/index.py
+++ b/index.py
@@ -217,14 +217,11 @@ def print_msg_info():
     return h
 
 def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist):
-    msg = """
-    ```python
-    Last emission date: {}
-    Apparent magnitude (band {}): {}
-    Time since first detection: {} days
-    Total number of detections: {}
-    ```
-    """.format(lastdate, fid, mag, jd - jdstarthist, ndethist)
+    dic_band = {1: 'g', 2: 'r'}
+    l1 = "Last emission date: "
+    l2 = "Apparent magnitude (band {}): ".format(dic_band[fid])
+    l3 = "Time since first detection: "
+    l4 = "Total number of detections: "
     simple_card_ = dbc.Card(
         [
             dbc.CardHeader(
@@ -237,7 +234,30 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist):
             dbc.CardBody(
                 [
                     html.H4("{}".format(finkclass), className="card-title"),
-                    dcc.Markdown(msg),
+                    html.P(
+                        [
+                            html.Strong(l1),
+                            html.P(lastdate)
+                        ]
+                    ),
+                    html.P(
+                        [
+                            html.Strong(l2),
+                            html.P("{:.2f}".format(mag))
+                        ]
+                    ),
+                    html.P(
+                        [
+                            html.Strong(l3),
+                            html.P('{}'.format(int(jd - jdstarthist)))
+                        ]
+                    ),
+                    html.P(
+                        [
+                            html.Strong(l4),
+                            html.P('{}'.format(ndethist))
+                        ]
+                    ),
                 ]
             ),
             dbc.CardFooter(dbc.Button("Go to {}".format(name), color="primary", outline=True))

--- a/index.py
+++ b/index.py
@@ -262,7 +262,7 @@ def carousel(nclick, data):
             slides_to_show=1,
             swipe_to_slide=True,
             autoplay=False,
-            speed=10,
+            speed=100,
             variable_width=False,
             center_mode=False
         )

--- a/index.py
+++ b/index.py
@@ -389,8 +389,8 @@ def display_table_results(table, is_mobile):
     fink_additional_fields = ['v:g-r', 'v:rate(g-r)', 'v:classification', 'v:lastdate']
 
     if is_mobile:
-        width_dropdown = 8
-        width_preview = 4
+        width_dropdown = 6
+        width_preview = 6
     else:
         width_dropdown = 10
         width_preview = 2

--- a/index.py
+++ b/index.py
@@ -218,10 +218,10 @@ def print_msg_info():
 def simple_card(name):
     simple_card_ = dbc.Card(
         [
-            dbc.CardHeader(name),
+            dbc.CardHeader(dbc.Row(id='stamps_quickview', justify='around')),
             dbc.CardBody(
                 [
-                    html.H4("Card title", className="card-title"),
+                    html.H4("{}".format(name), className="card-title"),
                     html.P(
                         "Some quick example text to build on the card title and "
                         "make up the bulk of the card's content.",
@@ -246,7 +246,7 @@ def carousel(nclick, data):
     """
     if nclick > 0:
         pdf = pd.DataFrame(data)
-        names = pdf['i:objectId']
+        names = pdf['i:objectId'][0:10]
         carousel = dtc.Carousel(
             [
                 html.Div(dbc.Container(simple_card(name))) for name in names

--- a/index.py
+++ b/index.py
@@ -266,7 +266,7 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, 
                 ]
             ),
             dbc.CardFooter(dbc.Button("Go to {}".format(name), color="primary", outline=True))
-        ],
+        ], style={'background-image': 'linear-gradient(rgba(255,255,255,0.3), rgba(255,255,255,0.3)), url(/assets/background.png)'}
     )
     return simple_card_
 

--- a/index.py
+++ b/index.py
@@ -362,7 +362,7 @@ def toggle_modal(n1, n2, is_open):
         return not is_open
     return is_open
 
-def display_table_results(table):
+def display_table_results(table, is_mobile):
     """ Display explorer results in the form of a table with a dropdown
     menu on top to insert more data columns.
 
@@ -388,6 +388,12 @@ def display_table_results(table):
     ztf_fields = [i for i in schema_list if i.startswith('i:')]
     fink_additional_fields = ['v:g-r', 'v:rate(g-r)', 'v:classification', 'v:lastdate']
 
+    if is_mobile:
+        width_dropdown = 8
+        width_preview = 4
+    else:
+        width_dropdown = 10
+        width_preview = 2
     return dbc.Container([
         html.Br(),
         dbc.Row(
@@ -406,9 +412,9 @@ def display_table_results(table):
                         searchable=True,
                         clearable=True,
                         placeholder="Add more fields to the table",
-                    ), width=10
+                    ), width=width_dropdown
                 ),
-                dbc.Col(modal_quickview, width=2)
+                dbc.Col(modal_quickview, width=width_preview)
             ]
         ),
         html.Br(),
@@ -659,14 +665,14 @@ def logo(ns):
     else:
         return logo
 
-def construct_results_layout(table):
+def construct_results_layout(table, is_mobile):
     """ Construct the tabs containing explorer query results
     """
     results_ = [
         dbc.Tabs(
             [
                 dbc.Tab(print_msg_info(), label='Info', tab_id='t0'),
-                dbc.Tab(display_table_results(table), label="Table", tab_id='t1'),
+                dbc.Tab(display_table_results(table, is_mobile), label="Table", tab_id='t1'),
                 dbc.Tab(display_skymap(), label="Sky map", tab_id='t2'),
             ],
             id="tabs",
@@ -755,10 +761,11 @@ def update_table(field_dropdown, data, columns):
         Input("search_bar_input", "value"),
         Input("dropdown-query", "label"),
         Input("select", "value"),
+        Input("is_mobile", "value"),
     ],
     State("results", "children")
 )
-def results(ns, query, query_type, dropdown_option, results):
+def results(ns, query, query_type, dropdown_option, results, is_mobile):
     """ Query the database from the search input
 
     Returns
@@ -876,7 +883,7 @@ def results(ns, query, query_type, dropdown_option, results):
         validation = 1
 
     table = populate_result_table(data, columns)
-    return construct_results_layout(table), validation
+    return construct_results_layout(table, is_mobile), validation
 
 
 noresults_toast = html.Div(

--- a/index.py
+++ b/index.py
@@ -216,12 +216,17 @@ def print_msg_info():
     ])
     return h
 
-def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist):
+def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, is_mobile):
     dic_band = {1: 'g', 2: 'r'}
     l1 = "Last emission date: "
     l2 = "Last magnitude (band {}): ".format(dic_band[fid])
     l3 = "Days since first detection: "
     l4 = "Total number of detections: "
+
+    if is_mobile:
+        fontsize = '75%'
+    else:
+        fontsize = '100%'
     simple_card_ = dbc.Card(
         [
             dbc.CardHeader(
@@ -236,25 +241,25 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist):
                     html.H4("{}".format(finkclass), className="card-title"),
                     html.P(
                         [
-                            html.Strong(l1, style={'font-size': '75%'}),
+                            html.Strong(l1, style={'font-size': fontsize}),
                             html.P(lastdate)
                         ]
                     ),
                     html.P(
                         [
-                            html.Strong(l2, style={'font-size': '75%'}),
+                            html.Strong(l2, style={'font-size': fontsize}),
                             html.P("{:.2f}".format(mag))
                         ]
                     ),
                     html.P(
                         [
-                            html.Strong(l3, style={'font-size': '75%'}),
+                            html.Strong(l3, style={'font-size': fontsize}),
                             html.P('{}'.format(int(jd - jdstarthist)))
                         ]
                     ),
                     html.P(
                         [
-                            html.Strong(l4, style={'font-size': '75%'}),
+                            html.Strong(l4, style={'font-size': fontsize}),
                             html.P('{}'.format(ndethist))
                         ]
                     ),
@@ -269,10 +274,11 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist):
     Output('carousel', 'children'),
     [
         Input("open_modal_quickview", "n_clicks"),
-        Input("result_table", "data")
+        Input("result_table", "data"),
+        Input('is-mobile', 'children')
     ],
 )
-def carousel(nclick, data):
+def carousel(nclick, data, is_mobile):
     """
     """
     if nclick > 0:
@@ -285,9 +291,10 @@ def carousel(nclick, data):
         jds = pdf['i:jd'].values[0:10]
         jdstarthists = pdf['i:jdstarthist'].values[0:10]
         ndethists = pdf['i:ndethist'].values[0:10]
+        is_mobiles = [is_mobile] * 10
         carousel = dtc.Carousel(
             [
-                html.Div(dbc.Container(simple_card(*args))) for args in zip(names, finkclasses, lastdates, fids, mags, jds, jdstarthists, ndethists)
+                html.Div(dbc.Container(simple_card(*args))) for args in zip(names, finkclasses, lastdates, fids, mags, jds, jdstarthists, ndethists, is_mobiles)
             ],
             slides_to_scroll=1,
             slides_to_show=1,

--- a/index.py
+++ b/index.py
@@ -218,10 +218,12 @@ def print_msg_info():
 
 def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist):
     msg = """
+    ```python
     Last emission date: {}
     Apparent magnitude (band {}): {}
     Time since first detection: {} days
     Total number of detections: {}
+    ```
     """.format(lastdate, fid, mag, jd - jdstarthist, ndethist)
     simple_card_ = dbc.Card(
         [

--- a/index.py
+++ b/index.py
@@ -784,7 +784,7 @@ def update_table(field_dropdown, data, columns):
     ],
     State("results", "children")
 )
-def results(ns, query, query_type, dropdown_option, results, is_mobile):
+def results(ns, query, query_type, dropdown_option, is_mobile, results):
     """ Query the database from the search input
 
     Returns

--- a/index.py
+++ b/index.py
@@ -324,12 +324,15 @@ modal_quickview = html.Div(
                         id='carousel',
                         fluid=True,
                         style={'width': '95%'}
-                    ), style={'background-image': 'linear-gradient(rgba(0,0,0,0.3), rgba(255,255,255,0.3)), url(/assets/background.png)'}
+                    ), style={
+                        'background': '#000',
+                        'background-image': 'linear-gradient(rgba(0,0,0,0.3), rgba(255,255,255,0.3)), url(/assets/background.png)'
+                    }
                 ),
                 dbc.ModalFooter(
                     dbc.Button(
                         "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0
-                    )
+                    ), style={'display': 'None'}
                 ),
             ],
             id="modal_quickview",

--- a/index.py
+++ b/index.py
@@ -289,7 +289,7 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, 
                     dbc.Col(draw_cutouts_quickview(name), width=3),
                     dbc.Col([l1, l2], width=4),
                     dbc.Col([l3, l4], width=4)
-                ]
+                ],
                 id='stamps_quickview',
                 justify='around'
             )

--- a/index.py
+++ b/index.py
@@ -761,7 +761,7 @@ def update_table(field_dropdown, data, columns):
         Input("search_bar_input", "value"),
         Input("dropdown-query", "label"),
         Input("select", "value"),
-        Input("is-mobile", "value"),
+        Input("is-mobile", "children"),
     ],
     State("results", "children")
 )

--- a/index.py
+++ b/index.py
@@ -265,7 +265,14 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, 
                     ),
                 ]
             ),
-            dbc.CardFooter(dbc.Button("Go to {}".format(name), color="primary", outline=True))
+            dbc.CardFooter(
+                dbc.Button(
+                    "Go to {}".format(name),
+                    color="primary",
+                    outline=True,
+                    href='{}/{}'.format(APIURL, name)
+                )
+            )
         ], style={'background-image': 'linear-gradient(rgba(255,255,255,0.3), rgba(255,255,255,0.3)), url(/assets/background.png)'}
     )
     return simple_card_

--- a/index.py
+++ b/index.py
@@ -20,6 +20,7 @@ import dash_bootstrap_components as dbc
 import dash_table
 from dash.exceptions import PreventUpdate
 import visdcc
+import dash_trich_components as dtc
 
 from app import server
 from app import app

--- a/index.py
+++ b/index.py
@@ -408,8 +408,8 @@ def display_table_results(table, is_mobile):
     )
 
     if is_mobile:
-        width_dropdown = 9
-        width_preview = 3
+        width_dropdown = 8
+        width_preview = 4
     else:
         width_dropdown = 10
         width_preview = 2

--- a/index.py
+++ b/index.py
@@ -284,11 +284,11 @@ modal_quickview = html.Div(
             [
                 dbc.ModalHeader("10 first alerts"),
                 dbc.ModalBody([dbc.Container(id='carousel'), html.Br()]),
-                # dbc.ModalFooter(
-                #     dbc.Button(
-                #         "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0
-                #     )
-                # ),
+                dbc.ModalFooter(
+                    dbc.Button(
+                        "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0
+                    )
+                ),
             ],
             id="modal_quickview",
             is_open=False,
@@ -300,12 +300,13 @@ modal_quickview = html.Div(
 @app.callback(
     Output("modal_quickview", "is_open"),
     [
-        Input("open_modal_quickview", "n_clicks")
+        Input("open_modal_quickview", "n_clicks"),
+        Input("close_modal_quickview", "n_clicks")
     ],
     [State("modal_quickview", "is_open")],
 )
-def toggle_modal(n1, is_open):
-    if n1:
+def toggle_modal(n1, n2, is_open):
+    if n1 or n2:
         return not is_open
     return is_open
 

--- a/index.py
+++ b/index.py
@@ -274,9 +274,7 @@ modal_quickview = html.Div(
         ),
         dbc.Modal(
             [
-                dbc.ModalHeader("Header"),
                 dbc.ModalBody(html.Div(id='carousel')),
-                dbc.ModalBody("hello"),
                 dbc.ModalFooter(
                     dbc.Button(
                         "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0

--- a/index.py
+++ b/index.py
@@ -286,9 +286,9 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, 
         header = dbc.CardHeader(
             dbc.Row(
                 [
-                    dbc.Col(draw_cutouts_quickview(name), width=3),
-                    dbc.Col([l1, l2], width=4),
-                    dbc.Col([l3, l4], width=4)
+                    dbc.Col(draw_cutouts_quickview(name), width=2),
+                    dbc.Col([l1, l2], width=5),
+                    dbc.Col([l3, l4], width=5)
                 ],
                 id='stamps_quickview',
                 justify='around'

--- a/index.py
+++ b/index.py
@@ -284,11 +284,11 @@ modal_quickview = html.Div(
             [
                 dbc.ModalHeader("10 first alerts"),
                 dbc.ModalBody(html.Div(id='carousel')),
-                dbc.ModalFooter(
-                    dbc.Button(
-                        "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0
-                    )
-                ),
+                # dbc.ModalFooter(
+                #     dbc.Button(
+                #         "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0
+                #     )
+                # ),
             ],
             id="modal_quickview",
             is_open=False,
@@ -297,18 +297,18 @@ modal_quickview = html.Div(
     ]
 )
 
-@app.callback(
-    Output("modal_quickview", "is_open"),
-    [
-        Input("open_modal_quickview", "n_clicks"),
-        Input("close_modal_quickview", "n_clicks")
-    ],
-    [State("modal_quickview", "is_open")],
-)
-def toggle_modal(n1, n2, is_open):
-    if n1 or n2:
-        return not is_open
-    return is_open
+# @app.callback(
+#     Output("modal_quickview", "is_open"),
+#     [
+#         Input("open_modal_quickview", "n_clicks"),
+#         Input("close_modal_quickview", "n_clicks")
+#     ],
+#     [State("modal_quickview", "is_open")],
+# )
+# def toggle_modal(n1, n2, is_open):
+#     if n1 or n2:
+#         return not is_open
+#     return is_open
 
 def display_table_results(table):
     """ Display explorer results in the form of a table with a dropdown

--- a/index.py
+++ b/index.py
@@ -262,7 +262,7 @@ def carousel(nclick, data):
             slides_to_show=1,
             swipe_to_slide=True,
             autoplay=False,
-            speed=100,
+            speed=1000,
             variable_width=False,
             center_mode=False
         )

--- a/index.py
+++ b/index.py
@@ -216,7 +216,13 @@ def print_msg_info():
     ])
     return h
 
-def simple_card(name):
+def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist):
+    msg = """
+    Last emission date: {}
+    Apparent magnitude (band {}): {}
+    Time since first detection: {} days
+    Total number of detections: {}
+    """.format(lastdate, fid, mag, jd - jdstarthist, ndethist)
     simple_card_ = dbc.Card(
         [
             dbc.CardHeader(
@@ -228,15 +234,11 @@ def simple_card(name):
             ),
             dbc.CardBody(
                 [
-                    html.H4("{}".format(name), className="card-title"),
-                    html.P(
-                        "Some quick example text to build on the card title and "
-                        "make up the bulk of the card's content.",
-                        className="card-text",
-                    ),
+                    html.H4("{}".format(finkclass), className="card-title"),
+                    dcc.Markdown(msg),
                 ]
             ),
-            dbc.CardFooter(dbc.Button("Go somewhere", color="primary"))
+            dbc.CardFooter(dbc.Button("Go to {}".format(name), color="primary", outline=True))
         ],
     )
     return simple_card_
@@ -254,9 +256,16 @@ def carousel(nclick, data):
     if nclick > 0:
         pdf = pd.DataFrame(data)
         names = pdf['i:objectId'].apply(lambda x: x.split('[')[1].split(']')[0]).values[0:10]
+        finkclasses = pdf['v:classification'].values[0:10]
+        lastdates = pdf['v:lastdate'].values[0:10]
+        fids = pdf['i:fid'].values[0:10]
+        mags = pdf['i:magpsf'].values[0:10]
+        jds = pdf['i:jd'].values[0:10]
+        jdstarthists = pdf['i:jdstarthist'].values[0:10]
+        ndethists = pdf['i:ndethist'].values[0:10]
         carousel = dtc.Carousel(
             [
-                html.Div(dbc.Container(simple_card(name))) for name in names
+                html.Div(dbc.Container(simple_card(*args))) for args in zip(names, finkclasses, lastdates, fids, mags, jds, jdstarthists, ndethists)
             ],
             slides_to_scroll=1,
             slides_to_show=1,
@@ -273,7 +282,7 @@ def carousel(nclick, data):
 modal_quickview = html.Div(
     [
         dbc.Button(
-            "Open modal",
+            "Preview",
             id="open_modal_quickview",
             n_clicks=0,
             outline=True,

--- a/index.py
+++ b/index.py
@@ -761,7 +761,7 @@ def update_table(field_dropdown, data, columns):
         Input("search_bar_input", "value"),
         Input("dropdown-query", "label"),
         Input("select", "value"),
-        Input("is_mobile", "value"),
+        Input("is-mobile", "value"),
     ],
     State("results", "children")
 )

--- a/index.py
+++ b/index.py
@@ -696,14 +696,18 @@ def construct_results_layout(table, is_mobile):
     ]
     return results_
 
-def populate_result_table(data, columns):
+def populate_result_table(data, columns, is_mobile):
     """ Define options of the results table, and add data and columns
     """
+    if is_mobile:
+        page_size = 5
+    else:
+        page_size = 10
     table = dash_table.DataTable(
         data=data,
         columns=columns,
         id='result_table',
-        page_size=10,
+        page_size=page_size,
         style_as_list_view=True,
         sort_action="native",
         filter_action="native",
@@ -897,7 +901,7 @@ def results(ns, query, query_type, dropdown_option, results, is_mobile):
         ]
         validation = 1
 
-    table = populate_result_table(data, columns)
+    table = populate_result_table(data, columns, is_mobile)
     return construct_results_layout(table, is_mobile), validation
 
 

--- a/index.py
+++ b/index.py
@@ -252,7 +252,7 @@ def carousel(nclick, data):
     """
     if nclick > 0:
         pdf = pd.DataFrame(data)
-        names = pdf['i:objectId'][0:10]
+        names = pdf['i:objectId'].apply(lambda x: x.split('[')[1].split(']')[0]).values[0:10]
         carousel = dtc.Carousel(
             [
                 html.Div(dbc.Container(simple_card(name))) for name in names

--- a/index.py
+++ b/index.py
@@ -392,38 +392,49 @@ def display_table_results(table, is_mobile):
     ztf_fields = [i for i in schema_list if i.startswith('i:')]
     fink_additional_fields = ['v:g-r', 'v:rate(g-r)', 'v:classification', 'v:lastdate']
 
+    dropdown = dcc.Dropdown(
+        id='field-dropdown2',
+        options=[
+            {'label': 'Fink science module outputs', 'disabled': True, 'value': 'None'},
+            *[{'label': field, 'value': field} for field in fink_fields],
+            {'label': 'Fink additional values', 'disabled': True, 'value': 'None'},
+            *[{'label': field, 'value': field} for field in fink_additional_fields],
+            {'label': 'Original ZTF fields (subset)', 'disabled': True, 'value': 'None'},
+            *[{'label': field, 'value': field} for field in ztf_fields]
+        ],
+        searchable=True,
+        clearable=True,
+        placeholder="Add more fields to the table",
+    )
+
     if is_mobile:
-        width_dropdown = 6
-        width_preview = 6
+        return dbc.Container([
+            html.Br(),
+            dbc.Row(
+                [
+                    dbc.Col(dropdown)
+                ]
+            ),
+            dbc.Row(
+                [
+                    dbc.Col(modal_quickview)
+                ]
+            ),
+            html.Br(),
+            table
+        ], fluid=True)
     else:
-        width_dropdown = 10
-        width_preview = 2
-    return dbc.Container([
-        html.Br(),
-        dbc.Row(
-            [
-                dbc.Col(
-                    dcc.Dropdown(
-                        id='field-dropdown2',
-                        options=[
-                            {'label': 'Fink science module outputs', 'disabled': True, 'value': 'None'},
-                            *[{'label': field, 'value': field} for field in fink_fields],
-                            {'label': 'Fink additional values', 'disabled': True, 'value': 'None'},
-                            *[{'label': field, 'value': field} for field in fink_additional_fields],
-                            {'label': 'Original ZTF fields (subset)', 'disabled': True, 'value': 'None'},
-                            *[{'label': field, 'value': field} for field in ztf_fields]
-                        ],
-                        searchable=True,
-                        clearable=True,
-                        placeholder="Add more fields to the table",
-                    ), width=width_dropdown
-                ),
-                dbc.Col(modal_quickview, width=width_preview)
-            ]
-        ),
-        html.Br(),
-        table
-    ], fluid=True)
+        return dbc.Container([
+            html.Br(),
+            dbc.Row(
+                [
+                    dbc.Col(dropdown, width=10),
+                    dbc.Col(modal_quickview, width=2)
+                ]
+            ),
+            html.Br(),
+            table
+        ], fluid=True)
 
 @app.callback(
     Output('aladin-lite-div-skymap', 'run'),

--- a/index.py
+++ b/index.py
@@ -30,7 +30,7 @@ from apps import home, summary, about, api
 from apps import __version__ as portal_version
 
 from apps.utils import markdownify_objectid
-from apps.api import APIURL
+from app import APIURL
 from apps.utils import isoify_time, validate_query
 
 import requests

--- a/index.py
+++ b/index.py
@@ -222,41 +222,50 @@ def print_msg_info():
 
 def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, is_mobile):
     dic_band = {1: 'g', 2: 'r'}
-    l1 = "Last emission date: "
-    l2 = "Last magnitude (band {}): ".format(dic_band[fid])
-    l3 = "Days since first detection: "
-    l4 = "Total number of detections: "
+    l1 = html.P(
+        [
+            html.Strong("Last emission date: ", style={'font-size': fontsize}),
+            html.P(lastdate)
+        ]
+    )
+    l2 = html.P(
+        [
+            html.Strong("Last magnitude (band {}): ".format(dic_band[fid]), style={'font-size': fontsize}),
+            html.P("{:.2f}".format(mag))
+        ]
+    )
+
+    l3 = html.P(
+        [
+            html.Strong("Days since first detection: ", style={'font-size': fontsize}),
+            html.P('{}'.format(int(jd - jdstarthist)))
+        ]
+    )
+
+    l4 = html.P(
+        [
+            html.Strong("Total number of detections: ", style={'font-size': fontsize}),
+            html.P('{}'.format(ndethist))
+        ]
+    )
 
     if is_mobile:
         fontsize = '75%'
         cardbody = dbc.CardBody(
             [
                 html.H4("{}".format(finkclass), className="card-title"),
-                html.P(
-                    [
-                        html.Strong(l1, style={'font-size': fontsize}),
-                        html.P(lastdate)
-                    ]
-                ),
-                html.P(
-                    [
-                        html.Strong(l2, style={'font-size': fontsize}),
-                        html.P("{:.2f}".format(mag))
-                    ]
-                ),
-                html.P(
-                    [
-                        html.Strong(l3, style={'font-size': fontsize}),
-                        html.P('{}'.format(int(jd - jdstarthist)))
-                    ]
-                ),
-                html.P(
-                    [
-                        html.Strong(l4, style={'font-size': fontsize}),
-                        html.P('{}'.format(ndethist))
-                    ]
-                ),
+                l1,
+                l2,
+                l3,
+                l4
             ]
+        )
+        header = dbc.CardHeader(
+            dbc.Row(
+                draw_cutouts_quickview(name),
+                id='stamps_quickview',
+                justify='around'
+            )
         )
     else:
         fontsize = '100%'
@@ -274,15 +283,22 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, 
             ]
         )
 
+        header = dbc.CardHeader(
+            dbc.Row(
+                [
+                    dbc.Col(draw_cutouts_quickview(name), width=3),
+                    dbc.Col([l1, l2], width=4),
+                    dbc.Col([l3, l4], width=4)
+                ]
+                id='stamps_quickview',
+                justify='around'
+            )
+        )
+
+
     simple_card_ = dbc.Card(
         [
-            dbc.CardHeader(
-                dbc.Row(
-                    draw_cutouts_quickview(name),
-                    id='stamps_quickview',
-                    justify='around'
-                )
-            ),
+            header,
             cardbody,
             dbc.CardFooter(
                 dbc.Button(

--- a/index.py
+++ b/index.py
@@ -281,6 +281,7 @@ modal_quickview = html.Div(
         ),
         dbc.Modal(
             [
+                dbc.ModalHeader("10 first alerts"),
                 dbc.ModalBody(html.Div(id='carousel')),
                 dbc.ModalFooter(
                     dbc.Button(

--- a/index.py
+++ b/index.py
@@ -32,7 +32,7 @@ from apps import __version__ as portal_version
 from apps.utils import markdownify_objectid
 from app import APIURL
 from apps.utils import isoify_time, validate_query
-from apps.plotting import draw_cutouts_quickview
+from apps.plotting import draw_cutouts_quickview, draw_lightcurve_preview
 
 import requests
 import pandas as pd
@@ -229,8 +229,44 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, 
 
     if is_mobile:
         fontsize = '75%'
+        cardbody = dbc.CardBody(
+            [
+                html.H4("{}".format(finkclass), className="card-title"),
+                html.P(
+                    [
+                        html.Strong(l1, style={'font-size': fontsize}),
+                        html.P(lastdate)
+                    ]
+                ),
+                html.P(
+                    [
+                        html.Strong(l2, style={'font-size': fontsize}),
+                        html.P("{:.2f}".format(mag))
+                    ]
+                ),
+                html.P(
+                    [
+                        html.Strong(l3, style={'font-size': fontsize}),
+                        html.P('{}'.format(int(jd - jdstarthist)))
+                    ]
+                ),
+                html.P(
+                    [
+                        html.Strong(l4, style={'font-size': fontsize}),
+                        html.P('{}'.format(ndethist))
+                    ]
+                ),
+            ]
+        )
     else:
         fontsize = '100%'
+        cardbody = dbc.CardBody(
+            [
+                html.H4("{}".format(finkclass), className="card-title"),
+                dcc.Graph(draw_lightcurve_preview(name))
+            ]
+        )
+
     simple_card_ = dbc.Card(
         [
             dbc.CardHeader(
@@ -240,35 +276,7 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, 
                     justify='around'
                 )
             ),
-            dbc.CardBody(
-                [
-                    html.H4("{}".format(finkclass), className="card-title"),
-                    html.P(
-                        [
-                            html.Strong(l1, style={'font-size': fontsize}),
-                            html.P(lastdate)
-                        ]
-                    ),
-                    html.P(
-                        [
-                            html.Strong(l2, style={'font-size': fontsize}),
-                            html.P("{:.2f}".format(mag))
-                        ]
-                    ),
-                    html.P(
-                        [
-                            html.Strong(l3, style={'font-size': fontsize}),
-                            html.P('{}'.format(int(jd - jdstarthist)))
-                        ]
-                    ),
-                    html.P(
-                        [
-                            html.Strong(l4, style={'font-size': fontsize}),
-                            html.P('{}'.format(ndethist))
-                        ]
-                    ),
-                ]
-            ),
+            cardbody,
             dbc.CardFooter(
                 dbc.Button(
                     "Go to {}".format(name),

--- a/index.py
+++ b/index.py
@@ -264,7 +264,8 @@ def carousel(nclick, data):
             autoplay=False,
             speed=800,
             variable_width=False,
-            center_mode=False
+            center_mode=False,
+            dots=True
         )
     else:
         carousel = html.Div("")

--- a/index.py
+++ b/index.py
@@ -220,7 +220,14 @@ def print_msg_info():
     ])
     return h
 
-def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, is_mobile):
+def simple_card(
+        name, finkclass, lastdate, fid,
+        mag, jd, jdstarthist, ndethist, is_mobile):
+    """ Preview card
+
+    The laptop version shows Science cutout + metadata + lightcurve
+    The mobile version shows Science cutout + metadata
+    """
     dic_band = {1: 'g', 2: 'r'}
     fontsize = '75%'
 
@@ -321,7 +328,7 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, 
     ],
 )
 def carousel(nclick, data, is_mobile):
-    """
+    """ Carousel that shows alert preview
     """
     if nclick > 0:
         pdf = pd.DataFrame(data)
@@ -349,6 +356,7 @@ def carousel(nclick, data, is_mobile):
     else:
         carousel = html.Div("")
     return carousel
+
 
 modal_quickview = html.Div(
     [
@@ -392,7 +400,7 @@ modal_quickview = html.Div(
     ],
     [State("modal_quickview", "is_open")],
 )
-def toggle_modal(n1, n2, is_open):
+def toggle_modal_preview(n1, n2, is_open):
     if n1 or n2:
         return not is_open
     return is_open

--- a/index.py
+++ b/index.py
@@ -297,18 +297,17 @@ modal_quickview = html.Div(
     ]
 )
 
-# @app.callback(
-#     Output("modal_quickview", "is_open"),
-#     [
-#         Input("open_modal_quickview", "n_clicks"),
-#         Input("close_modal_quickview", "n_clicks")
-#     ],
-#     [State("modal_quickview", "is_open")],
-# )
-# def toggle_modal(n1, n2, is_open):
-#     if n1 or n2:
-#         return not is_open
-#     return is_open
+@app.callback(
+    Output("modal_quickview", "is_open"),
+    [
+        Input("open_modal_quickview", "n_clicks")
+    ],
+    [State("modal_quickview", "is_open")],
+)
+def toggle_modal(n1, is_open):
+    if n1:
+        return not is_open
+    return is_open
 
 def display_table_results(table):
     """ Display explorer results in the form of a table with a dropdown

--- a/index.py
+++ b/index.py
@@ -283,7 +283,7 @@ modal_quickview = html.Div(
         dbc.Modal(
             [
                 dbc.ModalHeader("10 first alerts"),
-                dbc.ModalBody([dbc.Container(id='carousel'), html.Br()]),
+                dbc.ModalBody([dbc.Container(id='carousel'), html.Br()], fluid=True, style={'width': '95%'}),
                 dbc.ModalFooter(
                     dbc.Button(
                         "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0

--- a/index.py
+++ b/index.py
@@ -32,6 +32,7 @@ from apps import __version__ as portal_version
 from apps.utils import markdownify_objectid
 from app import APIURL
 from apps.utils import isoify_time, validate_query
+from apps.plotting import draw_cutouts_quickview
 
 import requests
 import pandas as pd

--- a/index.py
+++ b/index.py
@@ -412,7 +412,7 @@ def display_table_results(table, is_mobile):
             html.Br(),
             dbc.Row(
                 [
-                    dbc.Col(dropdown)
+                    dbc.Col(dropdown, width=12)
                 ]
             ),
             dbc.Row(

--- a/index.py
+++ b/index.py
@@ -283,7 +283,7 @@ modal_quickview = html.Div(
         dbc.Modal(
             [
                 dbc.ModalHeader("10 first alerts"),
-                dbc.ModalBody(html.Div(id='carousel')),
+                dbc.ModalBody(dbc.Container(id='carousel')),
                 # dbc.ModalFooter(
                 #     dbc.Button(
                 #         "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0

--- a/index.py
+++ b/index.py
@@ -249,7 +249,7 @@ def carousel(nclick, data):
         names = pdf['i:objectId']
         carousel = dtc.Carousel(
             [
-                html.Div(dbc.Container(simple_card(name))) for i in names
+                html.Div(dbc.Container(simple_card(name))) for name in names
             ],
             slides_to_scroll=1,
             slides_to_show=1,

--- a/index.py
+++ b/index.py
@@ -222,11 +222,7 @@ def print_msg_info():
 
 def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, is_mobile):
     dic_band = {1: 'g', 2: 'r'}
-
-    if is_mobile:
-        fontsize = '75%'
-    else:
-        fontsize = '100%'
+    fontsize = '75%'
 
     l1 = html.P(
         [

--- a/index.py
+++ b/index.py
@@ -263,7 +263,14 @@ def simple_card(name, finkclass, lastdate, fid, mag, jd, jdstarthist, ndethist, 
         cardbody = dbc.CardBody(
             [
                 html.H4("{}".format(finkclass), className="card-title"),
-                dcc.Graph(figure=draw_lightcurve_preview(name))
+                dcc.Graph(
+                    figure=draw_lightcurve_preview(name),
+                    config={'displayModeBar': False},
+                    style={
+                        'width': '100%',
+                        'height': '15pc'
+                    }
+                )
             ]
         )
 
@@ -356,7 +363,7 @@ modal_quickview = html.Div(
             ],
             id="modal_quickview",
             is_open=False,
-            #size="lg",
+            size="lg",
         ),
     ]
 )

--- a/index.py
+++ b/index.py
@@ -218,7 +218,13 @@ def print_msg_info():
 def simple_card(name):
     simple_card_ = dbc.Card(
         [
-            dbc.CardHeader(dbc.Row(id='stamps_quickview', justify='around')),
+            dbc.CardHeader(
+                dbc.Row(
+                    draw_cutouts_quickview(name),
+                    id='stamps_quickview',
+                    justify='around'
+                )
+            ),
             dbc.CardBody(
                 [
                     html.H4("{}".format(name), className="card-title"),

--- a/index.py
+++ b/index.py
@@ -264,8 +264,7 @@ def carousel(nclick, data):
             autoplay=False,
             speed=800,
             variable_width=False,
-            center_mode=False,
-            dots=True
+            center_mode=False
         )
     else:
         carousel = html.Div("")
@@ -283,7 +282,7 @@ modal_quickview = html.Div(
         dbc.Modal(
             [
                 dbc.ModalHeader("10 first alerts"),
-                dbc.ModalBody([dbc.Container(id='carousel', fluid=True, style={'width': '95%'}), html.Br()]),
+                dbc.ModalBody(dbc.Container(id='carousel', fluid=True, style={'width': '95%'})),
                 dbc.ModalFooter(
                     dbc.Button(
                         "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0

--- a/index.py
+++ b/index.py
@@ -283,7 +283,7 @@ modal_quickview = html.Div(
         dbc.Modal(
             [
                 dbc.ModalHeader("10 first alerts"),
-                dbc.ModalBody([dbc.Container(id='carousel'), html.Br()], fluid=True, style={'width': '95%'}),
+                dbc.ModalBody([dbc.Container(id='carousel', fluid=True, style={'width': '95%'}), html.Br()]),
                 dbc.ModalFooter(
                     dbc.Button(
                         "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0


### PR DESCRIPTION
The idea is to preview alerts when querying the database.

## Laptop

<img width="1440" alt="Screenshot 2021-07-15 at 10 23 09" src="https://user-images.githubusercontent.com/20426972/125757027-c9dcb881-36eb-43f9-ab57-e9ed81ab37e5.png">

<img width="1440" alt="Screenshot 2021-07-15 at 10 23 40" src="https://user-images.githubusercontent.com/20426972/125757040-c6473550-4a8e-45b9-97b3-29be956db4ef.png">

## Mobile

<img width="377" alt="Screenshot 2021-07-15 at 10 24 12" src="https://user-images.githubusercontent.com/20426972/125757063-dcfc429d-b650-40d4-b24e-ddf17b5d6953.png">

<img width="377" alt="Screenshot 2021-07-15 at 10 24 26" src="https://user-images.githubusercontent.com/20426972/125757076-55c215d0-60a9-429d-84fa-adf30e390b90.png">

## Caveats & limitations

There are some caveats:

- This is limited to the first 10 alerts because we have to download the data a posteriori (it is not loaded as you scroll).
- We show only the Science cutout (for the same data download reasons)
- The lightcurve is not shown in the mobile version because the display is not great (too squeezed).