### PR TITLE
Add a new modal to display alert properties

### DIFF
--- a/apps/cards.py
+++ b/apps/cards.py
@@ -927,7 +927,7 @@ def download_object_modal(objectid):
     )
     modal = [
         dbc.Button(
-            "Download",
+            "Download data",
             id="open-object",
             color='dark', outline=True,
             block=True
@@ -966,7 +966,7 @@ def inspect_object_modal(objectid):
     """.format(objectid, objectid, APIURL)
     modal = [
         dbc.Button(
-            "Inspect",
+            "Inspect data",
             id="open-object-prop",
             color='dark', outline=True,
             block=True

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -942,10 +942,9 @@ def inspect_object_modal(objectid):
     message = """
     Here are the fields contained in the {} alert. Note you can filter the
     table results using the first row (enter text and hit enter).
-    Legend:
     - Fields starting with `i:` are original fields from ZTF.
     - Fields starting with `d:` are live added values by Fink.
-    - Fields starting with `v:` are a posteriori added values by Fink.
+    - Fields starting with `v:` are added values by Fink (post-processing).
     """.format(objectid)
     modal = [
         dbc.Button(

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -879,6 +879,7 @@ def toggle_modal_sso(n1, n2, is_open):
 
 def download_object_modal(objectid):
     message_download = """
+    ### {}
     In a terminal, simply paste (CSV):
 
     ```bash
@@ -908,7 +909,7 @@ def download_object_modal(objectid):
     ```
 
     See http://134.158.75.151:24000/api for more options.
-    """.format(objectid, str(objectid).replace('/', '_'), objectid)
+    """.format(objectid, objectid, str(objectid).replace('/', '_'), objectid)
     modal = [
         dbc.Button(
             "Download",
@@ -918,11 +919,10 @@ def download_object_modal(objectid):
         ),
         dbc.Modal(
             [
-                dbc.ModalHeader("Download {} data".format(objectid)),
                 dbc.ModalBody(
                     dcc.Markdown(message_download),
                     style={
-                        'background-image': 'linear-gradient(rgba(0,0,0,0.6), rgba(255,255,255,0.8)), url(/assets/background.png)'
+                        'background-image': 'linear-gradient(rgba(255,255,255,0.2), rgba(255,255,255,0.4)), url(/assets/background.png)'
                     }
                 ),
                 dbc.ModalFooter(
@@ -940,12 +940,13 @@ def download_object_modal(objectid):
 
 def inspect_object_modal(objectid):
     message = """
+    ### {}
     Here are the fields contained in the {} alert. Note you can filter the
     table results using the first row (enter text and hit enter).
     - Fields starting with `i:` are original fields from ZTF.
     - Fields starting with `d:` are live added values by Fink.
     - Fields starting with `v:` are added values by Fink (post-processing).
-    """.format(objectid)
+    """.format(objectid, objectid)
     modal = [
         dbc.Button(
             "Inspect",
@@ -960,7 +961,7 @@ def inspect_object_modal(objectid):
                         dcc.Markdown(message),
                         html.Div([], id='alert_table')
                     ], style={
-                        'background-image': 'linear-gradient(rgba(0,0,0,0.4), rgba(255,255,255,0.6)), url(/assets/background.png)'
+                        'background-image': 'linear-gradient(rgba(255,255,255,0.4), rgba(255,255,255,0.6)), url(/assets/background.png)'
                     }
                 ),
                 dbc.ModalFooter(

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -945,12 +945,13 @@ def inspect_object_modal(objectid):
         ),
         dbc.Modal(
             [
-                dbc.ModalHeader("{} data".format(objectid)),
                 dbc.ModalBody(
                     [
                         dcc.Markdown(message),
                         html.Div([], id='alert_table')
-                    ]
+                    ], style={
+                        'background-image': 'linear-gradient(rgba(0,0,0,0.4), rgba(255,255,255,0.6)), url(/assets/background.png)'
+                    }
                 ),
                 dbc.ModalFooter(
                     dbc.Button("Close", id="close-object-prop", className="ml-auto")

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -19,7 +19,7 @@ from dash.dependencies import Input, Output, State
 import dash_table
 import visdcc
 
-from app import app
+from app import app, APIURL
 
 from apps.plotting import all_radio_options
 from apps.utils import queryMPC, convert_mpc_type
@@ -823,7 +823,7 @@ def download_sso_modal(ssnamenr):
     ```bash
     curl -H "Content-Type: application/json" -X POST \\
         -d '{{"n_or_d":"{}", "output-format":"csv"}}' \\
-        http://134.158.75.151:24000/api/v1/sso -o {}.csv
+        {}/api/v1/sso -o {}.csv
     ```
 
     Or in a python terminal, simply paste:
@@ -833,7 +833,7 @@ def download_sso_modal(ssnamenr):
     import pandas as pd
 
     r = requests.post(
-      'http://134.158.75.151:24000/api/v1/sso',
+      '{}/api/v1/sso',
       json={{
         'n_or_d': '{}',
         'output-format': 'json'
@@ -844,8 +844,15 @@ def download_sso_modal(ssnamenr):
     pdf = pd.read_json(r.content)
     ```
 
-    See http://134.158.75.151:24000/api for more options.
-    """.format(ssnamenr, str(ssnamenr).replace('/', '_'), ssnamenr)
+    See {}/api for more options.
+    """.format(
+        ssnamenr,
+        APIURL,
+        str(ssnamenr).replace('/', '_'),
+        APIURL,
+        ssnamenr,
+        APIURL
+    )
     modal = [
         dbc.Button(
             "Download {} data".format(ssnamenr),
@@ -885,7 +892,7 @@ def download_object_modal(objectid):
     ```bash
     curl -H "Content-Type: application/json" -X POST \\
         -d '{{"objectId":"{}", "output-format":"csv"}}' \\
-        http://134.158.75.151:24000/api/v1/objects \\
+        {}/api/v1/objects \\
         -o {}.csv
     ```
 
@@ -897,7 +904,7 @@ def download_object_modal(objectid):
 
     # get data for ZTF19acnjwgm
     r = requests.post(
-      'http://134.158.75.151:24000/api/v1/objects',
+      '{}/api/v1/objects',
       json={{
         'objectId': '{}',
         'output-format': 'json'
@@ -908,8 +915,16 @@ def download_object_modal(objectid):
     pdf = pd.read_json(r.content)
     ```
 
-    See http://134.158.75.151:24000/api for more options.
-    """.format(objectid, objectid, str(objectid).replace('/', '_'), objectid)
+    See {}/api for more options.
+    """.format(
+        objectid,
+        objectid,
+        APIURL,
+        str(objectid).replace('/', '_'),
+        APIURL,
+        objectid,
+        APIURL
+    )
     modal = [
         dbc.Button(
             "Download",
@@ -946,7 +961,9 @@ def inspect_object_modal(objectid):
     - Fields starting with `i:` are original fields from ZTF.
     - Fields starting with `d:` are live added values by Fink.
     - Fields starting with `v:` are added values by Fink (post-processing).
-    """.format(objectid, objectid)
+
+    See {}/api/v1/columns for more information.
+    """.format(objectid, objectid, APIURL)
     modal = [
         dbc.Button(
             "Inspect",

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -911,17 +911,26 @@ def download_object_modal(objectid):
     """.format(objectid, str(objectid).replace('/', '_'), objectid)
     modal = [
         dbc.Button(
-            "Download {} data".format(objectid),
+            "Download",
             id="open-object",
-            color='secondary',
+            color='dark', outline=True,
             size="lg", block=True
         ),
         dbc.Modal(
             [
                 dbc.ModalHeader("Download {} data".format(objectid)),
-                dbc.ModalBody(dcc.Markdown(message_download)),
+                dbc.ModalBody(
+                    dcc.Markdown(message_download),
+                    style={
+                        'background-image': 'linear-gradient(rgba(0,0,0,0.4), rgba(255,255,255,0.6)), url(/assets/background.png)'
+                    }
+                ),
                 dbc.ModalFooter(
-                    dbc.Button("Close", id="close-object", className="ml-auto")
+                    dbc.Button(
+                        "Close",
+                        color='dark', outline=True,
+                        id="close-object", className="ml-auto"
+                    )
                 ),
             ],
             id="modal-object", scrollable=True
@@ -940,7 +949,7 @@ def inspect_object_modal(objectid):
     """.format(objectid)
     modal = [
         dbc.Button(
-            "Inspect {} data".format(objectid),
+            "Inspect",
             id="open-object-prop",
             color='dark', outline=True,
             size="lg", block=True

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -929,12 +929,56 @@ def download_object_modal(objectid):
     ]
     return modal
 
+def inspect_object_modal(objectid):
+    message = """
+    Legend:
+    - Fields starting with `i:` are original fields from ZTF.
+    - Fields starting with `d:` are live added values by Fink.
+    - Fields starting with `v:` are a posteriori added values by Fink.
+    """
+    modal = [
+        dbc.Button(
+            "Inspect {} data".format(objectid),
+            id="open-object-prop",
+            color='secondary',
+            size="lg", block=True
+        ),
+        dbc.Modal(
+            [
+                dbc.ModalHeader("{} data".format(objectid)),
+                dbc.ModalBody(
+                    [
+                        dcc.Markdown(message),
+                        html.Div([], id='alert_table')
+                    ]
+                ),
+                dbc.ModalFooter(
+                    dbc.Button("Close", id="close-object-prop", className="ml-auto")
+                ),
+            ],
+            id="modal-object-prop", scrollable=True
+        ),
+    ]
+    return modal
+
 @app.callback(
     Output("modal-object", "is_open"),
     [Input("open-object", "n_clicks"), Input("close-object", "n_clicks")],
     [State("modal-object", "is_open")],
 )
 def toggle_modal_object(n1, n2, is_open):
+    """ Callback for the modal (open/close)
+    """
+    if n1 or n2:
+        return not is_open
+    return is_open
+
+@app.callback(
+    Output("modal-object-prop", "is_open"),
+    [Input("open-object-prop", "n_clicks"), Input("close-object-prop", "n_clicks")],
+    [State("modal-object-prop", "is_open")],
+)
+def toggle_modal_object_prop(n1, n2, is_open):
     """ Callback for the modal (open/close)
     """
     if n1 or n2:

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -956,7 +956,12 @@ def inspect_object_modal(objectid):
                     }
                 ),
                 dbc.ModalFooter(
-                    dbc.Button("Close", id="close-object-prop", className="ml-auto")
+                    dbc.Button(
+                        "Close",
+                        color='dark', outline=True,
+                        id="close-object-prop",
+                        className="ml-auto"
+                    )
                 ),
             ],
             id="modal-object-prop", scrollable=True

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -931,16 +931,18 @@ def download_object_modal(objectid):
 
 def inspect_object_modal(objectid):
     message = """
+    Here are the fields contained in the {} alert. Note you can filter the
+    table results using the first row (enter text and hit enter).
     Legend:
     - Fields starting with `i:` are original fields from ZTF.
     - Fields starting with `d:` are live added values by Fink.
     - Fields starting with `v:` are a posteriori added values by Fink.
-    """
+    """.format(objectid)
     modal = [
         dbc.Button(
             "Inspect {} data".format(objectid),
             id="open-object-prop",
-            color='secondary',
+            color='dark', outline=True,
             size="lg", block=True
         ),
         dbc.Modal(

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -914,7 +914,7 @@ def download_object_modal(objectid):
             "Download",
             id="open-object",
             color='dark', outline=True,
-            size="lg", block=True
+            block=True
         ),
         dbc.Modal(
             [
@@ -922,7 +922,7 @@ def download_object_modal(objectid):
                 dbc.ModalBody(
                     dcc.Markdown(message_download),
                     style={
-                        'background-image': 'linear-gradient(rgba(0,0,0,0.4), rgba(255,255,255,0.6)), url(/assets/background.png)'
+                        'background-image': 'linear-gradient(rgba(0,0,0,0.6), rgba(255,255,255,0.8)), url(/assets/background.png)'
                     }
                 ),
                 dbc.ModalFooter(
@@ -952,7 +952,7 @@ def inspect_object_modal(objectid):
             "Inspect",
             id="open-object-prop",
             color='dark', outline=True,
-            size="lg", block=True
+            block=True
         ),
         dbc.Modal(
             [

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1950,7 +1950,6 @@ def alert_properties(object_data):
         columns=columns,
         id='result_table_alert',
         style_as_list_view=True,
-        sort_action="native",
         filter_action="native",
         markdown_options={'link_target': '_blank'},
         fixed_columns={'headers': True, 'data': 1},

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1959,6 +1959,7 @@ def alert_properties(object_data):
         },
         style_table={'maxWidth': '100%'},
         style_cell={'padding': '5px', 'textAlign': 'left', 'overflow': 'hidden'},
+        style_filter={'backgroundColor': 'rgb(238, 238, 238, .7)'},
         style_data_conditional=[
             {
                 'if': {'row_index': 'odd'},

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -416,6 +416,8 @@ def layout(name, is_mobile):
             }
         )
     else:
+        button_inspect, modal_inspect = inspect_object_modal(pdf['i:objectId'].values[0])
+        button_download, modal_download = download_object_modal(pdf['i:objectId'].values[0])
         layout_ = html.Div(
             [
                 html.Br(),
@@ -437,10 +439,11 @@ def layout(name, is_mobile):
                                 html.Br(),
                                 dbc.ButtonGroup(
                                     [
-                                        *inspect_object_modal(pdf['i:objectId'].values[0]),
-                                        *download_object_modal(pdf['i:objectId'].values[0])
+                                        button_inspect, button_download
                                     ]
-                                )
+                                ),
+                                modal_inspect,
+                                modal_download
                             ], width={"size": 3},
                         ),
                         dbc.Col(tabs(pdf, is_mobile), width=8)

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -437,11 +437,11 @@ def layout(name, is_mobile):
                                     }
                                 ),
                                 html.Br(),
-                                html.Div(
+                                dbc.Row(
                                     [
-                                        button_inspect,
-                                        button_download
-                                    ]
+                                        dbc.Col(button_inspect, width=6),
+                                        dbc.Col(button_download, width=6)
+                                    ],
                                 ),
                                 modal_inspect,
                                 modal_download

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -437,9 +437,10 @@ def layout(name, is_mobile):
                                     }
                                 ),
                                 html.Br(),
-                                dbc.ButtonGroup(
+                                html.Div(
                                     [
-                                        button_inspect, button_download
+                                        button_inspect,
+                                        button_download
                                     ]
                                 ),
                                 modal_inspect,

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -28,7 +28,7 @@ from app import app, client, clientU, clientUV, clientSSO
 
 from apps.cards import card_cutouts, card_sn_scores
 from apps.cards import card_id, card_sn_properties
-from apps.cards import download_object_modal
+from apps.cards import download_object_modal, inspect_object_modal
 from apps.cards import card_variable_plot, card_variable_button
 from apps.cards import card_explanation_variable, card_explanation_mulens
 from apps.cards import card_mulens_plot, card_mulens_button, card_mulens_param
@@ -435,6 +435,7 @@ def layout(name, is_mobile):
                                     }
                                 ),
                                 html.Br(),
+                                *inspect_object_modal(pdf['i:objectId'].values[0]),
                                 *download_object_modal(pdf['i:objectId'].values[0])
                             ], width={"size": 3},
                         ),

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -435,8 +435,12 @@ def layout(name, is_mobile):
                                     }
                                 ),
                                 html.Br(),
-                                *inspect_object_modal(pdf['i:objectId'].values[0]),
-                                *download_object_modal(pdf['i:objectId'].values[0])
+                                dbc.ButtonGroup(
+                                    [
+                                        *inspect_object_modal(pdf['i:objectId'].values[0]),
+                                        *download_object_modal(pdf['i:objectId'].values[0])
+                                    ]
+                                )
                             ], width={"size": 3},
                         ),
                         dbc.Col(tabs(pdf, is_mobile), width=8)


### PR DESCRIPTION
This PR adds a new button to inspect alert properties, and re-organise the `download` button. The display is now:

### Main

<img width="823" alt="Screenshot 2021-07-19 at 14 59 02" src="https://user-images.githubusercontent.com/20426972/126163343-83a07279-5682-4a43-aaa3-19c6e1c577a1.png">

### Inspect modal

<img width="1440" alt="Screenshot 2021-07-19 at 14 59 15" src="https://user-images.githubusercontent.com/20426972/126163357-bd4a4eb6-1925-4ffe-b49c-1742af9342ae.png">

### Download modal

<img width="1440" alt="Screenshot 2021-07-19 at 14 59 24" src="https://user-images.githubusercontent.com/20426972/126163366-00448ea3-029d-4c7c-8f95-8a3fd908b82c.png">
