### PR TITLE
[WIP] Add support for tracklets

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -1798,7 +1798,11 @@ def return_tracklet():
         payload = 'TRCK{}'.format(designation)
     else:
         # date
-        jd_date = Time(request.json['date']).jd
+        date = request.json['date']
+        if date.isdigit():
+            jd_date = Time(float(date)).jd
+        else:
+            jd_date = Time(date).jd
         # conversion: NID=1682 is jd=2459436.5
         jd_ref = Time(2459436.5, format='jd')
 

--- a/apps/api.py
+++ b/apps/api.py
@@ -1786,7 +1786,10 @@ def return_tracklet():
         cols = '*'
         truncated = False
 
-    designation = request.json['id']
+    if 'id' in request.json:
+        designation = request.json['id']
+    else:
+        designation = ''
 
     if designation.startswith('TRCK'):
         payload = designation

--- a/apps/api.py
+++ b/apps/api.py
@@ -1799,14 +1799,17 @@ def return_tracklet():
     else:
         # date
         date = request.json['date']
-        if date.isdigit():
-            jd_date = Time(float(date)).jd
+        # ugly hack...
+        if date.isdigit() and date.startswith('24'):
+            jd_date = Time(float(date), format='jd').jd
+        elif date.isdigit():
+            jd_date = Time(float(date), format='mjd').jd
         else:
             jd_date = Time(date).jd
         # conversion: NID=1682 is jd=2459436.5
         jd_ref = Time(2459436.5, format='jd')
 
-        NID = 1682 + (jd_date - jd_ref)
+        NID = 1682 + int(jd_date - jd_ref)
         payload = 'TRCK{}'.format(NID)
 
     # Note the trailing _

--- a/apps/api.py
+++ b/apps/api.py
@@ -509,7 +509,7 @@ In python, you would use
 import requests
 import pandas as pd
 
