### PR TITLE
Query Fink by URL

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -69,7 +69,7 @@ api_doc_summary = """
 | POST/GET | {}/api/v1/bayestar | Cross-match LIGO/Virgo sky map with Fink alert data| &#x2611;&#xFE0F; |
 | GET  | {}/api/v1/classes  | Display all Fink derived classification | &#x2611;&#xFE0F; |
 | GET  | {}/api/v1/columns  | Display all available alert fields and their type | &#x2611;&#xFE0F; |
-""".format(APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL)
+""".format(APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL)
 
 api_doc_object = """
 ## Retrieve single object data

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -884,7 +884,7 @@ def extract_query_url(search: str):
         query = '{}, {}, {}'.format(ra, dec, radius)
 
         if startdate != '' and window != '':
-            query += ', {}, {}'.format(startdate, window)
+            query += ', {}, {}'.format(startdate.replace('%20', ' '), window)
 
         dropdown_option = None
 

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -917,4 +917,12 @@ def extract_query_url(search: str):
         # conversion... I do not know why this is called Class in index.py
         query_type = 'Class'
 
+    elif query_type == 'SSO%20Search':
+        n_or_d = extract_parameter_value_from_url(param_dic, 'n_or_d', '')
+
+        query = n_or_d.replace('%20', ' ')
+        dropdown_option = None
+        # conversion... I do not know why this is called SSO in index.py
+        query_type = 'SSO'
+
     return query, query_type, dropdown_option

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -907,7 +907,13 @@ def extract_query_url(search: str):
         class_ = extract_parameter_value_from_url(param_dic, 'class', '')
 
         query = ''
+
         dropdown_option = class_.replace('%20', ' ')
+
+        # I changed the name on the interface, but not on the database...
+        if dropdown_option == 'Early SN Ia candidate':
+            dropdown_option = 'Early SN candidate'
+
         # conversion... I do not know why this is called Class in index.py
         query_type = 'Class'
 

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -825,6 +825,15 @@ def return_empty_query():
     """
     return '', '', None
 
+def extract_parameter_value_from_url(param_dic, key, default):
+    """
+    """
+    if key in param_dic:
+        val = param_dic[key]
+    else:
+        val = default
+    return val
+
 def extract_query_url(search: str):
     """ try to infer the query from an URL
 
@@ -859,11 +868,14 @@ def extract_query_url(search: str):
     query_type = param_dic['query_type']
 
     if query_type == 'objectID':
-        is_valid = 'objectID' in param_dic
+        query = extract_parameter_value_from_url(param_dic, 'objectID', None)
+        dropdown_option = None
+    elif query_type == 'Conesearch':
+        ra = extract_parameter_value_from_url(param_dic, 'ra', '')
+        dec = extract_parameter_value_from_url(param_dic, 'dec', '')
+        radius = extract_parameter_value_from_url(param_dic, 'radius', '')
 
-        if is_valid:
-            query = param_dic['objectID']
-            dropdown_option = None
-            return query, query_type, dropdown_option
-        else:
-            return return_empty_query()
+        query = '{}, {}, {}'.format(ra, dec, radius)
+        dropdown_option = None
+
+    return query, query_type, dropdown_option

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -906,7 +906,7 @@ def extract_query_url(search: str):
         # webpage (or URL query), one can only change the class... to be fixed
         class_ = extract_parameter_value_from_url(param_dic, 'class', '')
 
-        query = ''
+        query = class_.replace('%20', ' ')
 
         dropdown_option = class_.replace('%20', ' ')
 

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -874,8 +874,18 @@ def extract_query_url(search: str):
         ra = extract_parameter_value_from_url(param_dic, 'ra', '')
         dec = extract_parameter_value_from_url(param_dic, 'dec', '')
         radius = extract_parameter_value_from_url(param_dic, 'radius', '')
+        startdate = extract_parameter_value_from_url(
+            param_dic, 'startdate_conesearch', ''
+        )
+        window = extract_parameter_value_from_url(
+            param_dic, 'window_days_conesearch', ''
+        )
 
         query = '{}, {}, {}'.format(ra, dec, radius)
