### PR TITLE
Fix classname for early sn ia candidates

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -1667,6 +1667,11 @@ def latest_objects():
             classname = request.json['class'].split('(SIMBAD) ')[1]
         else:
             classname = request.json['class']
+
+        if classname == 'Early SN Ia candidate':
+            # ugly fix. In the database,
+            # we made a typo that is not fixed.
+            classname = 'Early SN candidate'
         clientS.setLimit(nalerts)
         clientS.setRangeScan(True)
         clientS.setReversed(True)


### PR DESCRIPTION
Manually fix a typo in the database: `Early SN Ia candidate` should be interpreted as `Early SN candidate` from the point of view of the database.