-# get data for ZTF19acnjwgm
+# get data for object 4209
 r = requests.post(
   'http://134.158.75.151:24000/api/v1/sso',
   json={
@@ -557,6 +557,78 @@ r = requests.post(
 ```
 
 Note that the fields should be comma-separated. Unknown field names are ignored.
+"""
+
+api_doc_tracklets = """
+## Retrieve tracklet data
+
+The list of arguments for retrieving tracklet data can be found at http://134.158.75.151:24000/api/v1/tracklet.
+
+Each night there are a lot of fast moving objects seen in single exposures (or a few).
+These objects usually leave discrete tracks (several connected dots), that we call tracklets.
+The magnitude is rather low, and their magnitude can oscillate (e.g. rotating objects).
+This is somehow similar to solar system object, expect that these objects
+seem mainly man-made, they are fast moving, and they typically orbit around the Earth (this
+is also tighted to the detection method we use).
+
+In order to get tracklet data, you have the choice to specify:
+1. a tracklet ID if you know it
+2. a ZTF night ID
+3. a date at the format YYYYMMDD.
+
+Tracklet processing has been added on 2021/08/10, so there won't be data before this date.
+
+In a unix shell, you would simply use
+
+```bash
+# Get tracklet data for the night 20210810
+curl -H "Content-Type: application/json" -X POST -d '{"date":"20210810", "output-format":"csv"}' http://134.158.75.151:24000/api/v1/tracklet -o trck_20210810.csv
+```
+
+In python, you would use
+
+```python
+import requests
+import pandas as pd
+
+# Get all tracklet data for the night 20210810
+r = requests.post(
+  'http://134.158.75.151:24000/api/v1/tracklet',
+  json={
+    'date': '20210810',
+    'output-format': 'json'
+  }
+)
+
+# Format output in a DataFrame
+pdf = pd.read_json(r.content)
+```
+
+You can also specify a tracklet ID (in the format TRCK<NID>_<number>), or
+a ZTF NID (20210810 has a night ID of 1682 for example):
+
+```python
+import requests
+import pandas as pd
+
+# Get all tracklet data for the night ID 1682
+r = requests.post(
+  'http://134.158.75.151:24000/api/v1/tracklet',
+  json={
+    'id': '1682',
+    'output-format': 'json'
+  }
+)
+
+# Get tracklet data TRCK1682_00
+r = requests.post(
+  'http://134.158.75.151:24000/api/v1/tracklet',
+  json={
+    'id': 'TRCK1682_00',
+    'output-format': 'json'
+  }
+)
+```
 """
 
 api_doc_cutout = """
@@ -869,6 +941,17 @@ def layout(is_mobile):
                                         }
                                     ),
                                 ], label="Get Solar System Objects"
+                            ),
+                            dbc.Tab(
+                                [
+                                    dbc.Card(
+                                        dbc.CardBody(
+                                            dcc.Markdown(api_doc_tracklets)
+                                        ), style={
+                                            'backgroundColor': 'rgb(248, 248, 248, .7)'
+                                        }
+                                    ),
+                                ], label="Get Tracklet Objects"
                             ),
                             dbc.Tab(
                                 [

--- a/apps/api.py
+++ b/apps/api.py
@@ -1790,9 +1790,17 @@ def return_tracklet():
 
     if designation.startswith('TRCK'):
         payload = designation
-    else:
+    elif designation != '':
         # In this case, designation = NID
         payload = 'TRCK{}'.format(designation)
+    else:
+        # date
+        jd_date = Time(request.json['date']).jd
+        # conversion: NID=1682 is jd=2459436.5
+        jd_ref = Time(2459436.5, format='jd')
+
+        NID = 1682 + (jd_date - jd_ref)
+        payload = 'TRCK{}'.format(NID)
 
     # Note the trailing _
     to_evaluate = "key:key:{}_".format(payload)

--- a/apps/api.py
+++ b/apps/api.py
@@ -572,6 +572,7 @@ seem mainly man-made, they are fast moving, and they typically orbit around the 
 is also tighted to the detection method we use).
 
 In order to get tracklet data, you have the choice to specify:
+
 1. a tracklet ID if you know it
 2. a ZTF night ID
 3. a date at the format YYYY-MM-DD.

--- a/apps/api.py
+++ b/apps/api.py
@@ -1044,7 +1044,7 @@ args_tracklet = [
     {
         'name': 'date',
         'required': False,
-        'description': 'A date (astropy format). Not used if `id` is set.'
+        'description': 'A date (format YYYY-MM-DD). Not used if `id` is set.'
     },
     {
         'name': 'columns',
@@ -1798,14 +1798,7 @@ def return_tracklet():
         payload = 'TRCK{}'.format(designation)
     else:
         # date
-        date = request.json['date']
-        # ugly hack...
-        if date.isdigit() and date.startswith('24'):
-            jd_date = Time(float(date), format='jd').jd
-        elif date.isdigit():
-            jd_date = Time(float(date), format='mjd').jd
-        else:
-            jd_date = Time(date).jd
+        jd_date = Time(request.json['date'], format='iso').jd
         # conversion: NID=1682 is jd=2459436.5
         jd_ref = Time(2459436.5, format='jd')
 

--- a/apps/api.py
+++ b/apps/api.py
@@ -573,9 +573,9 @@ is also tighted to the detection method we use).
 
 In order to get tracklet data, you have the choice to specify:
 
-1. a tracklet ID if you know it
-2. a ZTF night ID
-3. a date at the format YYYY-MM-DD.
+1. a tracklet ID (format TRCK<night ID>_<XY>, with XY=00,01,02,... e.g. TRCK1682_01)
+2. a ZTF night ID (4 digits, e.g. 1682)
+3. a date at the format YYYY-MM-DD (e.g. 2021-08-10).
 
 Tracklet processing has been added on 2021-08-10, so there won't be data before this date.
 

--- a/apps/api.py
+++ b/apps/api.py
@@ -574,15 +574,15 @@ is also tighted to the detection method we use).
 In order to get tracklet data, you have the choice to specify:
 1. a tracklet ID if you know it
 2. a ZTF night ID
-3. a date at the format YYYYMMDD.
+3. a date at the format YYYY-MM-DD.
 
-Tracklet processing has been added on 2021/08/10, so there won't be data before this date.
+Tracklet processing has been added on 2021-08-10, so there won't be data before this date.
 
 In a unix shell, you would simply use
 
 ```bash
-# Get tracklet data for the night 20210810
-curl -H "Content-Type: application/json" -X POST -d '{"date":"20210810", "output-format":"csv"}' http://134.158.75.151:24000/api/v1/tracklet -o trck_20210810.csv
+# Get tracklet data for the night 2021-08-10
+curl -H "Content-Type: application/json" -X POST -d '{"date":"2021-08-10", "output-format":"csv"}' http://134.158.75.151:24000/api/v1/tracklet -o trck_20210810.csv
 ```
 
 In python, you would use
@@ -591,11 +591,11 @@ In python, you would use
 import requests
 import pandas as pd
 
-# Get all tracklet data for the night 20210810
+# Get all tracklet data for the night 2021-08-10
 r = requests.post(
   'http://134.158.75.151:24000/api/v1/tracklet',
   json={
-    'date': '20210810',
+    'date': '2021-08-10',
     'output-format': 'json'
   }
 )
@@ -605,7 +605,7 @@ pdf = pd.read_json(r.content)
 ```
 
 You can also specify a tracklet ID (in the format TRCK<NID>_<number>), or
-a ZTF NID (20210810 has a night ID of 1682 for example):
+a ZTF NID (2021-08-10 has a night ID of 1682 for example):
 
 ```python
 import requests
@@ -620,11 +620,11 @@ r = requests.post(
   }
 )
 
-# Get tracklet data TRCK1682_00
+# Get tracklet data TRCK1682_01
 r = requests.post(
   'http://134.158.75.151:24000/api/v1/tracklet',
   json={
-    'id': 'TRCK1682_00',
+    'id': 'TRCK1682_01',
     'output-format': 'json'
   }
 )

--- a/apps/api.py
+++ b/apps/api.py
@@ -573,9 +573,9 @@ is also tighted to the detection method we use).
 
 In order to get tracklet data, you have the choice to specify:
 
-1. a tracklet ID (format TRCK<night ID>_<XY>, with XY=00,01,02,... e.g. TRCK1682_01)
-2. a ZTF night ID (4 digits, e.g. 1682)
-3. a date at the format YYYY-MM-DD (e.g. 2021-08-10).
+1. a tracklet ID (format `TRCKXXXX_YY`, with `XXXX` being the ZTF night ID, and `YY=00,01,02,...` e.g. `TRCK1682_01`)
+2. a ZTF night ID (4 digits, e.g. `1682`)
+3. a date at the format `YYYY-MM-DD` (e.g. `2021-08-10`).
 
 Tracklet processing has been added on 2021-08-10, so there won't be data before this date.
 

--- a/apps/api.py
+++ b/apps/api.py
@@ -1800,7 +1800,7 @@ def return_tracklet():
         # date
         jd_date = Time(request.json['date'], format='iso').jd
         # conversion: NID=1682 is jd=2459436.5
-        jd_ref = Time(2459436.5, format='jd')
+        jd_ref = Time(2459436.5, format='jd').jd
 
         NID = 1682 + int(jd_date - jd_ref)
         payload = 'TRCK{}'.format(NID)

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -422,6 +422,28 @@ def card_sso_radec():
     card = html.Div(id='sso_radec')
     return card
 
+def card_tracklet_lightcurve():
+    """ Add a card to display tracklet lightcurve
+
+    Returns
+    ----------
+    card: dbc.Card
+        Card with the tracklet lightcurve
+    """
+    card = html.Div(id='tracklet_lightcurve')
+    return card
+
+def card_tracklet_radec():
+    """ Add a card to display tracklet radec
+
+    Returns
+    ----------
+    card: dbc.Card
+        Card with the tracklet radec
+    """
+    card = html.Div(id='tracklet_radec')
+    return card
+
 def card_sso_skymap():
     """ Display the sky map in the explorer tab results (Aladin lite)
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1997,7 +1997,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     else:
         period = 0.0
 
-    if len(bad_id) > 0 and ~pd.isnull(bad_id):
+    if len(bad_id) > 0:
         mask_bad_id = pdf['i:objectId'].isin(bad_id)
     else:
         mask_bad_id = np.ones(len(pdf), dtype=np.bool)
@@ -2051,13 +2051,18 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         }
         return dic
 
+    data_ = []
+    for filt in np.unique(pdf['i:fid']):
+        if filt == 1:
+            data_.append(generate_plot(~mask_bad_id, 1, marker='o', color='#1f77b4', showlegend=True))
+            if np.sum(mask_bad_id) > 0:
+                data_.append(generate_plot(mask_bad_id, 1, marker='x', color='#1f77b4', showlegend=False))
+        elif filt == 2:
+            data_.append(generate_plot(~mask_bad_id, 2, marker='o', color='#ff7f0e', showlegend=True))
+            if np.sum(mask_bad_id) > 0:
+                data_.append(generate_plot(mask_bad_id, 2, marker='x', color='#ff7f0e', showlegend=False))
     figure = {
-        'data': [
-            generate_plot(~mask_bad_id, 1, marker='o', color='#1f77b4', showlegend=True),
-            generate_plot(~mask_bad_id, 2, marker='o', color='#ff7f0e', showlegend=True),
-            generate_plot(mask_bad_id, 1, marker='x', color='#1f77b4', showlegend=False),
-            generate_plot(mask_bad_id, 2, marker='x', color='#ff7f0e', showlegend=False)
-        ],
+        'data': data_,
         "layout": layout_tracklet_lightcurve
     }
     graph = dcc.Graph(

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1997,6 +1997,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     mag = pdf['i:magpsf']
     err = pdf['i:sigmapsf']
 
+    layout_tracklet_lightcurve['title'] = 'Tracklet ID: {}'.format(pdf['d:tracklet'].values[0])
     layout_tracklet_lightcurve['yaxis']['title'] = 'Difference magnitude'
     layout_tracklet_lightcurve['yaxis']['autorange'] = 'reversed'
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1997,7 +1997,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     else:
         period = 0.0
 
-    if len(bad_id) > 0 and ~np.isnan(bad_id):
+    if len(bad_id) > 0 and ~pd.isnull(bad_id):
         mask_bad_id = pdf['i:objectId'].isin(bad_id)
     else:
         mask_bad_id = np.ones(len(pdf), dtype=np.bool)

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2017,7 +2017,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     <extra></extra>
     """
 
-    def generate_plot(mask, filt, marker, color):
+    def generate_plot(mask, filt, marker, color, showlegend):
         if filt == 1:
             name = 'g band'
         else:
@@ -2033,6 +2033,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
             },
             'mode': 'markers',
             'name': name,
+            'showlegend': showlegend,
             'customdata': list(
                 zip(
                     pdf[mask]['i:objectId'][pdf[mask]['i:fid'] == filt],
@@ -2049,10 +2050,10 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
 
     figure = {
         'data': [
-            generate_plot(~mask_bad_id, 1, marker='o', color='#1f77b4'),
-            generate_plot(~mask_bad_id, 2, marker='o', color='#ff7f0e'),
-            generate_plot(mask_bad_id, 1, marker='x', color='#1f77b4'),
-            generate_plot(mask_bad_id, 2, marker='x', color='#ff7f0e')
+            generate_plot(~mask_bad_id, 1, marker='o', color='#1f77b4', showlegend=True),
+            generate_plot(~mask_bad_id, 2, marker='o', color='#ff7f0e', showlegend=True),
+            generate_plot(mask_bad_id, 1, marker='x', color='#1f77b4', showlegend=False),
+            generate_plot(mask_bad_id, 2, marker='x', color='#ff7f0e', showlegend=False)
         ],
         "layout": layout_tracklet_lightcurve
     }
@@ -2091,13 +2092,38 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         }
     )
 
-    card = [
-        dbc.Alert(
-            "Tracklet ID: {} -- Inferred period: {:.1f} hours".format(
-                pdf['d:tracklet'].values[0],
-                period
+    alert = dbc.Alert(
+        "Tracklet ID: {} -- Inferred period: {:.1f} hours".format(
+            pdf['d:tracklet'].values[0],
+            period
+        ),
+        color="info"
+    )
+
+    toast = html.Div(
+        [
+            dbc.Button(
+                "Open toast",
+                id="simple-toast-toggle",
+                color="primary",
+                className="mb-3",
+                n_clicks=0,
             ),
-            color="info"
+            dbc.Toast(
+                [html.P("This is the content of the toast", className="mb-0")],
+                id="simple-toast",
+                header="This is the header",
+                icon="primary",
+                dismissable=True,
+            ),
+        ]
+    )
+    card = [
+        dbc.Row(
+            [
+                dbc.Col(alert, width=8),
+                dbc.Col(toast)
+            ]
         ),
         dbc.Card(
             dbc.CardBody(graph),

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2068,6 +2068,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     )
 
     # Compute period
+    pdf = pdf.sort_values('i:jd')
     vel = get_tracklet_velocity_bystep(pdf, min_alert_per_exposure=5)
     if ~np.isnan(vel):
         period = 360. / vel
@@ -2076,7 +2077,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
 
     card = [
         dbc.Alert(
-            "Tracklet ID: {} -- Inferred period: {:.2f} hours".format(
+            "Tracklet ID: {} -- Inferred period: {:.1f} hours".format(
                 pdf['d:tracklet'].values[0],
                 period
             ),

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2065,6 +2065,33 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         config={'displayModeBar': False}
     )
 
+    msg = """
+    Tracklets are discrete tracks (several spatially connected dots)
+    seen on one or more exposures. This is somehow similar to solar
+    system object, expect that these objects are probably human-made,
+    they are typically fast moving, and they seem to orbit
+    around the Earth (this type of orbit is also tight to
+    the detection method we use). The rotation period, in hour, is inferred from the
+    velocity estimate of the object assuming a circular orbit.
+
+    The velocity is computed by integrating the distance between subsequent measurements:
+
+    ```
+    v = sum_i[x(i+1) - x(i)] / dt, i=alert
+    ```
+
+    If the tracklet spans several exposures, we discard exposures with less than 5 alerts.
+    Discarded alerts are shown with cross markers, while alerts used to estimate the period are
+    shown with circle markers.
+    """
+    card_info = dbc.Card(
+        dbc.CardBody(
+            dcc.Markdown(msg)
+        ), style={
+            'backgroundColor': 'rgb(248, 248, 248, .7)'
+        }
+    )
+
     card = [
         dbc.Alert(
             "Tracklet ID: {} -- Inferred period: {:.1f} hours".format(
@@ -2076,7 +2103,8 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         dbc.Card(
             dbc.CardBody(graph),
             className="mt-3"
-        )
+        ),
+        card_info
     ]
     return card
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -23,7 +23,7 @@ import requests
 
 import dash
 import dash_table
-from dash.dependencies import Input, Output
+from dash.dependencies import Input, Output, State
 import plotly.graph_objects as go
 import plotly.express as px
 import dash_core_components as dcc

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1995,9 +1995,12 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     if ~np.isnan(vel):
         period = 360. / vel
     else:
-        period = 'None'
+        period = 0.0
 
-    mask_bad_id = pdf['i:objectId'].isin(bad_id)
+    if ~np.isnan(bad_id):
+        mask_bad_id = pdf['i:objectId'].isin(bad_id)
+    else:
+        mask_bad_id = np.ones(len(pdf), dtype=np.bool)
 
     # type conversion
     pdf['i:fid'] = pdf['i:fid'].apply(lambda x: int(x))

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2000,7 +2000,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     if len(bad_id) > 0:
         mask_bad_id = pdf['i:objectId'].isin(bad_id)
     else:
-        mask_bad_id = np.ones(len(pdf), dtype=np.bool)
+        mask_bad_id = np.zeros(len(pdf), dtype=np.bool)
 
     # type conversion
     pdf['i:fid'] = pdf['i:fid'].apply(lambda x: int(x))

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2008,7 +2008,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     <extra></extra>
     """
 
-    def generate_plot(filt, marker):
+    def generate_plot(filt, marker, color):
         dic = {
             'x': pdf['i:ra'][pdf['i:fid'] == filt],
             'y': mag[pdf['i:fid'] == filt],
@@ -2016,7 +2016,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                 'type': 'data',
                 'array': err[pdf['i:fid'] == filt],
                 'visible': True,
-                'color': '#1f77b4'
+                'color': color
             },
             'mode': 'markers',
             'name': 'g band',
@@ -2029,15 +2029,15 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
             'hovertemplate': hovertemplate,
             'marker': {
                 'size': 12,
-                'color': '#1f77b4',
+                'color': color,
                 'symbol': marker}
         }
         return dic
 
     figure = {
         'data': [
-            generate_plot(1, marker='o'),
-            generate_plot(2, marker='o')
+            generate_plot(1, marker='o', color='#1f77b4'),
+            generate_plot(2, marker='o', color='#ff7f0e')
         ],
         "layout": layout_tracklet_lightcurve
     }

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2103,7 +2103,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     toast = html.Div(
         [
             dbc.Button(
-                "Open toast",
+                "Information",
                 id="simple-toast-toggle",
                 color="secondary",
                 outline=True,
@@ -2117,6 +2117,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                 header="This is the header",
                 icon="primary",
                 dismissable=True,
+                is_open=False
             ),
         ]
     )
@@ -2124,9 +2125,12 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     @app.callback(
         Output("simple-toast", "is_open"),
         [Input("simple-toast-toggle", "n_clicks")],
+        [State("simple-toast", "is_open")],
     )
-    def open_toast(n):
-        return True
+    def open_toast(n, is_open):
+        if n:
+            return not is_open
+        return is_open
 
     card = [
         alert,

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1997,7 +1997,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     else:
         period = 'None'
 
-    mask_bad_id = pdf[pdf['i:objectId'].isin(bad_id)]
+    mask_bad_id = pdf['i:objectId'].isin(bad_id)
 
     # type conversion
     pdf['i:fid'] = pdf['i:fid'].apply(lambda x: int(x))

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2105,9 +2105,11 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
             dbc.Button(
                 "Open toast",
                 id="simple-toast-toggle",
-                color="primary",
+                color="secondary",
+                outline=True,
                 className="mb-3",
                 n_clicks=0,
+                block=True
             ),
             dbc.Toast(
                 [html.P("This is the content of the toast", className="mb-0")],
@@ -2118,17 +2120,21 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
             ),
         ]
     )
+
+    @app.callback(
+        Output("simple-toast", "is_open"),
+        [Input("simple-toast-toggle", "n_clicks")],
+    )
+    def open_toast(n):
+        return True
+
     card = [
-        dbc.Row(
-            [
-                dbc.Col(alert, width=8),
-                dbc.Col(toast)
-            ]
-        ),
+        alert,
         dbc.Card(
             dbc.CardBody(graph),
             className="mt-3"
         ),
+        toast,
         card_info
     ]
     return card

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2068,12 +2068,11 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     msg = """
     Tracklets are discrete tracks (several spatially connected dots)
     seen on one or more exposures. This is somehow similar to solar
-    system object, expect that these objects are probably human-made,
+    system objects, expect that these objects are probably human-made,
     they are typically fast moving, and they seem to orbit
     around the Earth (this type of orbit is also tight to
     the detection method we use). The rotation period, in hour, is inferred from the
     velocity estimate of the object assuming a circular orbit.
-
     The velocity is computed by integrating the distance between subsequent measurements:
 
     ```

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1991,7 +1991,6 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         return html.Div([html.Br(), dbc.Alert(msg, color="danger")])
 
     # type conversion
-    dates = pdf['i:jd'].apply(lambda x: convert_jd(float(x), to='iso'))
     pdf['i:fid'] = pdf['i:fid'].apply(lambda x: int(x))
 
     # shortcuts
@@ -2010,7 +2009,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     figure = {
         'data': [
             {
-                'x': dates[pdf['i:ra'] == 1],
+                'x': pdf['i:ra'][pdf['i:fid'] == 1],
                 'y': mag[pdf['i:fid'] == 1],
                 'error_y': {
                     'type': 'data',
@@ -2028,7 +2027,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                     'symbol': 'o'}
             },
             {
-                'x': dates[pdf['i:ra'] == 2],
+                'x': pdf['i:ra'][pdf['i:fid'] == 2],
                 'y': mag[pdf['i:fid'] == 2],
                 'error_y': {
                     'type': 'data',

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2007,54 +2007,37 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     <b>Date</b>: %{customdata[1]}
     <extra></extra>
     """
+
+    def generate_plot(filt, marker):
+        dic = {
+            'x': pdf['i:ra'][pdf['i:fid'] == filt],
+            'y': mag[pdf['i:fid'] == filt],
+            'error_y': {
+                'type': 'data',
+                'array': err[pdf['i:fid'] == filt],
+                'visible': True,
+                'color': '#1f77b4'
+            },
+            'mode': 'markers',
+            'name': 'g band',
+            'customdata': list(
+                zip(
+                    pdf['i:objectId'][pdf['i:fid'] == filt],
+                    pdf['v:lastdate'][pdf['i:fid'] == filt]
+                )
+            ),
+            'hovertemplate': hovertemplate,
+            'marker': {
+                'size': 12,
+                'color': '#1f77b4',
+                'symbol': marker}
+        }
+        return dic
+
     figure = {
         'data': [
-            {
-                'x': pdf['i:ra'][pdf['i:fid'] == 1],
-                'y': mag[pdf['i:fid'] == 1],
-                'error_y': {
-                    'type': 'data',
-                    'array': err[pdf['i:fid'] == 1],
-                    'visible': True,
-                    'color': '#1f77b4'
-                },
-                'mode': 'markers',
-                'name': 'g band',
-                'customdata': list(
-                    zip(
-                        pdf['i:objectId'][pdf['i:fid'] == 1],
-                        pdf['v:lastdate'][pdf['i:fid'] == 1]
-                    )
-                ),
-                'hovertemplate': hovertemplate,
-                'marker': {
-                    'size': 12,
-                    'color': '#1f77b4',
-                    'symbol': 'o'}
-            },
-            {
-                'x': pdf['i:ra'][pdf['i:fid'] == 2],
-                'y': mag[pdf['i:fid'] == 2],
-                'error_y': {
-                    'type': 'data',
-                    'array': err[pdf['i:fid'] == 2],
-                    'visible': True,
-                    'color': '#ff7f0e'
-                },
-                'mode': 'markers',
-                'name': 'r band',
-                'customdata': list(
-                    zip(
-                        pdf['i:objectId'][pdf['i:fid'] == 2],
-                        pdf['v:lastdate'][pdf['i:fid'] == 2]
-                    )
-                ),
-                'hovertemplate': hovertemplate,
-                'marker': {
-                    'size': 12,
-                    'color': '#ff7f0e',
-                    'symbol': 'o'}
-            }
+            generate_plot(1, marker='o'),
+            generate_plot(2, marker='o')
         ],
         "layout": layout_tracklet_lightcurve
     }
@@ -2068,7 +2051,6 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     )
 
     # Compute period
-    pdf = pdf.sort_values('i:jd')
     vel = get_tracklet_velocity_bystep(pdf, min_alert_per_exposure=5)
     if ~np.isnan(vel):
         period = 360. / vel

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2019,7 +2019,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                 },
                 'mode': 'markers',
                 'name': 'g band',
-                'customdata': [t, o for t, o in zip(pdf['v:lastdate'][pdf['i:fid'] == 1], pdf['i:objectId'][pdf['i:fid'] == 1])],
+                'customdata': list(zip(pdf['v:lastdate'][pdf['i:fid'] == 1], pdf['i:objectId'][pdf['i:fid'] == 1])),
                 'hovertemplate': hovertemplate,
                 'marker': {
                     'size': 12,
@@ -2037,7 +2037,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                 },
                 'mode': 'markers',
                 'name': 'r band',
-                'customdata': [t, o for t, o in zip(pdf['v:lastdate'][pdf['i:fid'] == 2], pdf['i:objectId'][pdf['i:fid'] == 2])],
+                'customdata': list(zip(pdf['v:lastdate'][pdf['i:fid'] == 2], pdf['i:objectId'][pdf['i:fid'] == 2])),
                 'hovertemplate': hovertemplate,
                 'marker': {
                     'size': 12,

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -31,7 +31,7 @@ import dash_bootstrap_components as dbc
 import dash_html_components as html
 
 from apps.utils import convert_jd, readstamp, _data_stretch, convolve
-from apps.utils import apparent_flux, dc_mag
+from apps.utils import apparent_flux, dc_mag, get_tracklet_velocity_bystep
 from app import APIURL
 
 from pyLIMA import event
@@ -2054,8 +2054,22 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         },
         config={'displayModeBar': False}
     )
+
+    # Compute period
+    vel = get_tracklet_velocity_bystep(pdf, min_alert_per_exposure=5)
+    if ~np.isnan(vel):
+        period = 360. / vel
+    else:
+        period = 'None'
+
     card = [
-        dbc.Alert("Tracklet ID: {}".format(pdf['d:tracklet'].values[0]), color="info"),
+        dbc.Alert(
+            [
+                html.P("Tracklet ID: {}".format(pdf['d:tracklet'].values[0])),
+                html.P("Inferred period: {:.2f} hours".format(period))
+            ],
+            color="info"
+        ),
         dbc.Card(
             dbc.CardBody(graph),
             className="mt-3"

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2002,7 +2002,6 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
 
     hovertemplate = r"""
     <b>%{yaxis.title.text}</b>: %{y:.2f} &plusmn; %{error_y.array:.2f}<br>
-    <b>%{xaxis.title.text}</b>: %{x|%Y/%m/%d %H:%M:%S.%L}<br>
     <b>mjd</b>: %{customdata}
     <extra></extra>
     """

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2002,7 +2002,8 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
 
     hovertemplate = r"""
     <b>%{yaxis.title.text}</b>: %{y:.2f} &plusmn; %{error_y.array:.2f}<br>
-    <b>mjd</b>: %{customdata}
+    <b>date</b>: %{customdata[0]}
+    <b>objectId</b>: %{customdata[1]}
     <extra></extra>
     """
     figure = {
@@ -2018,7 +2019,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                 },
                 'mode': 'markers',
                 'name': 'g band',
-                'customdata': pdf['i:jd'].apply(lambda x: float(x) - 2400000.5)[pdf['i:fid'] == 1],
+                'customdata': [t, o for t, o in zip(pdf['v:lastdate'][pdf['i:fid'] == 1], pdf['i:objectId'][pdf['i:fid'] == 1])],
                 'hovertemplate': hovertemplate,
                 'marker': {
                     'size': 12,
@@ -2036,7 +2037,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                 },
                 'mode': 'markers',
                 'name': 'r band',
-                'customdata': pdf['i:jd'].apply(lambda x: float(x) - 2400000.5)[pdf['i:fid'] == 2],
+                'customdata': [t, o for t, o in zip(pdf['v:lastdate'][pdf['i:fid'] == 2], pdf['i:objectId'][pdf['i:fid'] == 2])],
                 'hovertemplate': hovertemplate,
                 'marker': {
                     'size': 12,
@@ -2066,6 +2067,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         dbc.Alert(
             [
                 html.P("Tracklet ID: {}".format(pdf['d:tracklet'].values[0])),
+                html.Hr(),
                 html.P("Inferred period: {:.2f} hours".format(period))
             ],
             color="info"

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2001,9 +2001,10 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     layout_tracklet_lightcurve['yaxis']['autorange'] = 'reversed'
 
     hovertemplate = r"""
+    <b>objectId</b>: %{customdata[0]}<br>
     <b>%{yaxis.title.text}</b>: %{y:.2f} &plusmn; %{error_y.array:.2f}<br>
-    <b>date</b>: %{customdata[0]}
-    <b>objectId</b>: %{customdata[1]}
+    <b>%{xaxis.title.text}</b>: %{x:.2f}<br>
+    <b>Date</b>: %{customdata[1]}
     <extra></extra>
     """
     figure = {
@@ -2019,7 +2020,12 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                 },
                 'mode': 'markers',
                 'name': 'g band',
-                'customdata': list(zip(pdf['v:lastdate'][pdf['i:fid'] == 1], pdf['i:objectId'][pdf['i:fid'] == 1])),
+                'customdata': list(
+                    zip(
+                        pdf['i:objectId'][pdf['i:fid'] == 1],
+                        pdf['v:lastdate'][pdf['i:fid'] == 1]
+                    )
+                ),
                 'hovertemplate': hovertemplate,
                 'marker': {
                     'size': 12,
@@ -2037,7 +2043,12 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                 },
                 'mode': 'markers',
                 'name': 'r band',
-                'customdata': list(zip(pdf['v:lastdate'][pdf['i:fid'] == 2], pdf['i:objectId'][pdf['i:fid'] == 2])),
+                'customdata': list(
+                    zip(
+                        pdf['i:objectId'][pdf['i:fid'] == 2],
+                        pdf['v:lastdate'][pdf['i:fid'] == 2]
+                    )
+                ),
                 'hovertemplate': hovertemplate,
                 'marker': {
                     'size': 12,
@@ -2065,11 +2076,10 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
 
     card = [
         dbc.Alert(
-            [
-                html.P("Tracklet ID: {}".format(pdf['d:tracklet'].values[0])),
-                html.Hr(),
-                html.P("Inferred period: {:.2f} hours".format(period))
-            ],
+            "Tracklet ID: {} -- Inferred period: {:.2f} hours".format(
+                pdf['d:tracklet'].values[0],
+                period
+            ),
             color="info"
         ),
         dbc.Card(
@@ -2110,7 +2120,7 @@ def draw_tracklet_radec(pathname: str, object_tracklet) -> dict:
     <b>objectId</b>: %{customdata[0]}<br>
     <b>%{yaxis.title.text}</b>: %{y:.2f}<br>
     <b>%{xaxis.title.text}</b>: %{x:.2f}<br>
-    <b>mjd</b>: %{customdata[1]}
+    <b>Date</b>: %{customdata[1]}
     <extra></extra>
     """
     figure = {
@@ -2123,7 +2133,7 @@ def draw_tracklet_radec(pathname: str, object_tracklet) -> dict:
                 'customdata': list(
                     zip(
                         pdf['i:objectId'],
-                        pdf['i:jd'].apply(lambda x: float(x) - 2400000.5),
+                        pdf['v:lastdate']
                     )
                 ),
                 'hovertemplate': hovertemplate,

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1944,7 +1944,7 @@ def draw_sso_radec(pathname: str, object_sso) -> dict:
         Input('url', 'pathname'),
         Input('object-tracklet', 'children')
     ])
-def draw_sso_lightcurve(pathname: str, object_tracklet) -> dict:
+def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     """ Draw tracklet object lightcurve with errorbars
 
     Parameters

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -307,6 +307,33 @@ layout_sso_radec = dict(
     }
 )
 
+layout_tracklet_lightcurve = dict(
+    automargin=True,
+    margin=dict(l=50, r=30, b=0, t=0),
+    hovermode="closest",
+    hoverlabel={
+        'align': "left"
+    },
+    legend=dict(
+        font=dict(size=10),
+        orientation="h",
+        xanchor="right",
+        x=1,
+        y=1.2,
+        bgcolor='rgba(218, 223, 225, 0.3)'
+    ),
+    yaxis={
+        'autorange': 'reversed',
+        'title': 'Magnitude',
+        'automargin': True
+    },
+    xaxis={
+        'autorange': 'reversed',
+        'title': 'Right Ascension',
+        'automargin': True
+    }
+)
+
 def extract_scores(data: java.util.TreeMap) -> pd.DataFrame:
     """ Extract SN scores from the data
     """
@@ -1971,8 +1998,8 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     mag = pdf['i:magpsf']
     err = pdf['i:sigmapsf']
 
-    layout_sso_lightcurve['yaxis']['title'] = 'Difference magnitude'
-    layout_sso_lightcurve['yaxis']['autorange'] = 'reversed'
+    layout_tracklet_lightcurve['yaxis']['title'] = 'Difference magnitude'
+    layout_tracklet_lightcurve['yaxis']['autorange'] = 'reversed'
 
     hovertemplate = r"""
     <b>%{yaxis.title.text}</b>: %{y:.2f} &plusmn; %{error_y.array:.2f}<br>
@@ -1983,7 +2010,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     figure = {
         'data': [
             {
-                'x': dates[pdf['i:fid'] == 1],
+                'x': dates[pdf['i:ra'] == 1],
                 'y': mag[pdf['i:fid'] == 1],
                 'error_y': {
                     'type': 'data',
@@ -2001,7 +2028,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                     'symbol': 'o'}
             },
             {
-                'x': dates[pdf['i:fid'] == 2],
+                'x': dates[pdf['i:ra'] == 2],
                 'y': mag[pdf['i:fid'] == 2],
                 'error_y': {
                     'type': 'data',
@@ -2019,7 +2046,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                     'symbol': 'o'}
             }
         ],
-        "layout": layout_sso_lightcurve
+        "layout": layout_tracklet_lightcurve
     }
     graph = dcc.Graph(
         figure=figure,

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2112,9 +2112,9 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                 block=True
             ),
             dbc.Toast(
-                [html.P("This is the content of the toast", className="mb-0")],
+                [dcc.Markdown(msg)],
                 id="simple-toast",
-                header="This is the header",
+                header="Fink tracklets",
                 icon="primary",
                 dismissable=True,
                 is_open=False
@@ -2124,12 +2124,11 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
 
     card = [
         alert,
+        toast,
         dbc.Card(
             dbc.CardBody(graph),
             className="mt-3"
-        ),
-        toast,
-        card_info
+        )
     ]
     return card
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1997,7 +1997,6 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     mag = pdf['i:magpsf']
     err = pdf['i:sigmapsf']
 
-    layout_tracklet_lightcurve['title'] = 'Tracklet ID: {}'.format(pdf['d:tracklet'].values[0])
     layout_tracklet_lightcurve['yaxis']['title'] = 'Difference magnitude'
     layout_tracklet_lightcurve['yaxis']['autorange'] = 'reversed'
 
@@ -2055,10 +2054,13 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         },
         config={'displayModeBar': False}
     )
-    card = dbc.Card(
-        dbc.CardBody(graph),
-        className="mt-3"
-    )
+    card = [
+        dbc.Alert("Tracklet ID: {}".format(pdf['d:tracklet'].values[0]), color="info"),
+        dbc.Card(
+            dbc.CardBody(graph),
+            className="mt-3"
+        )
+    ]
     return card
 
 @app.callback(

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -330,6 +330,7 @@ def plot_classbar(pdf, is_mobile=False):
         'SN candidate': 'orange',
         'Kilonova candidate': 'blue',
         'Microlensing candidate': 'green',
+        'Tracklet': "rgb(204,255,204)",
         'Solar System MPC': "rgb(254,224,144)",
         'Solar System candidate': "rgb(171,217,233)",
         'Ambiguous': 'rgb(116,196,118)',

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1997,7 +1997,7 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     else:
         period = 0.0
 
-    if ~np.isnan(bad_id):
+    if len(bad_id) > 0 and ~np.isnan(bad_id):
         mask_bad_id = pdf['i:objectId'].isin(bad_id)
     else:
         mask_bad_id = np.ones(len(pdf), dtype=np.bool)

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2122,16 +2122,6 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         ]
     )
 
-    @app.callback(
-        Output("simple-toast", "is_open"),
-        [Input("simple-toast-toggle", "n_clicks")],
-        [State("simple-toast", "is_open")],
-    )
-    def open_toast(n, is_open):
-        if n:
-            return not is_open
-        return is_open
-
     card = [
         alert,
         dbc.Card(
@@ -2142,6 +2132,16 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         card_info
     ]
     return card
+
+@app.callback(
+    Output("simple-toast", "is_open"),
+    [Input("simple-toast-toggle", "n_clicks")],
+    [State("simple-toast", "is_open")],
+)
+def open_toast(n, is_open):
+    if n:
+        return not is_open
+    return is_open
 
 @app.callback(
     Output('tracklet_radec', 'children'),

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -126,12 +126,27 @@ def tab5_content(pdf):
 def tab6_content(pdf):
     """ Tracklet tab
     """
-    trackletId = pdf['d:tracklet'].values[0]
+    msg = """
+    TBD
+    """
+    card_info = dbc.Card(
+        dbc.CardBody(
+            dcc.Markdown(msg)
+        ), style={
+            'backgroundColor': 'rgb(248, 248, 248, .7)'
+        }
+    )
+
     tab6_content_ = html.Div([
         dbc.Row(
             [
-                dbc.Col([card_tracklet_lightcurve(), card_tracklet_radec()]),
-                # dbc.Col([card_sso_mpc_params(ssnamenr)], width=4)
+                dbc.Col(
+                    [
+                        card_tracklet_lightcurve(),
+                        card_tracklet_radec(),
+                        card_info()
+                    ]
+                ),
             ]
         ),
     ])

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -24,7 +24,7 @@ import pandas as pd
 import numpy as np
 import requests
 
-from app import app, client, clientU, clientUV, clientSSO
+from app import app, client, clientU, clientUV, clientSSO, clientTRCK
 
 from apps.cards import card_cutouts, card_sn_scores
 from apps.cards import card_id, card_sn_properties

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -126,25 +126,13 @@ def tab5_content(pdf):
 def tab6_content(pdf):
     """ Tracklet tab
     """
-    msg = """
-    TBD
-    """
-    card_info = dbc.Card(
-        dbc.CardBody(
-            dcc.Markdown(msg)
-        ), style={
-            'backgroundColor': 'rgb(248, 248, 248, .7)'
-        }
-    )
-
     tab6_content_ = html.Div([
         dbc.Row(
             [
                 dbc.Col(
                     [
-                        card_tracklet_lightcurve(),
                         card_tracklet_radec(),
-                        card_info
+                        card_tracklet_lightcurve()
                     ]
                 ),
             ]

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -144,7 +144,7 @@ def tab6_content(pdf):
                     [
                         card_tracklet_lightcurve(),
                         card_tracklet_radec(),
-                        card_info()
+                        card_info
                     ]
                 ),
             ]

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -131,8 +131,8 @@ def tab6_content(pdf):
             [
                 dbc.Col(
                     [
-                        card_tracklet_radec(),
-                        card_tracklet_lightcurve()
+                        card_tracklet_lightcurve(),
+                        card_tracklet_radec()
                     ]
                 ),
             ]

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -517,7 +517,8 @@ def layout(name, is_mobile):
                 html.Div(id='object-data', style={'display': 'none'}),
                 html.Div(id='object-upper', style={'display': 'none'}),
                 html.Div(id='object-uppervalid', style={'display': 'none'}),
-                html.Div(id='object-sso', style={'display': 'none'})
+                html.Div(id='object-sso', style={'display': 'none'}),
+                html.Div(id='object-tracklet', style={'display': 'none'}),
             ], className='home', style={'background-image': 'linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0.5)), url(/assets/background.png)', 'background-size': 'contain'}
         )
 

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -33,6 +33,7 @@ from apps.cards import card_variable_plot, card_variable_button
 from apps.cards import card_explanation_variable, card_explanation_mulens
 from apps.cards import card_mulens_plot, card_mulens_button, card_mulens_param
 from apps.cards import card_sso_lightcurve, card_sso_radec, card_sso_mpc_params
+from apps.cards import card_tracklet_lightcurve, card_tracklet_radec
 from apps.plotting import plot_classbar
 from apps.plotting import all_radio_options
 
@@ -122,6 +123,20 @@ def tab5_content(pdf):
     ])
     return tab5_content_
 
+def tab6_content(pdf):
+    """ Tracklet tab
+    """
+    trackletId = pdf['d:tracklet'].values[0]
+    tab6_content_ = html.Div([
+        dbc.Row(
+            [
+                dbc.Col([card_tracklet_lightcurve(), card_tracklet_radec()]),
+                # dbc.Col([card_sso_mpc_params(ssnamenr)], width=4)
+            ]
+        ),
+    ])
+    return tab6_content_
+
 def tab_mobile_content(pdf):
     """ Content for mobile application
     """
@@ -157,6 +172,7 @@ def tabs(pdf, is_mobile):
                 dbc.Tab(tab3_content(pdf), label="Variable stars", label_style=label_style),
                 dbc.Tab(tab4_content(pdf), label="Microlensing", label_style=label_style),
                 dbc.Tab(tab5_content(pdf), label="Solar System", label_style=label_style),
+                dbc.Tab(tab6_content(pdf), label="Tracklets", label_style=label_style),
                 dbc.Tab(label="GRB", disabled=True)
             ]
         )