+
+        if startdate != '' and window != '':
+            query += ', {}, {}'.format(startdate, window)
+
         dropdown_option = None
 
     return query, query_type, dropdown_option

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -136,6 +136,14 @@ def markdownify_objectid(objectid):
 def validate_query(query, query_type):
     """ Validate a query. Need to be rewritten in a better way.
     """
+    empty_query_type = (query_type is None) or (query_type == '')
+
+    if empty_query_type:
+        # This can only happen in queries formed from URL parameters
+        header = "Empty query type"
+        text = "You need to specify a query_type in your request (e.g. ?query_type=Conesearch&ra=value&dec=value&radius=value)"
+        return {'flag': False, 'header': header, 'text': text}
+
     empty_query = (query is None) or (query == '')
 
     # no queries
@@ -811,3 +819,51 @@ def get_superpixels(idx, nside_subpix, nside_superpix, nest=False):
         idx[m] = -1
 
     return idx
+
+def return_empty_query():
+    """ Wrapper for malformed query from URL
+    """
+    return '', '', None
+
+def extract_query_url(search: str):
+    """ try to infer the query from an URL
+
+    Parameters
+    ----------
+    search: str
+        String returned by `dcc.Location.search` property.
+        Typically starts with ?
+
+    Returns
+    ----------
+    query: str
+        The query formed by the args in the URL
+    query_type: str
+        The type of query (objectID, SSO, Conesearch, etc.)
+    dropdown_option: str
+        Parameter value used in `Date` or `Class` search.
+    """
+    # remove trailing ?
+    search = search[1:]
+
+    # split parameters
+    parameters = search.split('&')
+
+    # Make a dictionary with the parameter keys and values
+    param_dic = {s.split('=')[0]: s.split('=')[1] for s in parameters}
+
+    # if the user forgot to specify the query type
+    if 'query_type' not in param_dic:
+        return_empty_query()
+
+    query_type = param_dic['query_type']
+
+    if query_type == 'objectID':
+        is_valid = 'objectID' in param_dic
+
+        if is_valid:
+            query = param_dic['objectID']
+            dropdown_option = None
+            return query, query_type, dropdown_option
+        else:
+            return_empty_query()

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -897,4 +897,13 @@ def extract_query_url(search: str):
         # conversion... I do not know why this is called Date in index.py
         query_type = 'Date'
 
+    elif query_type == 'Class%20Search':
+        class_ = extract_parameter_value_from_url(param_dic, 'class', '')
+        n = extract_parameter_value_from_url(param_dic, 'n', '')
+
+        query = class_.replace('%20', ' ')
+        dropdown_option = n
+        # conversion... I do not know why this is called Class in index.py
+        query_type = 'Class'
+
     return query, query_type, dropdown_option

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -898,8 +898,15 @@ def extract_query_url(search: str):
         query_type = 'Date'
 
     elif query_type == 'Class%20Search':
+        # This one is weird. The Class search has 4 parameters: class, n,
+        # startdate, stopdate.
+        # But from the webpage, the user can only select the class. The other
+        # parameters are fixed (n=100, startdate=2019, stopdate=now).
+        # Of course using the API, one can do whatever, but using the
+        # webpage (or URL query), one can only change the class... to be fixed
         class_ = extract_parameter_value_from_url(param_dic, 'class', '')
 
+        query = ''
         dropdown_option = class_.replace('%20', ' ')
         # conversion... I do not know why this is called Class in index.py
         query_type = 'Class'

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -899,10 +899,8 @@ def extract_query_url(search: str):
 
     elif query_type == 'Class%20Search':
         class_ = extract_parameter_value_from_url(param_dic, 'class', '')
-        n = extract_parameter_value_from_url(param_dic, 'n', '')
 
-        query = class_.replace('%20', ' ')
-        dropdown_option = n
+        dropdown_option = class_.replace('%20', ' ')
         # conversion... I do not know why this is called Class in index.py
         query_type = 'Class'
 

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -888,4 +888,12 @@ def extract_query_url(search: str):
 
         dropdown_option = None
 
+    elif query_type == 'Date%20Search':
+        startdate = extract_parameter_value_from_url(param_dic, 'startdate', '')
+        window = extract_parameter_value_from_url(param_dic, 'window', '')
+
+        query = '{}'.format(startdate.replace('%20', ' '))
+        dropdown_option = window
+        query_type = query_type.replace('%20', ' ')
+
     return query, query_type, dropdown_option

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -854,7 +854,7 @@ def extract_query_url(search: str):
 
     # if the user forgot to specify the query type
     if 'query_type' not in param_dic:
-        return_empty_query()
+        return return_empty_query()
 
     query_type = param_dic['query_type']
 
@@ -866,4 +866,4 @@ def extract_query_url(search: str):
             dropdown_option = None
             return query, query_type, dropdown_option
         else:
-            return_empty_query()
+            return return_empty_query()

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -894,6 +894,7 @@ def extract_query_url(search: str):
 
         query = '{}'.format(startdate.replace('%20', ' '))
         dropdown_option = window
-        query_type = query_type.replace('%20', ' ')
+        # conversion... I do not know why this is called Date in index.py
+        query_type = 'Date'
 
     return query, query_type, dropdown_option

--- a/index.py
+++ b/index.py
@@ -982,15 +982,21 @@ noresults_toast = html.Div(
         Input("search_bar_input", "value"),
         Input("dropdown-query", "label"),
         Input("select", "value"),
+        Input("url", "search")
     ]
 )
-def open_noresults(n, results, query, query_type, dropdown_option):
+def open_noresults(n, results, query, query_type, dropdown_option, searchurl):
     """ Toast to warn the user about the fact that we found no results
     """
     # Trigger the query only if the submit button is pressed.
     changed_id = [p['prop_id'] for p in dash.callback_context.triggered][0]
-    if 'submit' not in changed_id or results is None:
+    if ('submit' not in changed_id and searchurl == '') or results is None:
         raise PreventUpdate
+
+    # catch parameters sent from URL
+    # override any other options
+    if searchurl != '':
+        query, query_type, dropdown_option = extract_query_url(searchurl)
 
     validation = validate_query(query, query_type)
     if not validation['flag']:

--- a/index.py
+++ b/index.py
@@ -687,10 +687,11 @@ def on_button_click(n1, n2, n3, n4, n5, val):
 @app.callback(
     Output("logo", "children"),
     [
-        Input("submit", "n_clicks")
+        Input("submit", "n_clicks"),
+        Input("url", "search")
     ],
 )
-def logo(ns):
+def logo(ns, searchurl):
     """ Show the logo in the start page (and hide it otherwise)
     """
     ctx = dash.callback_context
@@ -714,7 +715,7 @@ def logo(ns):
     else:
         button_id = ctx.triggered[0]["prop_id"].split(".")[0]
 
-    if button_id == "submit":
+    if button_id == "submit" or searchurl != '':
         return []
     else:
         return logo

--- a/index.py
+++ b/index.py
@@ -682,7 +682,7 @@ def on_button_click(n1, n2, n3, n4, n5, val):
     elif button_id == "dropdown-menu-item-5":
         return "Enter a valid IAU number. See Help for more information", "SSO", val
     else:
-        return "Valid object ID", "objectID", ""
+        return "Valid ZTF object ID", "objectID", ""
 
 @app.callback(
     Output("logo", "children"),

--- a/index.py
+++ b/index.py
@@ -665,7 +665,7 @@ def on_button_click(n1, n2, n3, n4, n5, val):
     """
     ctx = dash.callback_context
 
-    default = "Enter a valid object ID or choose another query type"
+    default = "Enter a valid ZTF object ID or choose another query type"
     if not ctx.triggered:
         return default, "objectID", ""
     else:

--- a/index.py
+++ b/index.py
@@ -24,7 +24,7 @@ import dash_trich_components as dtc
 
 from app import server
 from app import app
-from app import clientP
+from app import client
 from app import APIURL
 
 from apps import home, summary, about, api
@@ -435,7 +435,7 @@ def display_table_results(table, is_mobile):
           2. Table of results
         The dropdown is shown only if the table is non-empty.
     """
-    schema = clientP.schema()
+    schema = client.schema()
     schema_list = list(schema.columnNames())
     fink_fields = [i for i in schema_list if i.startswith('d:')]
     ztf_fields = [i for i in schema_list if i.startswith('i:')]
@@ -988,7 +988,7 @@ def open_noresults(n, results, query, query_type, dropdown_option):
     """
     # Trigger the query only if the submit button is pressed.
     changed_id = [p['prop_id'] for p in dash.callback_context.triggered][0]
-    if 'submit' not in changed_id:
+    if 'submit' not in changed_id or results is None:
         raise PreventUpdate
 
     validation = validate_query(query, query_type)

--- a/index.py
+++ b/index.py
@@ -25,13 +25,13 @@ import dash_trich_components as dtc
 from app import server
 from app import app
 from app import clientP
+from app import APIURL
 
 from apps import home, summary, about, api
 from apps import __version__ as portal_version
 
 from apps.utils import markdownify_objectid
-from app import APIURL
-from apps.utils import isoify_time, validate_query
+from apps.utils import isoify_time, validate_query, extract_query_url
 from apps.plotting import draw_cutouts_quickview, draw_lightcurve_preview
 
 import requests
@@ -822,10 +822,11 @@ def update_table(field_dropdown, data, columns):
         Input("dropdown-query", "label"),
         Input("select", "value"),
         Input("is-mobile", "children"),
+        Input('url', 'search')
     ],
     State("results", "children")
 )
-def results(ns, query, query_type, dropdown_option, is_mobile, results):
+def results(ns, query, query_type, dropdown_option, is_mobile, searchurl, results):
     """ Query the database from the search input
 
     Returns
@@ -842,8 +843,13 @@ def results(ns, query, query_type, dropdown_option, is_mobile, results):
     ctx = dash.callback_context
     button_id = ctx.triggered[0]["prop_id"].split(".")[0]
 
-    if button_id != "submit":
+    if button_id != "submit" and searchurl == '':
         raise PreventUpdate
+
+    # catch parameters sent from URL
+    # override any other options
+    if searchurl != '':
+        query, query_type, dropdown_option = extract_query_url(searchurl)
 
     is_ok = validate_query(query, query_type)
     if not is_ok['flag']:

--- a/index.py
+++ b/index.py
@@ -925,11 +925,18 @@ def results(ns, query, query_type, dropdown_option, is_mobile, searchurl, result
     pdf = pd.read_json(r.content)
 
     if pdf.empty:
-        return dash_table.DataTable(
-            data=[],
-            columns=[],
-            id='result_table'
-        ), 0
+        if searchurl != '':
+            return dbc.Alert(
+                "No alerts found using the {} type: {}".format(query_type, query),
+                color="info",
+                dismissable=True
+            ), 0
+        else:
+            return dash_table.DataTable(
+                data=[],
+                columns=[],
+                id='result_table'
+            ), 0
     else:
         # Make clickable objectId
         pdf['i:objectId'] = pdf['i:objectId'].apply(markdownify_objectid)

--- a/index.py
+++ b/index.py
@@ -710,7 +710,7 @@ def logo(ns, searchurl):
         ),
         html.Br()
     ]
-    if not ctx.triggered:
+    if not ctx.triggered and searchurl == '':
         return logo
     else:
         button_id = ctx.triggered[0]["prop_id"].split(".")[0]


### PR DESCRIPTION
This PR allows to query Fink via an URL. Some example:

### Object ID search

```
https://fink-portal.org/?query_type=objectID&objectID=ZTF21abfmbix
```

### Conesearch

```
https://fink-portal.org/?query_type=Conesearch&ra=193.822&dec=2.89732&radius=5&startdate_conesearch=2021-07-01 05:59:36&window_days_conesearch=1
```

Note that `startdate_conesearch` and `window_days_conesearch` are optional.

### Class search

```
https://fink-portal.org/?query_type=Date Search&startdate=2020-07-01%2005:59:36&window=1
```

### Solar system object search

```
https://fink-portal.org/?query_type=SSO Search&n_or_d=4209
```

## Missing

- [ ] Add documentation