@@ -364,6 +380,7 @@ def toggle_accordion(n1, n2, n3, n4, is_open1, is_open2, is_open3, is_open4):
         Output('object-upper', 'children'),
         Output('object-uppervalid', 'children'),
         Output('object-sso', 'children'),
+        Output('object-tracklet', 'children'),
     ],
     [
         Input('url', 'pathname'),
@@ -395,7 +412,20 @@ def store_query(name):
         results, schema_client_sso,
         group_alerts=False, truncated=False, extract_color=False
     )
-    return pdfs.to_json(), pdfsU.to_json(), pdfsUV.to_json(), pdfsso.to_json()
+
+    payload = pdfs['d:tracklet'].values[0]
+    results = clientTRCK.scan(
+        "",
+        "key:key:{}_".format(payload),
+        "*",
+        0, True, True
+    )
+    schema_client_tracklet = clientTRCK.schema()
+    pdftracklet = format_hbase_output(
+        results, schema_client_tracklet,
+        group_alerts=False, truncated=False, extract_color=False
+    )
+    return pdfs.to_json(), pdfsU.to_json(), pdfsUV.to_json(), pdfsso.to_json(), pdftracklet.to_json()
 
 def layout(name, is_mobile):
     # even if there is one object ID, this returns  several alerts
@@ -441,6 +471,7 @@ def layout(name, is_mobile):
             html.Div(id='object-upper', style={'display': 'none'}),
             html.Div(id='object-uppervalid', style={'display': 'none'}),
             html.Div(id='object-sso', style={'display': 'none'}),
+            html.Div(id='object-tracklet', style={'display': 'none'}),
             ],
             className='home',
             style={

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -116,7 +116,7 @@ def tab5_content(pdf):
     tab5_content_ = html.Div([
         dbc.Row(
             [
-                dbc.Col([card_sso_lightcurve(), card_sso_radec()]),
+                dbc.Col([card_sso_lightcurve(), card_sso_radec()], width=8),
                 dbc.Col([card_sso_mpc_params(ssnamenr)], width=4)
             ]
         ),

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -874,7 +874,7 @@ def get_tracklet_velocity_bystep(data, single_exposure_time = 30., min_alert_per
 
         # Discard if there are not enough alerts left (we want a total of 5 at least)
         if np.sum(mask_exposure) < 5:
-            return np.nan
+            return np.nan, np.nan
 
         # Compute the time lapse between the start of the first and last exposure (0 if the same exposure)
         delta_jd_second = (

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -53,6 +53,9 @@ def format_hbase_output(
     if 'd:knscore' not in pdfs.columns:
         pdfs['d:knscore'] = np.zeros(len(pdfs), dtype=float)
 
+    if 'd:tracklet' not in pdfs.columns:
+        pdfs['d:tracklet'] = np.zeros(len(pdfs), dtype='U20')
+
     # Remove hbase specific fields
     if 'key:key' in pdfs.columns or 'key:time' in pdfs.columns:
         pdfs = pdfs.drop(columns=['key:key', 'key:time'])
@@ -76,7 +79,8 @@ def format_hbase_output(
             pdfs['i:classtar'],
             pdfs['i:jd'],
             pdfs['i:jdstarthist'],
-            pdfs['d:knscore']
+            pdfs['d:knscore'],
+            pdfs['d:tracklet']
         )
 
         pdfs['v:classification'] = classifications
@@ -279,7 +283,8 @@ def extract_fink_classification_single(data):
             'i:classtar',
             'i:jd',
             'i:jdstarthist',
-            'd:knscore'
+            'd:knscore',
+            'd;tracklet'
         ]
     )
     pdf = pdf.sort_values('i:jd', ascending=False)
@@ -297,7 +302,8 @@ def extract_fink_classification_single(data):
         pdf['i:classtar'],
         pdfs['i:jd'],
         pdfs['i:jdstarthist'],
-        pdfs['d:knscore']
+        pdfs['d:knscore'],
+        pdfs['d:tracklet']
     )
 
     return classification[0]
@@ -305,13 +311,16 @@ def extract_fink_classification_single(data):
 def extract_fink_classification(
         cdsxmatch, roid, mulens_class_1, mulens_class_2,
         snn_snia_vs_nonia, snn_sn_vs_all, rfscore,
-        ndethist, drb, classtar, jd, jdstarthist, knscore_):
+        ndethist, drb, classtar, jd, jdstarthist, knscore_, tracklet):
     """ Extract the classification of an alert based on module outputs
 
     See https://arxiv.org/abs/2009.10185 for more information
     """
     classification = pd.Series(['Unknown'] * len(cdsxmatch))
     ambiguity = pd.Series([0] * len(cdsxmatch))
+
+    # Tracklet ID
+    f_tracklet = tracklet.apply(lambda x: x != '')
 
     # Microlensing classification
     medium_ndethist = ndethist.astype(int) < 100
@@ -382,6 +391,7 @@ def extract_fink_classification(
     classification.mask(f_sn_early.values, 'Early SN Ia candidate', inplace=True)
     classification.mask(f_kn.values, 'Kilonova candidate', inplace=True)
     classification.mask(f_roid_2.values, 'Solar System candidate', inplace=True)
+    classification.mask(f_tracklet.values, 'Tracklet', inplace=True)
     classification.mask(f_roid_3.values, 'Solar System MPC', inplace=True)
 
     # If several flags are up, we cannot rely on the classification

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -886,7 +886,7 @@ def get_tracklet_velocity_bystep(data, single_exposure_time = 30., min_alert_per
 
     # Sort data, and integrate the trajectory
     data_small = data[mask_exposure].sort_values('i:dec')
-    objectid_discarded = data['i:objectId'][mask_exposure]
+    objectid_discarded = data['i:objectId'][~mask_exposure]
     for i in range(len(data_small) - 1):
         first = SkyCoord(
             data_small['i:ra'].values[i],

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -874,7 +874,7 @@ def get_tracklet_velocity_bystep(data, single_exposure_time = 30., min_alert_per
 
         # Discard if there are not enough alerts left (we want a total of 5 at least)
         if np.sum(mask_exposure) < 5:
-            return np.nan, np.nan
+            return np.nan, data['i:objectId'].values
 
         # Compute the time lapse between the start of the first and last exposure (0 if the same exposure)
         delta_jd_second = (

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -882,16 +882,16 @@ def get_tracklet_velocity_bystep(data, single_exposure_time = 30., min_alert_per
         single_exposure_time = delta_jd_second + 30.
 
     # Sort data, and integrate the trajectory
-    data = data.sort_values('i:dec')
-    for i in range(len(data[mask_exposure]) - 1):
+    data_small = data[mask_exposure].sort_values('i:dec')
+    for i in range(len(data_small) - 1):
         first = SkyCoord(
-            data['i:ra'][mask_exposure][i],
-            data['i:dec'][mask_exposure][i],
+            data_small['i:ra'].values[i],
+            data_small['i:dec'].values[i],
             unit='deg'
         )
         last = SkyCoord(
-            data['i:ra'][mask_exposure][i+1],
-            data['i:dec'][mask_exposure][i+1],
+            data_small['i:ra'].values[i+1],
+            data_small['i:dec'].values[i+1],
             unit='deg'
         )
         length += first.separation(last).degree

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -886,7 +886,7 @@ def get_tracklet_velocity_bystep(data, single_exposure_time = 30., min_alert_per
 
     # Sort data, and integrate the trajectory
     data_small = data[mask_exposure].sort_values('i:dec')
-    objectid_discarded = data['i:objectId'][~mask_exposure]
+    objectid_discarded = data['i:objectId'][~mask_exposure].values
     for i in range(len(data_small) - 1):
         first = SkyCoord(
             data_small['i:ra'].values[i],

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -850,6 +850,9 @@ def get_tracklet_velocity_bystep(data, single_exposure_time = 30., min_alert_per
     ----------
     velocity: float or NaN
         Velocity in deg/hour. Invalid tracklets return NaN.
+    objectid_discarded: list of str
+        List of objectId discarded from the velocity computation because
+        the exposure(s) contained too few alerts
     """
     # Initialise the trajectory
     length = 0.0
@@ -883,6 +886,7 @@ def get_tracklet_velocity_bystep(data, single_exposure_time = 30., min_alert_per
 
     # Sort data, and integrate the trajectory
     data_small = data[mask_exposure].sort_values('i:dec')
+    objectid_discarded = data['i:objectId'][mask_exposure]
     for i in range(len(data_small) - 1):
         first = SkyCoord(
             data_small['i:ra'].values[i],
@@ -897,4 +901,4 @@ def get_tracklet_velocity_bystep(data, single_exposure_time = 30., min_alert_per
         length += first.separation(last).degree
 
     # return the velocity in deg/hour
-    return length / (single_exposure_time / 3600.)
+    return length / (single_exposure_time / 3600.), objectid_discarded

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -320,7 +320,7 @@ def extract_fink_classification(
     ambiguity = pd.Series([0] * len(cdsxmatch))
 
     # Tracklet ID
-    f_tracklet = tracklet.apply(lambda x: x != '')
+    f_tracklet = tracklet.apply(lambda x: (x != '') & (x == x))
 
     # Microlensing classification
     medium_ndethist = ndethist.astype(int) < 100

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -319,8 +319,8 @@ def extract_fink_classification(
     classification = pd.Series(['Unknown'] * len(cdsxmatch))
     ambiguity = pd.Series([0] * len(cdsxmatch))
 
-    # Tracklet ID
-    f_tracklet = tracklet.apply(lambda x: (x != '') & (x == x))
+    # Tracklet ID -- automatic casts are painful...
+    f_tracklet = tracklet.apply(lambda x: (x != '') & (x != 'nan'))
 
     # Microlensing classification
     medium_ndethist = ndethist.astype(int) < 100

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -855,16 +855,16 @@ def get_tracklet_velocity_bystep(data, single_exposure_time = 30., min_alert_per
     length = 0.0
 
     # Get unique exposure
-    jd_unique = np.unique(data['jd'])
+    jd_unique = np.unique(data['i:jd'])
     n_exposure = len(jd_unique)
 
     # Treat the case where tracklets span several exposures
-    mask_exposure = np.ones_like(data['jd'], dtype=bool)
+    mask_exposure = np.ones_like(data['i:jd'], dtype=bool)
 
     if n_exposure > 1:
         # remove exposures with nalert < min_alert_per_exposure
         for k in jd_unique:
-            mask_ = data['jd'] == k
+            mask_ = data['i:jd'] == k
             l = np.sum(mask_)
             if l < min_alert_per_exposure:
                 mask_exposure[mask_] = False
@@ -875,17 +875,25 @@ def get_tracklet_velocity_bystep(data, single_exposure_time = 30., min_alert_per
 
         # Compute the time lapse between the start of the first and last exposure (0 if the same exposure)
         delta_jd_second = (
-            np.max(data['jd'][mask_exposure]) - np.min(data['jd'][mask_exposure])
+            np.max(data['i:jd'][mask_exposure]) - np.min(data['i:jd'][mask_exposure])
         ) * 24. * 3600.
 
         # add the last exposure time
         single_exposure_time = delta_jd_second + 30.
 
     # Sort data, and integrate the trajectory
-    data = data.sort_values('dec')
+    data = data.sort_values('i:dec')
     for i in range(len(data[mask_exposure]) - 1):
-        first = SkyCoord(data['ra'][mask_exposure][i], data['dec'][mask_exposure][i], unit='deg')
-        last = SkyCoord(data['ra'][mask_exposure][i+1], data['dec'][mask_exposure][i+1], unit='deg')
+        first = SkyCoord(
+            data['i:ra'][mask_exposure][i],
+            data['i:dec'][mask_exposure][i],
+            unit='deg'
+        )
+        last = SkyCoord(
+            data['i:ra'][mask_exposure][i+1],
+            data['i:dec'][mask_exposure][i+1],
+            unit='deg'
+        )
         length += first.separation(last).degree
 
     # return the velocity in deg/hour

--- a/assets/fink_types.csv
+++ b/assets/fink_types.csv
@@ -2,6 +2,7 @@ Early SN Ia candidate
 Kilonova candidate
 SN candidate
 Microlensing candidate
+Tracklet
 Solar System MPC
 Solar System candidate
 Ambiguous

--- a/index.py
+++ b/index.py
@@ -533,6 +533,7 @@ def display_skymap(validation, data, columns, activetab):
             'SN candidate': 'orange',
             'Kilonova candidate': 'blue',
             'Microlensing candidate': 'green',
+            'Tracklet': "rgb(204,255,204)",
             'Solar System MPC': "rgb(254,224,144)",
             'Solar System candidate': "rgb(171,217,233)",
             'Ambiguous': 'rgb(116,196,118)',

--- a/index.py
+++ b/index.py
@@ -1034,6 +1034,9 @@ def open_noresults(n, results, query, query_type, dropdown_option):
         elif query_type == 'SSO':
             header = "Search by Solar System Object ID"
             text = "{} ({}) not found".format(query, str(query).replace(' ', ''))
+        elif query_type == 'Tracklet':
+            header = "Search by Tracklet ID"
+            text = "{} not found".format(query)
         elif query_type == 'Conesearch':
             header = "Conesearch"
             text = "No alerts found for (RA, Dec, radius) = {}".format(

--- a/index.py
+++ b/index.py
@@ -24,7 +24,7 @@ import dash_trich_components as dtc
 
 from app import server
 from app import app
-from app import clientP
+from app import client
 
 from apps import home, summary, about, api
 from apps import __version__ as portal_version
@@ -435,7 +435,7 @@ def display_table_results(table, is_mobile):
           2. Table of results
         The dropdown is shown only if the table is non-empty.
     """
-    schema = clientP.schema()
+    schema = client.schema()
     schema_list = list(schema.columnNames())
     fink_fields = [i for i in schema_list if i.startswith('d:')]
     ztf_fields = [i for i in schema_list if i.startswith('i:')]

--- a/index.py
+++ b/index.py
@@ -116,10 +116,10 @@ Note for designation, you can also use space (2010 JO69 or C/2020 V2).
 ##### Tracklet data
 Search for Tracklet Objects in the Fink database.
 
-Tracklet data is available only from 20210810. You have the choice to specify:
-1. a tracklet ID, e.g. TRCK1682_00
+Tracklet data is available only from 2021-08-10. You have the choice to specify:
+1. a tracklet ID, e.g. TRCK1682_01
 2. a ZTF night ID, e.g. 1682
-3. a date at the format YYYYMMDD, e.g. 20210810
+3. a date at the format YYYY-MM-DD, e.g. 2021-08-10
 """
 
 msg_info = """
@@ -891,15 +891,15 @@ def results(ns, query, query_type, dropdown_option, is_mobile, results):
             payload = {
                 'id': query
             }
-        elif len(query.strip()) == 8:
-            # YYYYMMDD
+        elif len(query.strip()) == 10:
+            # YYYY-MM-DD
             payload = {
                 'date': '{}'.format(query)
             }
         else:
             # In this case, designation = NID
             payload = {
-                'date': 'TRCK{}'.format(query)
+                'id': 'TRCK{}'.format(query)
             }
 
         r = requests.post(

--- a/index.py
+++ b/index.py
@@ -632,6 +632,7 @@ def input_type(n1, n2, n3, n4, n5):
             {'label': 'Supernova candidates', 'value': 'SN candidate'},
             {'label': 'Kilonova candidates', 'value': 'Kilonova candidate'},
             {'label': 'Microlensing candidates', 'value': 'Microlensing candidate'},
+            {'label': 'Tracklet', 'value': 'Tracklet'},
             {'label': 'Solar System (MPC)', 'value': 'Solar System MPC'},
             {'label': 'Solar System (candidates)', 'value': 'Solar System candidate'},
             {'label': 'Ambiguous', 'value': 'Ambiguous'},


### PR DESCRIPTION
 

This PR exposes tracklet data to the users. A tracklet is a set of spatially connected alerts (typically belonging to the same exposure) from a fast moving object. This is somehow similar to solar system object, expect that these objects are mainly man-made and they typically orbit around the Earth. The tracklet data can be accessed in different ways:
- search by class
- search for tracklets

more information at http://134.158.75.151:24000/api.

## Search by class

Tracklets are an object class like the other classes. Hence you can look for these using the class search:

<img width="1440" alt="Screenshot 2021-08-25 at 20 56 00" src="https://user-images.githubusercontent.com/20426972/130848973-7e5d7520-735e-4320-a128-78a063589484.png">


In the API you would just use:

```python
import requests
import pandas as pd

# Get latests 100 alerts belonging to tracklet
r = requests.post(
  'http://134.158.75.151:24000/api/v1/latests',
  json={
    'class': 'Tracklet',
    'n': '100'
  }
)

# Format output in a DataFrame
pdf = pd.read_json(r.content)
```

Look for the column `pdf["tracklet"]` to find out individual tracklets.

## Search by Tracklet

You can  also perform a search for tracklets directly. Here you have the choice to specify: (1) a tracklet ID if you know if, or (2) a ZTF night ID, or (3) a date at the format YYYYMMDD.

<img width="1440" alt="Screenshot 2021-08-25 at 20 56 30" src="https://user-images.githubusercontent.com/20426972/130849026-60bee24a-4c7d-40ee-9e1f-33ad0bfe9d05.png">


In the API, you would use the `tracklet` endpoint:

```python
import requests
import pandas as pd

# Get all alerts corresponding to tracklets in the night 20210810
r = requests.post(
  'http://134.158.75.151:24000/api/v1/tracklet',
  json={
    'date': '20210810',
  }
)

# Format output in a DataFrame
pdf = pd.read_json(r.content)
```

## Tracklet data display

The tracklet data (if it exists) is displayed on the right most tab of an alert belonging to that tracklet:

<img width="1440" alt="Screenshot 2021-08-25 at 20 57 07" src="https://user-images.githubusercontent.com/20426972/130849123-64df68c0-d112-40b9-98a4-940699a712c0.png">


Alternatively, you can also display the tracklet when querying the results, using the Sky Map tab:

<img width="1427" alt="Screenshot 2021-08-25 at 20 57 43" src="https://user-images.githubusercontent.com/20426972/130849209-287254d0-01b3-4d37-8a8c-06989e83d400.png">

Todo: see #203 