### PR TITLE
Add a new page with statistics

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -33,6 +33,7 @@ from apps.utils import format_hbase_output
 from apps.utils import extract_cutouts
 from apps.utils import get_superpixels
 from apps.plotting import legacy_normalizer, convolve, sigmoid_normalizer
+from apps.statistics import dic_names
 
 import io
 import requests
@@ -943,10 +944,10 @@ import pandas as pd
 # get stats for all the year 2021
 r = requests.post(
   'https://fink-portal.org/api/v1/statistics',
-  json={
+  json={{
     'date': '2021',
     'output-format': 'json'
-  }
+  }}
 )
 
 # Format output in a DataFrame
@@ -954,7 +955,12 @@ pdf = pd.read_json(r.content)
 ```
 
 Note `date` can be either a given night (YYYYMMDD), month (YYYYMM), year (YYYY), or eveything (empty string).
-"""
+The schema of the dataframe is the following:
+
+{}
+
+All other fields starting with `class:` are crossmatch from the SIMBAD database.
+""".format(pd.DataFrame([dic_names]).T.rename(columns={0: 'description'}).to_markdown())
 
 def layout(is_mobile):
     if is_mobile:

--- a/apps/api.py
+++ b/apps/api.py
@@ -930,6 +930,8 @@ plt.show()
 """
 
 api_doc_stats = """
+## Fink data statistics
+
 The [statistics](https://fink-portal.org/stats) page makes use of the REST API.
 If you want to further explore Fink statistics, or create your own dashboard based on Fink data,
 you can do also all of these yourself using the REST API. Here is an example using Python:

--- a/apps/api.py
+++ b/apps/api.py
@@ -2339,7 +2339,7 @@ def query_bayestar():
 def query_statistics_arguments():
     """ Obtain information about Fink statistics
     """
-    return jsonify({'args': args_statistics})
+    return jsonify({'args': args_stats})
 
 @api_bp.route('/api/v1/statistics', methods=['POST'])
 def return_statistics():

--- a/apps/api.py
+++ b/apps/api.py
@@ -27,6 +27,7 @@ from app import clientP128, clientP4096, clientP131072
 from app import clientT, clientS
 from app import clientSSO, clientTNS
 from app import clientU, clientUV, nlimit
+from app import clientStats
 from app import APIURL
 from apps.utils import format_hbase_output
 from apps.utils import extract_cutouts
@@ -66,9 +67,10 @@ api_doc_summary = """
 | POST/GET | {}/api/v1/cutouts | Retrieve cutout data from the Fink database| &#x2611;&#xFE0F; |
 | POST/GET | {}/api/v1/xmatch | Cross-match user-defined catalog with Fink alert data| &#x2611;&#xFE0F; |
 | POST/GET | {}/api/v1/bayestar | Cross-match LIGO/Virgo sky map with Fink alert data| &#x2611;&#xFE0F; |
+| POST/GET | {}/api/v1/statistics | Statistics concerning Fink alert data| &#x2611;&#xFE0F; |
 | GET  | {}/api/v1/classes  | Display all Fink derived classification | &#x2611;&#xFE0F; |
 | GET  | {}/api/v1/columns  | Display all available alert fields and their type | &#x2611;&#xFE0F; |
-""".format(APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL)
+""".format(APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL, APIURL)
 
 api_doc_object = """
 ## Retrieve single object data
@@ -927,6 +929,31 @@ plt.show()
 ![gw](https://user-images.githubusercontent.com/20426972/134175884-3b190fa9-8051-4a1d-8bf8-cc8b47252494.png)
 """
 
+api_doc_stats = """
+The [statistics](https://fink-portal.org/stats) page makes use of the REST API.
+If you want to further explore Fink statistics, or create your own dashboard based on Fink data,
+you can do also all of these yourself using the REST API. Here is an example using Python:
+
+```python
+import requests
+import pandas as pd
+
+# get stats for all the year 2021
+r = requests.post(
+  'https://fink-portal.org/api/v1/statistics',
+  json={
+    'date': '2021',
+    'output-format': 'json'
+  }
+)
+
+# Format output in a DataFrame
+pdf = pd.read_json(r.content)
+```
+
+Note `date` can be either a given night (YYYYMMDD), month (YYYYMM), year (YYYY), or eveything (empty string).
+"""
+
 def layout(is_mobile):
     if is_mobile:
         width = '95%'
@@ -1029,6 +1056,17 @@ def layout(is_mobile):
                                         }
                                     ),
                                 ], label="Gravitational Waves"
+                            ),
+                            dbc.Tab(
+                                [
+                                    dbc.Card(
+                                        dbc.CardBody(
+                                            dcc.Markdown(api_doc_stats)
+                                        ), style={
+                                            'backgroundColor': 'rgb(248, 248, 248, .7)'
+                                        }
+                                    ),
+                                ], label="Statistics"
                             ),
                         ]
                     )
@@ -1254,6 +1292,24 @@ args_bayestar = [
         'name': 'credible_level',
         'required': True,
         'description': 'GW credible region threshold to look for. Note that the values in the resulting credible level map vary inversely with probability density: the most probable pixel is assigned to the credible level 0.0, and the least likely pixel is assigned the credible level 1.0.'
+    },
+    {
+        'name': 'output-format',
+        'required': False,
+        'description': 'Output format among json[default], csv, parquet'
+    }
+]
+
+args_stats = [
+    {
+        'name': 'date',
+        'required': True,
+        'description': 'Observing date. This can be either a given night (YYYYMMDD), month (YYYYMM), year (YYYY), or eveything (empty string)'
+    },
+    {
+        'name': 'columns',
+        'required': False,
+        'description': 'Comma-separated data columns to transfer. Default is all columns. See {}/api/v1/columns for more information.'.format(APIURL)
     },
     {
         'name': 'output-format',
@@ -2274,5 +2330,54 @@ def query_bayestar():
     rep = {
         'status': 'error',
         'text': "Output format `{}` is not supported. Choose among json, csv, or parquet\n".format(request.json['output-format'])
+    }
+    return Response(str(rep), 400)
+
+@api_bp.route('/api/v1/statistics', methods=['GET'])
+def query_statistics_arguments():
+    """ Obtain information about Fink statistics
+    """
+    return jsonify({'args': args_statistics})
+
+@api_bp.route('/api/v1/statistics', methods=['POST'])
+def return_statistics():
+    """ Retrieve statistics about Fink data
+    """
+    if 'output-format' in request.json:
+        output_format = request.json['output-format']
+    else:
+        output_format = 'json'
+
+    if 'columns' in request.json:
+        cols = request.json['columns'].replace(" ", "")
+    else:
+        cols = '*'
+
+    payload = request.json['date']
+
+    to_evaluate = "key:key:ztf_{}".format(payload)
+
+    results = clientStats.scan(
+        "",
+        to_evaluate,
+        cols,
+        0, True, True
+    )
+
+    pdf = pd.DataFrame.from_dict(results, orient='index')
+
+    if output_format == 'json':
+        return pdf.to_json(orient='records')
+    elif output_format == 'csv':
+        return pdf.to_csv(index=False)
+    elif output_format == 'parquet':
+        f = io.BytesIO()
+        pdf.to_parquet(f)
+        f.seek(0)
+        return f.read()
+
+    rep = {
+        'status': 'error',
+        'text': "Output format `{}` is not supported. Choose among json, csv, or parquet\n".format(output_format)
     }
     return Response(str(rep), 400)

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2454,6 +2454,47 @@ def hist_classified(pathname, dropdown_days):
     return card
 
 @app.callback(
+    Output('hist_candidates', 'children'),
+    [
+        Input('url', 'pathname'),
+        Input('dropdown_days', 'value'),
+    ]
+)
+def hist_candidates(pathname, dropdown_days):
+    """ Make an histogram
+    """
+    results = clientStats.scan(
+        "",
+        "key:key:ztf_",
+        'class:Solar System candidate,class:SN candidate,class:Early SN candidate,class:Kilonova candidate',
+        0,
+        False,
+        False
+    )
+
+    # Construct the dataframe
+    pdf = pd.DataFrame.from_dict(results, orient='index')
+
+    pdf = pdf.rename(
+        columns={
+            'class:Solar System candidate': 'SSO',
+            'class:SN candidate': 'SNe',
+            'class:Early SN candidate': 'SN Ia',
+            'class:Kilonova candidate': 'Kilonova'
+        }
+    )
+
+    if dropdown_days is None or dropdown_days == '':
+        dropdown_days = pdf.index[-1]
+    pdf = pdf[pdf.index == dropdown_days]
+
+    card = make_daily_card(
+        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)', title='Candidates'
+    )
+
+    return card
+
+@app.callback(
     Output('daily_classification', 'children'),
     [
         Input('url', 'pathname'),

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2070,9 +2070,12 @@ def plot_stat_evolution(pathname, param_name):
         y=newcol,
         x='date',
         text=newcol,
-        color='rgb(21, 40, 79)'
     )
-    fig.update_traces(texttemplate='%{text:.2s}', textposition='outside')
+    fig.update_traces(
+        texttemplate='%{text:.2s}',
+        textposition='outside',
+        marker_color='rgb(21, 40, 79)'
+    )
     fig.update_layout(
         uniformtext_minsize=8,
         uniformtext_mode='hide',

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -41,7 +41,7 @@ from pyLIMA import telescopes
 from pyLIMA import microlmodels, microltoolbox
 from pyLIMA.microloutputs import create_the_fake_telescopes
 
-from app import client, app, clientSSO
+from app import client, app, clientSSO, clientStats
 
 # colors_ = [
 #     '#1f77b4',  # muted blue
@@ -2034,15 +2034,29 @@ def plot_heatmap(pathname, object_stats):
     Output('evolution', 'children'),
     [
         Input('url', 'pathname'),
-        Input('object-stats', 'children')
+        Input('dropdown_params', 'value'),
     ]
 )
-def plot_stat_evolution(pathname, object_stats):
+def plot_stat_evolution(pathname, param_name):
     """ Plot evolution of parameters as a function of time
 
     TODO: connect the callback to a dropdown button to choose the parameter
     """
-    pdf = pd.read_json(object_stats)
+    if param_name is None or param_name == '':
+        param_name = 'basic:sci'
+
+    col = '{}'.format(param_name)
+    results = clientStats.scan(
+        "",
+        "key:key:ztf_",
+        col,
+        0,
+        True,
+        True
+    )
+
+    # Construct the dataframe
+    pdf = pd.DataFrame.from_dict(results, orient='index')
 
     pdf['date'] = [
         Time(x[4:8] + '-' + x[8:10] + '-' + x[10:12]).datetime

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2441,6 +2441,8 @@ def hist_classified(pathname, dropdown_days):
     pdf = pdf.rename(columns={'class:Unknown': 'unclassified'})
     pdf = pdf.drop(columns=['basic:sci'])
 
+    pdf = pdf.rename(columns={i: i.split(':')[1] for i in pdf.columns})
+
     if dropdown_days is None or dropdown_days == '':
         dropdown_days = pdf.index[-1]
     pdf = pdf[pdf.index == dropdown_days]

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2446,7 +2446,7 @@ def hist_classified(pathname, dropdown_days):
     pdf = pdf[pdf.index == dropdown_days]
 
     card = make_daily_card(
-        pdf, color='rgb(245, 98, 46)', linecolor='rgb(135, 86, 69)'
+        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)'
     )
 
     return card

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2050,8 +2050,8 @@ def plot_stat_evolution(pathname, param_name):
         "key:key:ztf_",
         param_name,
         0,
-        True,
-        True
+        False,
+        False
     )
 
     # Construct the dataframe
@@ -2304,3 +2304,15 @@ def display_years(pdf, years):
         # Fix the height
         fig.update_layout(height=200 * len(years))
     return fig
+
+@app.callback(
+    Output('hist_sci_raw', 'children'),
+    [
+        Input('url', 'pathname'),
+        Input('dropdown_days', 'value'),
+    ]
+)
+def hist_sci_raw(pathname, dropdown_days):
+    """ Make an histogram
+    """
+    pass

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2035,9 +2035,10 @@ def plot_heatmap(pathname, object_stats):
     [
         Input('url', 'pathname'),
         Input('dropdown_params', 'value'),
+        Input('switch-cumulative', 'value'),
     ]
 )
-def plot_stat_evolution(pathname, param_name):
+def plot_stat_evolution(pathname, param_name, switch):
     """ Plot evolution of parameters as a function of time
 
     TODO: connect the callback to a dropdown button to choose the parameter
@@ -2064,6 +2065,9 @@ def plot_stat_evolution(pathname, param_name):
 
     newcol = 'Processed {}'.format(param_name.split(':')[1])
     pdf = pdf.rename(columns={param_name: newcol})
+
+    if switch == [1]:
+        pdf[newcol] = pdf[newcol].cumsum()
 
     fig = px.bar(
         pdf,
@@ -2528,7 +2532,7 @@ def fields_exposures(pathname, dropdown_days):
     card = make_daily_card(
         pdf,
         color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)',
-        title='Individual classifications (zoom in to see details)',
+        title='Individual classifications (zoom in to see more details)',
         height='20pc', scale='log'
     )
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2318,7 +2318,7 @@ def hist_sci_raw(pathname, dropdown_days):
     results = clientStats.scan(
         "",
         "key:key:ztf_",
-        'basic:raw,basic:raw',
+        'basic:raw,basic:sci',
         0,
         False,
         False
@@ -2337,25 +2337,25 @@ def hist_sci_raw(pathname, dropdown_days):
         ]
     )
 
-    fig.update_traces(texttemplate='%{text:.2s}', textposition='outside')
-    fig.update_layout(
-        uniformtext_minsize=8,
-        uniformtext_mode='hide',
-        showlegend=True
-    )
     fig.update_layout(
         title='',
         margin=dict(t=0, r=0, b=0, l=0),
-        showlegend=True,
+        showlegend=False,
         paper_bgcolor='rgba(0,0,0,0)',
         plot_bgcolor='rgba(0,0,0,0)'
+    )
+
+    fig.update_traces(
+        marker_color='rgb(158,202,225)',
+        marker_line_color='rgb(8,48,107)',
+        marker_line_width=1.5, opacity=0.6
     )
 
     graph = dcc.Graph(
         figure=fig,
         style={
             'width': '100%',
-            'height': '25pc'
+            'height': '15pc'
         },
         config={'displayModeBar': False}
     )

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2489,7 +2489,7 @@ def hist_candidates(pathname, dropdown_days):
     pdf = pdf[pdf.index == dropdown_days]
 
     card = make_daily_card(
-        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)', title='Selected candidates'
+        pdf, color='rgb(213, 213, 211)', linecolor='rgb(138, 138, 132)', title='Selected candidates'
     )
 
     return card

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2441,8 +2441,6 @@ def hist_classified(pathname, dropdown_days):
     pdf = pdf.rename(columns={'class:Unknown': 'unclassified'})
     pdf = pdf.drop(columns=['basic:sci'])
 
-    pdf = pdf.rename(columns={i: i.split(':')[1] for i in pdf.columns})
-
     if dropdown_days is None or dropdown_days == '':
         dropdown_days = pdf.index[-1]
     pdf = pdf[pdf.index == dropdown_days]
@@ -2477,6 +2475,8 @@ def fields_exposures(pathname, dropdown_days):
 
     to_drop = [i for i in pdf.columns if i.startswith('basic:')]
     pdf = pdf.drop(columns=to_drop)
+
+    pdf = pdf.rename(columns={i: i.split(':')[1] for i in pdf.columns})
 
     if dropdown_days is None or dropdown_days == '':
         dropdown_days = pdf.index[-1]

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2412,7 +2412,7 @@ def hist_catalogued(pathname, dropdown_days):
     pdf = pdf[pdf.index == dropdown_days]
 
     card = make_daily_card(
-        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)', title='Catalogs'
+        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)', title='External catalogs'
     )
 
     return card

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2410,7 +2410,7 @@ def hist_catalogued(pathname, dropdown_days):
     pdf = pdf[pdf.index == dropdown_days]
 
     card = make_daily_card(
-        pdf, color='rgb(245, 98, 46)', linecolor='rgb(135, 86, 69)'
+        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)'
     )
 
     return card
@@ -2446,7 +2446,7 @@ def hist_classified(pathname, dropdown_days):
     pdf = pdf[pdf.index == dropdown_days]
 
     card = make_daily_card(
-        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)'
+        pdf, color='rgb(245, 98, 46)', linecolor='rgb(135, 86, 69)'
     )
 
     return card

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2375,6 +2375,8 @@ def hist_sci_raw(pathname, dropdown_days):
         dropdown_days = pdf.index[-1]
     pdf = pdf[pdf.index == dropdown_days]
 
+    pdf = pdf.rename(columns={'basic:raw': 'Received', 'basic:sci': 'Processed'})
+
     card = make_daily_card(
         pdf, color='rgb(158,202,225)', linecolor='rgb(8,48,107)'
     )
@@ -2437,8 +2439,8 @@ def hist_classified(pathname, dropdown_days):
     # Construct the dataframe
     pdf = pd.DataFrame.from_dict(results, orient='index')
 
-    pdf['classified'] = pdf['basic:sci'].astype(int) - pdf['class:Unknown'].astype(int)
-    pdf = pdf.rename(columns={'class:Unknown': 'unclassified'})
+    pdf['Classified'] = pdf['basic:sci'].astype(int) - pdf['class:Unknown'].astype(int)
+    pdf = pdf.rename(columns={'class:Unknown': 'Unclassified'})
     pdf = pdf.drop(columns=['basic:sci'])
 
     if dropdown_days is None or dropdown_days == '':

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2315,4 +2315,50 @@ def display_years(pdf, years):
 def hist_sci_raw(pathname, dropdown_days):
     """ Make an histogram
     """
-    pass
+    results = clientStats.scan(
+        "",
+        "key:key:ztf_",
+        'basic:raw,basic:raw',
+        0,
+        False,
+        False
+    )
+
+    # Construct the dataframe
+    pdf = pd.DataFrame.from_dict(results, orient='index')
+
+    pdf = pdf[pdf.index == dropdown_days]
+
+    fig = go.Figure(
+        [
+            go.Bar(x=pdf.columns, y=pdf.values[0])
+        ]
+    )
+
+    fig.update_traces(texttemplate='%{text:.2s}', textposition='outside')
+    fig.update_layout(
+        uniformtext_minsize=8,
+        uniformtext_mode='hide',
+        showlegend=True
+    )
+    fig.update_layout(
+        title='',
+        margin=dict(t=0, r=0, b=0, l=0),
+        showlegend=True,
+        paper_bgcolor='rgba(0,0,0,0)',
+        plot_bgcolor='rgba(0,0,0,0)'
+    )
+
+    graph = dcc.Graph(
+        figure=fig,
+        style={
+            'width': '100%',
+            'height': '25pc'
+        },
+        config={'displayModeBar': False}
+    )
+    card = dbc.Card(
+        dbc.CardBody(graph),
+        className="mt-3"
+    )
+    return card

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -34,6 +34,7 @@ import dash_html_components as html
 
 from apps.utils import convert_jd, readstamp, _data_stretch, convolve
 from apps.utils import apparent_flux, dc_mag
+from apps.statistics import dic_names
 from app import APIURL
 
 from pyLIMA import event
@@ -2063,7 +2064,11 @@ def plot_stat_evolution(pathname, param_name, switch):
         for x in pdf.index.values
     ]
 
-    newcol = 'Processed {}'.format(param_name.split(':')[1])
+    if param_name in dic_names:
+        newcol = dic_names[param_name]
+    else:
+        newcol = param_name.replace('class', 'SIMBAD')
+
     pdf = pdf.rename(columns={param_name: newcol})
 
     if switch == [1]:

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2069,7 +2069,8 @@ def plot_stat_evolution(pathname, param_name):
         pdf,
         y=newcol,
         x='date',
-        text=newcol
+        text=newcol,
+        marker_color='rgb(21, 40, 79)'
     )
     fig.update_traces(texttemplate='%{text:.2s}', textposition='outside')
     fig.update_layout(

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2045,11 +2045,10 @@ def plot_stat_evolution(pathname, param_name):
     if param_name is None or param_name == '':
         param_name = 'basic:sci'
 
-    col = '{}'.format(param_name)
     results = clientStats.scan(
         "",
         "key:key:ztf_",
-        col,
+        param_name,
         0,
         True,
         True
@@ -2063,8 +2062,8 @@ def plot_stat_evolution(pathname, param_name):
         for x in pdf.index.values
     ]
 
-    newcol = 'Processed alerts'
-    pdf = pdf.rename(columns={'basic:sci': newcol})
+    newcol = 'Processed {}'.format(param_name.split(':')[1])
+    pdf = pdf.rename(columns={param_name: newcol})
 
     fig = px.bar(
         pdf,

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2466,7 +2466,7 @@ def hist_classified(pathname, dropdown_days):
 
     pdf['classified'] = pdf['basic:sci'] - pdf['class:Unknown']
     pdf = pdf.rename(columns={'class:Unknown': 'unclassified'})
-    pdf = pdf.drop(['basic:sci'])
+    pdf = pdf.drop(colummns=['basic:sci'])
 
     if dropdown_days is None or dropdown_days == '':
         dropdown_days = pdf.index[-1]
@@ -2501,7 +2501,7 @@ def fields_exposures(pathname, dropdown_days):
     pdf = pd.DataFrame.from_dict(results, orient='index')
 
     to_drop = [i for i in pdf.columns if i.startswith('basic:')]
-    pdf = pdf.drop(to_drop)
+    pdf = pdf.drop(columns=to_drop)
 
     if dropdown_days is None or dropdown_days == '':
         dropdown_days = pdf.index[-1]

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2354,7 +2354,7 @@ def make_daily_card(pdf, color, linecolor, title, height='12pc', scale='lin'):
         config={'displayModeBar': False}
     )
     card = dbc.Card(
-        dbc.CardBody(graph),
+        dbc.CardBody([html.H6(title, className="card-subtitle"), graph]),
         className="mt-3"
     )
     return card

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2309,7 +2309,7 @@ def display_years(pdf, years):
         fig.update_layout(height=200 * len(years))
     return fig
 
-def make_daily_card(pdf, color, linecolor, height='12pc', scale='lin'):
+def make_daily_card(pdf, color, linecolor, title, height='12pc', scale='lin'):
     """
     """
     fig = go.Figure(
@@ -2330,6 +2330,16 @@ def make_daily_card(pdf, color, linecolor, height='12pc', scale='lin'):
         marker_color=color,
         marker_line_color=linecolor,
         marker_line_width=1.5, opacity=0.6
+    )
+
+    fig.update_layout(
+        title={
+            'text': title,
+            'y': 0.995,
+            'x': 0.5,
+            'xanchor': 'center',
+            'yanchor': 'top'
+        }
     )
 
     if scale == 'log':
@@ -2378,7 +2388,7 @@ def hist_sci_raw(pathname, dropdown_days):
     pdf = pdf.rename(columns={'basic:raw': 'Received', 'basic:sci': 'Processed'})
 
     card = make_daily_card(
-        pdf, color='rgb(158,202,225)', linecolor='rgb(8,48,107)'
+        pdf, color='rgb(158,202,225)', linecolor='rgb(8,48,107)', title='Quality cuts'
     )
 
     return card
@@ -2412,7 +2422,7 @@ def hist_catalogued(pathname, dropdown_days):
     pdf = pdf[pdf.index == dropdown_days]
 
     card = make_daily_card(
-        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)'
+        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)', title='Catalogs'
     )
 
     return card
@@ -2448,7 +2458,7 @@ def hist_classified(pathname, dropdown_days):
     pdf = pdf[pdf.index == dropdown_days]
 
     card = make_daily_card(
-        pdf, color='rgb(245, 98, 46)', linecolor='rgb(135, 86, 69)'
+        pdf, color='rgb(245, 98, 46)', linecolor='rgb(135, 86, 69)', title='Classification'
     )
 
     return card
@@ -2485,7 +2495,10 @@ def fields_exposures(pathname, dropdown_days):
     pdf = pdf[pdf.index == dropdown_days]
 
     card = make_daily_card(
-        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)', height='20pc', scale='log'
+        pdf,
+        color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)',
+        title='Individual classifications (zoom in to see details)',
+        height='20pc', scale='log'
     )
 
     return card

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2070,7 +2070,7 @@ def plot_stat_evolution(pathname, param_name):
         y=newcol,
         x='date',
         text=newcol,
-        marker_color='rgb(21, 40, 79)'
+        color='rgb(21, 40, 79)'
     )
     fig.update_traces(texttemplate='%{text:.2s}', textposition='outside')
     fig.update_layout(

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2050,7 +2050,7 @@ def plot_stat_evolution(pathname, object_stats):
     ]
 
     newcol = 'Processed alerts'
-    pdf = pdf.rename(columns={col: newcol})
+    pdf = pdf.rename(columns={'basic:sci': newcol})
 
     fig = px.bar(
         pdf,

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2309,7 +2309,7 @@ def display_years(pdf, years):
         fig.update_layout(height=200 * len(years))
     return fig
 
-def make_daily_card(pdf, color, linecolor, height='10pc', scale='lin'):
+def make_daily_card(pdf, color, linecolor, height='12pc', scale='lin'):
     """
     """
     fig = go.Figure(
@@ -2382,19 +2382,19 @@ def hist_sci_raw(pathname, dropdown_days):
     return card
 
 @app.callback(
-    Output('hist_g_r', 'children'),
+    Output('hist_catalogued', 'children'),
     [
         Input('url', 'pathname'),
         Input('dropdown_days', 'value'),
     ]
 )
-def hist_g_r(pathname, dropdown_days):
+def hist_catalogued(pathname, dropdown_days):
     """ Make an histogram
     """
     results = clientStats.scan(
         "",
         "key:key:ztf_",
-        'basic:n_g,basic:n_r',
+        'class:Solar System MPC,class:simbad_tot',
         0,
         False,
         False

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2305,6 +2305,43 @@ def display_years(pdf, years):
         fig.update_layout(height=200 * len(years))
     return fig
 
+def make_daily_card(pdf, color, linecolor):
+    """
+    """
+    fig = go.Figure(
+        [
+            go.Bar(x=pdf.columns, y=pdf.values[0])
+        ]
+    )
+
+    fig.update_layout(
+        title='',
+        margin=dict(t=0, r=0, b=0, l=0),
+        showlegend=False,
+        paper_bgcolor='rgba(0,0,0,0)',
+        plot_bgcolor='rgba(0,0,0,0)'
+    )
+
+    fig.update_traces(
+        marker_color=color,
+        marker_line_color=linecolor,
+        marker_line_width=1.5, opacity=0.6
+    )
+
+    graph = dcc.Graph(
+        figure=fig,
+        style={
+            'width': '100%',
+            'height': '15pc'
+        },
+        config={'displayModeBar': False}
+    )
+    card = dbc.Card(
+        dbc.CardBody(graph),
+        className="mt-3"
+    )
+    return card
+
 @app.callback(
     Output('hist_sci_raw', 'children'),
     [
@@ -2331,36 +2368,72 @@ def hist_sci_raw(pathname, dropdown_days):
         dropdown_days = pdf.index[-1]
     pdf = pdf[pdf.index == dropdown_days]
 
-    fig = go.Figure(
-        [
-            go.Bar(x=pdf.columns, y=pdf.values[0])
-        ]
+    card = make_daily_card(
+        pdf, color='rgb(158,202,225)', linecolor='rgb(8,48,107)'
     )
 
-    fig.update_layout(
-        title='',
-        margin=dict(t=0, r=0, b=0, l=0),
-        showlegend=False,
-        paper_bgcolor='rgba(0,0,0,0)',
-        plot_bgcolor='rgba(0,0,0,0)'
+    return card
+
+@app.callback(
+    Output('hist_g_r', 'children'),
+    [
+        Input('url', 'pathname'),
+        Input('dropdown_days', 'value'),
+    ]
+)
+def hist_g_r(pathname, dropdown_days):
+    """ Make an histogram
+    """
+    results = clientStats.scan(
+        "",
+        "key:key:ztf_",
+        'basic:n_g,basic:n_r',
+        0,
+        False,
+        False
     )
 
-    fig.update_traces(
-        marker_color='rgb(158,202,225)',
-        marker_line_color='rgb(8,48,107)',
-        marker_line_width=1.5, opacity=0.6
+    # Construct the dataframe
+    pdf = pd.DataFrame.from_dict(results, orient='index')
+
+    if dropdown_days is None or dropdown_days == '':
+        dropdown_days = pdf.index[-1]
+    pdf = pdf[pdf.index == dropdown_days]
+
+    card = make_daily_card(
+        pdf, color='rgb(245, 98, 46)', linecolor='rgb(135, 86, 69)'
     )
 
-    graph = dcc.Graph(
-        figure=fig,
-        style={
-            'width': '100%',
-            'height': '15pc'
-        },
-        config={'displayModeBar': False}
+    return card
+
+@app.callback(
+    Output('fields_exposures', 'children'),
+    [
+        Input('url', 'pathname'),
+        Input('dropdown_days', 'value'),
+    ]
+)
+def fields_exposures(pathname, dropdown_days):
+    """ Make an histogram
+    """
+    results = clientStats.scan(
+        "",
+        "key:key:ztf_",
+        'basic:fields,basic:exposures',
+        0,
+        False,
+        False
     )
-    card = dbc.Card(
-        dbc.CardBody(graph),
-        className="mt-3"
+
+    # Construct the dataframe
+    pdf = pd.DataFrame.from_dict(results, orient='index')
+
+    if dropdown_days is None or dropdown_days == '':
+        dropdown_days = pdf.index[-1]
+    pdf = pdf[pdf.index == dropdown_days]
+
+    card = make_daily_card(
+        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)'
     )
+
     return card

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2403,44 +2403,14 @@ def hist_catalogued(pathname, dropdown_days):
     # Construct the dataframe
     pdf = pd.DataFrame.from_dict(results, orient='index')
 
+    pdf = pdf.rename(columns={'class:Solar System MPC': 'MPC', 'class:simbad_tot': 'SIMBAD'})
+
     if dropdown_days is None or dropdown_days == '':
         dropdown_days = pdf.index[-1]
     pdf = pdf[pdf.index == dropdown_days]
 
     card = make_daily_card(
         pdf, color='rgb(245, 98, 46)', linecolor='rgb(135, 86, 69)'
-    )
-
-    return card
-
-@app.callback(
-    Output('fields_exposures', 'children'),
-    [
-        Input('url', 'pathname'),
-        Input('dropdown_days', 'value'),
-    ]
-)
-def fields_exposures(pathname, dropdown_days):
-    """ Make an histogram
-    """
-    results = clientStats.scan(
-        "",
-        "key:key:ztf_",
-        'basic:fields,basic:exposures',
-        0,
-        False,
-        False
-    )
-
-    # Construct the dataframe
-    pdf = pd.DataFrame.from_dict(results, orient='index')
-
-    if dropdown_days is None or dropdown_days == '':
-        dropdown_days = pdf.index[-1]
-    pdf = pdf[pdf.index == dropdown_days]
-
-    card = make_daily_card(
-        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)'
     )
 
     return card

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2336,7 +2336,7 @@ def make_daily_card(pdf, color, linecolor):
         figure=fig,
         style={
             'width': '100%',
-            'height': '15pc'
+            'height': '10pc'
         },
         config={'displayModeBar': False}
     )
@@ -2431,6 +2431,77 @@ def fields_exposures(pathname, dropdown_days):
 
     # Construct the dataframe
     pdf = pd.DataFrame.from_dict(results, orient='index')
+
+    if dropdown_days is None or dropdown_days == '':
+        dropdown_days = pdf.index[-1]
+    pdf = pdf[pdf.index == dropdown_days]
+
+    card = make_daily_card(
+        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)'
+    )
+
+    return card
+
+@app.callback(
+    Output('hist_classified', 'children'),
+    [
+        Input('url', 'pathname'),
+        Input('dropdown_days', 'value'),
+    ]
+)
+def hist_classified(pathname, dropdown_days):
+    """ Make an histogram
+    """
+    results = clientStats.scan(
+        "",
+        "key:key:ztf_",
+        'basic:sci,class:Unknown',
+        0,
+        False,
+        False
+    )
+
+    # Construct the dataframe
+    pdf = pd.DataFrame.from_dict(results, orient='index')
+
+    pdf['classified'] = pdf['basic:sci'] - pdf['class:Unknown']
+    pdf = pdf.rename(columns={'class:Unknown': 'unclassified'})
+    pdf = pdf.drop(['basic:sci'])
+
+    if dropdown_days is None or dropdown_days == '':
+        dropdown_days = pdf.index[-1]
+    pdf = pdf[pdf.index == dropdown_days]
+
+    card = make_daily_card(
+        pdf, color='rgb(245, 98, 46)', linecolor='rgb(135, 86, 69)'
+    )
+
+    return card
+
+@app.callback(
+    Output('daily_classification', 'children'),
+    [
+        Input('url', 'pathname'),
+        Input('dropdown_days', 'value'),
+    ]
+)
+def fields_exposures(pathname, dropdown_days):
+    """ Make an histogram
+    """
+    results = clientStats.scan(
+        "",
+        "key:key:ztf_",
+        '*',
+        0,
+        False,
+        False
+    )
+
+    # Construct the dataframe
+    pdf = pd.DataFrame.from_dict(results, orient='index')
+
+    to_drop = [i for i in pdf.columns if i.startswith('basic:')]
+    pdf = pdf.drop(to_drop)
 
     if dropdown_days is None or dropdown_days == '':
         dropdown_days = pdf.index[-1]

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2309,7 +2309,7 @@ def display_years(pdf, years):
         fig.update_layout(height=200 * len(years))
     return fig
 
-def make_daily_card(pdf, color, linecolor):
+def make_daily_card(pdf, color, linecolor, height='10pc', scale='lin'):
     """
     """
     fig = go.Figure(
@@ -2332,11 +2332,14 @@ def make_daily_card(pdf, color, linecolor):
         marker_line_width=1.5, opacity=0.6
     )
 
+    if scale == 'log':
+        fig.update_yaxes(type='log')
+
     graph = dcc.Graph(
         figure=fig,
         style={
             'width': '100%',
-            'height': '10pc'
+            'height': height
         },
         config={'displayModeBar': False}
     )
@@ -2464,9 +2467,9 @@ def hist_classified(pathname, dropdown_days):
     # Construct the dataframe
     pdf = pd.DataFrame.from_dict(results, orient='index')
 
-    pdf['classified'] = pdf['basic:sci'] - pdf['class:Unknown']
+    pdf['classified'] = pdf['basic:sci'].astype(int) - pdf['class:Unknown'].astype(int)
     pdf = pdf.rename(columns={'class:Unknown': 'unclassified'})
-    pdf = pdf.drop(colummns=['basic:sci'])
+    pdf = pdf.drop(columns=['basic:sci'])
 
     if dropdown_days is None or dropdown_days == '':
         dropdown_days = pdf.index[-1]
@@ -2508,7 +2511,7 @@ def fields_exposures(pathname, dropdown_days):
     pdf = pdf[pdf.index == dropdown_days]
 
     card = make_daily_card(
-        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)'
+        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)', height='20pc', scale='log'
     )
 
     return card

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2327,6 +2327,8 @@ def hist_sci_raw(pathname, dropdown_days):
     # Construct the dataframe
     pdf = pd.DataFrame.from_dict(results, orient='index')
 
+    if dropdown_days is None or dropdown_days == '':
+        dropdown_days = pdf.index[-1]
     pdf = pdf[pdf.index == dropdown_days]
 
     fig = go.Figure(

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2335,7 +2335,7 @@ def make_daily_card(pdf, color, linecolor, title, height='12pc', scale='lin'):
     fig.update_layout(
         title={
             'text': title,
-            'y': 0.995,
+            'y': 1.0,
             'x': 0.5,
             'xanchor': 'center',
             'yanchor': 'top'

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2489,7 +2489,7 @@ def hist_candidates(pathname, dropdown_days):
     pdf = pdf[pdf.index == dropdown_days]
 
     card = make_daily_card(
-        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)', title='Candidates'
+        pdf, color='rgb(21, 40, 79)', linecolor='rgb(4, 14, 33)', title='Selected candidates'
     )
 
     return card

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2067,7 +2067,7 @@ def plot_stat_evolution(pathname, param_name, switch):
     pdf = pdf.rename(columns={param_name: newcol})
 
     if switch == [1]:
-        pdf[newcol] = pdf[newcol].cumsum()
+        pdf[newcol] = pdf[newcol].astype(int).cumsum()
 
     fig = px.bar(
         pdf,

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2332,16 +2332,6 @@ def make_daily_card(pdf, color, linecolor, title, height='12pc', scale='lin'):
         marker_line_width=1.5, opacity=0.6
     )
 
-    fig.update_layout(
-        title={
-            'text': title,
-            'y': 1.0,
-            'x': 0.5,
-            'xanchor': 'center',
-            'yanchor': 'top'
-        }
-    )
-
     if scale == 'log':
         fig.update_yaxes(type='log')
 

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -173,14 +173,15 @@ def generate_night_list(object_stats):
 def generate_col_list():
     """ Generate the list of available columns
     """
-    pdf = get_data_one_night('ztf_20211125')
-    labels = [i.split(':')[1] for i in pdf.columns]
+    schema = clientStats.schema()
+    schema_list = list(schema.columnNames())
+    labels = [i.split(':')[1] for i in schema_list]
 
     dropdown = dcc.Dropdown(
         options=[
             *[
                 {'label': label, 'value': value}
-                for label, value in zip(labels, pdf.columns)]
+                for label, value in zip(labels, schema_list)]
         ],
         id='dropdown_params',
         searchable=True,

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -139,7 +139,7 @@ def daily_stats():
     layout_ = html.Div(
         [
             html.Br(),
-            dbc.Row(dbc.Col(id='dropdown_days'))
+            dbc.Row(dbc.Col(id='dropdown_days')),
             dbc.Row(
                 [
                     dbc.Col(id='evolution', width=10)

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -246,7 +246,10 @@ def generate_col_list():
         for i in schema_list
     ]
 
-    labels = np.sort(labels)
+    # Sort them for better readability
+    idx = np.argsort(labels)
+    labels = np.array(labels)[idx]
+    schema_list = np.array(schema_list)[idx]
 
     dropdown = dcc.Dropdown(
         options=[

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -65,7 +65,7 @@ def create_stat_row(object_stats):
         children=[
             html.Br(),
             html.H3(html.B(night)),
-            html.P('Last observing night')
+            html.P('Last ZTF observing night')
         ], width=2
     )
     c1 = dbc.Col(

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -70,29 +70,34 @@ def create_stat_row(object_stats):
     c1 = dbc.Col(
         children=[
             html.Br(),
-            html.H3(html.B('{:,}'.format(pdf['basic:raw'].values[-1]))),
-            html.P('Alerts received')
+            html.H3(html.B('{:,}'.format(pdf['basic:sci'].values[-1]))),
+            html.P('Alerts processed')
         ], width=2
     )
     c2 = dbc.Col(
         children=[
             html.Br(),
-            html.H3(html.B('{:,}'.format(pdf['basic:sci'].values[-1]))),
-            html.P('Alerts processed')
+            html.H3(html.B('{:,}'.format(np.sum(pdf['basic:sci'].values)))),
+            html.P('Alerts processed since 2019/11/01')
         ], width=2
     )
+
+    n_alert_unclassified = np.sum(pdf['class:Unknown'].values)
+    n_alert_classified = np.sum(pdf['basic:sci'].values) - n_alert_unclassified
+
     c3 = dbc.Col(
         children=[
             html.Br(),
-            html.H3(html.B(pdf['basic:fields'].values[-1])),
-            html.P('Fields visited')
+            html.H3(html.B(n_alert_classified)),
+            html.P('Alerts with classification since 2019/11/01')
         ], width=2
     )
+
     c4 = dbc.Col(
         children=[
             html.Br(),
-            html.H3(html.B(pdf['basic:exposures'].values[-1])),
-            html.P('Exposures taken')
+            html.H3(html.B(n_alert_unclassified)),
+            html.P('Alerts without classification since 2019/11/01')
         ], width=2
     )
 
@@ -141,6 +146,16 @@ def daily_stats():
         [
             html.Br(),
             dbc.Row(dbc.Col(id='dropdown_days_row')),
+            # dbc.Row(
+            #     [
+            #         dbc.Col(id="hist_sci_raw", width=3),
+            #         dbc.Col(id="hist_g_r", width=3),
+            #         dbc.Col(id="fields_exposures", width=3)
+            #     ]
+            # ),
+            # dbc.Row(
+            #     dbc.Col(id="daily_classification")
+            # )
         ],
     )
 
@@ -162,7 +177,7 @@ def generate_night_list(object_stats):
                 {'label': label, 'value': value}
                 for label, value in zip(labels[::-1], pdf['key:key'].values[::-1])]
         ],
-        id='dropdowm_days',
+        id='dropdown_days',
         searchable=True,
         clearable=True,
         placeholder="Choose a date",

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -246,6 +246,8 @@ def generate_col_list():
         for i in schema_list
     ]
 
+    labels = np.sort(labels)
+
     dropdown = dcc.Dropdown(
         options=[
             *[

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -24,6 +24,65 @@ import pandas as pd
 
 dcc.Location(id='url', refresh=False)
 
+stat_doc = """
+This page shows various statistics concerning Fink processed data.
+These statistics are updated once a day, after the ZTF observing night.
+Click on the different tabs to explore data.
+
+## Heatmap
+
+The heatmap shows the number of alerts processed by Fink for each night
+since the beginning of our operations (2019/11/01). The graph is color coded,
+dark cells represent a low number of processed alerts, while bright cells represent
+a high number of processed alerts.
+
+## Daily statistics
+
+The `Daily statistics` tab shows various statistics for a given observing night. By default,
+we show the last observing night. You can change the night by using the dropdown button.
+
+The first row shows histograms for various indicators:
+- Quality cuts: difference between number of received alerts versus number of processed alerts. The difference is simmply due to the quality cuts in Fink selecting only the best quality alerts.
+- Classification: Number of alerts that receive a tag by Fink, either from the Machine Learning classifiers, or from a crossmatch with catalogs. The rest is "unclassified".
+- External catalogs: Number of alerts that have a counterpart either in the MPC catalog or in the SIMBAD database.
+- Selected candidates: Number of alerts for a subset of classes: early type Ia supernova (SN Ia), supernovae or core-collapse (SNe), Kilonova, or Solar System candidates.
+
+The second row shows the number of alerts for all labels in Fink (from classifiers or crossmatch).
+Since there are many labels available, do not hesitate to zoom in to see more details!
+
+## Timelines
+
+This tab shows the evolution of several parameters over time. By default, we show the number of
+processed alerts per night, since the beginning of operations. You can change the parameter to
+show by using the dropdown button. Fields starting with `SIMBAD:` are labels from the SIMBAD database.
+
+Note that you can also show the cumulative number of alerts over time by switching the button on the top right :-)
+
+## REST API
+
+If you want to explore more statistics, or create your own dashboard based on Fink data,
+you can do all of these yourself using the REST API. Here is an example using Python:
+
+```python
+import requests
+import pandas as pd
+
+# get stats for all the year 2021
+r = requests.post(
+  'https://fink-portal.org/api/v1/statistics',
+  json={
+    'date': '2021',
+    'output-format': 'json'
+  }
+)
+
+# Format output in a DataFrame
+pdf = pd.read_json(r.content)
+```
+
+Note `date` can be either a given night (YYYYMMDD), month (YYYYMM), year (YYYY), or eveything (empty string).
+"""
+
 dic_names = {
     'basic:night': 'Observation date',
     'basic:raw': 'Number of alerts received',
@@ -297,7 +356,16 @@ def layout(is_mobile):
                 dbc.Tab(daily_stats(), label="Daily statistics", label_style=label_style),
                 dbc.Tab(timelines(), label="Timelines", label_style=label_style),
                 dbc.Tab(label="TNS", disabled=True),
-                dbc.Tab(label="Help", disabled=True),
+                dbc.Tab(
+                    dbc.Card(
+                        dbc.CardBody(
+                            dcc.Markdown(stat_doc)
+                        ), style={
+                            'backgroundColor': 'rgb(248, 248, 248, .7)'
+                        }
+                    ),
+                    label="Help"
+                ),
             ]
         )
 

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -57,15 +57,16 @@ def create_stat_row(object_stats):
     """ Create links to external website. Used in the mobile app.
     """
     pdf = pd.read_json(object_stats)
-    c0 = stat_card(pdf['key:key'].values[0], 'Last night'),
-    c1 = stat_card(pdf['basic:raw'].values[0], 'Alerts received'),
-    c2 = stat_card(pdf['basic:sci'].values[0], 'Alerts processed'),
-    c3 = stat_card(pdf['basic:fields'].values[0], 'Fields visited'),
-    c4 = stat_card(pdf['basic:exposures'].values[0], 'Exposures taken')
+    c0 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['key:key'].values[-1])), html.P('Last night')], width=2)
+    c1 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['basic:raw'].values[-1])), html.P('Alerts received')], width=2)
+    c2 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['basic:sci'].values[-1])), html.P('Alerts processed')], width=2)
+    c3 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['basic:fields'].values[-1])), html.P('Fields visited')], width=2)
+    c4 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['basic:exposures'].values[-1])), html.P('Exposures taken')], width=2)
+
     row = [
         dbc.Col(width=1), c0, c1, c2, c3, c4, dbc.Col(width=1)
     ]
-    return dbc.Row(row)
+    return row
 
 def stat_card(value, title):
     """
@@ -134,7 +135,7 @@ def layout(is_mobile):
             [
                 html.Br(),
                 html.Br(),
-                html.Div(id='stat_row'),
+                dbc.Row(id='stat_row'),
                 dbc.Row(
                     [
                         html.Br(),

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -36,10 +36,11 @@ def store_stat_query(name):
     # Query everything from this century
     name = 'ztf_20'
 
+    cols = 'key:key,basic:raw,basic:sci,basic:fields,basic:exposures'
     results = clientStats.scan(
         "",
         "key:key:{}".format(name),
-        "*",
+        cols,
         0,
         True,
         True

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -248,6 +248,7 @@ def layout(is_mobile):
                 dbc.Tab(daily_stats(), label="Daily statistics", label_style=label_style),
                 dbc.Tab(timelines(), label="Timelines", label_style=label_style),
                 dbc.Tab(label="TNS", disabled=True),
+                dbc.Tab(label="Help", disabled=True),
             ]
         )
 

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -146,7 +146,7 @@ def daily_stats():
     layout_ = html.Div(
         [
             html.Br(),
-            dbc.Row(dbc.Col(id='dropdown_days_row')),
+            dbc.Row(dbc.Col(generate_night_list())),
             dbc.Row(
                 [
                     dbc.Col(id="hist_sci_raw", width=3),
@@ -162,14 +162,21 @@ def daily_stats():
 
     return layout_
 
-@app.callback(
-    Output('dropdown_days_row', 'children'),
-    Input('object-stats', 'children')
-)
-def generate_night_list(object_stats):
+def generate_night_list():
     """ Generate the list of available nights (last night first)
     """
-    pdf = pd.read_json(object_stats)
+    results = clientStats.scan(
+        "",
+        "key:key:ztf_",
+        '',
+        0,
+        True,
+        True
+    )
+
+    # Construct the dataframe
+    pdf = pd.DataFrame.from_dict(results, orient='index')
+
     labels = pdf['key:key'].apply(lambda x: x[4:8] + '-' + x[8:10] + '-' + x[10:12])
 
     dropdown = dcc.Dropdown(

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -36,7 +36,7 @@ def store_stat_query(name):
     # Query everything from this century
     name = 'ztf_20'
 
-    cols = 'key:key,basic:raw,basic:sci,basic:fields,basic:exposures'
+    cols = 'basic:raw,basic:sci,basic:fields,basic:exposures'
     results = clientStats.scan(
         "",
         "key:key:{}".format(name),

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -19,6 +19,7 @@ from dash.dependencies import Input, Output
 
 from app import app, clientStats
 
+import numpy as np
 import pandas as pd
 
 dcc.Location(id='url', refresh=False)

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -130,7 +130,7 @@ def timelines():
         [
             dbc.Checklist(
                 options=[
-                    {"label": "Option 1", "value": 1},
+                    {"label": "Cumulative", "value": 1},
                 ],
                 value=[],
                 id="switch-cumulative",

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -24,6 +24,27 @@ import pandas as pd
 
 dcc.Location(id='url', refresh=False)
 
+dic_names = {
+    'basic:night': 'Observation date',
+    'basic:raw': 'Number of alerts received',
+    'basic:sci': 'Number of alerts processed (passing quality cuts)',
+    'basic:n_g': 'Number of measurements in the g band',
+    'basic:n_r': 'Number of measurements in the r band',
+    'basic:exposures': 'Number of exposures (30 seconds)',
+    'basic:fields': 'Number of fields visited',
+    'class:simbad_tot': 'Number of alerts with a counterpart in SIMBAD',
+    'class:simbad_gal': 'Number of alerts with a close-by candidate host-galaxy in SIMBAD',
+    'class:Solar System MPC': 'Number of alerts with a counterpart in MPC (SSO)',
+    'class:SN candidate': 'Number of alerts classified as SN by Fink',
+    'class:Early SN candidate': 'Number of alerts classified as early SN Ia by Fink',
+    'class:Kilonova candidate': 'Number of alerts classified as Kilonova by Fink',
+    'class:Microlensing candidate': 'Number of alerts classified as Microlensing by Fink',
+    'class:SN candidate': 'Number of alerts classified as SN by Fink',
+    'class:Solar System candidate': 'Number of alerts classified as SSO candidates by Fink',
+    'class:Tracklet': 'Number of alerts classified as satelitte glints or space debris by Fink',
+    'class:Unknown': 'Number of alerts without classification'
+}
+
 stat_doc = """
 This page shows various statistics concerning Fink processed data.
 These statistics are updated once a day, after the ZTF observing night.
@@ -81,28 +102,11 @@ pdf = pd.read_json(r.content)
 ```
 
 Note `date` can be either a given night (YYYYMMDD), month (YYYYMM), year (YYYY), or eveything (empty string).
-"""
+The schema of the dataframe is the following:
 
-dic_names = {
-    'basic:night': 'Observation date',
-    'basic:raw': 'Number of alerts received',
-    'basic:sci': 'Number of alerts processed (passing quality cuts)',
-    'basic:n_g': 'Number of measurements in the g band',
-    'basic:n_r': 'Number of measurements in the r band',
-    'basic:exposures': 'Number of exposures (30 seconds)',
-    'basic:fields': 'Number of fields visited',
-    'class:simbad_tot': 'Number of alerts with a counterpart in SIMBAD',
-    'class:simbad_gal': 'Number of alerts with a close-by candidate host-galaxy in SIMBAD',
-    'class:Solar System MPC': 'Number of alerts with a counterpart in MPC (SSO)',
-    'class:SN candidate': 'Number of alerts classified as SN by Fink',
-    'class:Early SN candidate': 'Number of alerts classified as early SN Ia by Fink',
-    'class:Kilonova candidate': 'Number of alerts classified as Kilonova by Fink',
-    'class:Microlensing candidate': 'Number of alerts classified as Microlensing by Fink',
-    'class:SN candidate': 'Number of alerts classified as SN by Fink',
-    'class:Solar System candidate': 'Number of alerts classified as SSO candidates by Fink',
-    'class:Tracklet': 'Number of alerts classified as satelitte glints or space debris by Fink',
-    'class:Unknown': 'Number of alerts without classification'
-}
+| field | description |
+{}
+""".format(pd.DataFrame([dic_names]).T.rename(columns={0:'description'}).to_markdown())
 
 @app.callback(
     Output('object-stats', 'children'),

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -79,7 +79,7 @@ def create_stat_row(object_stats):
         children=[
             html.Br(),
             html.H3(html.B('{:,}'.format(np.sum(pdf['basic:sci'].values)))),
-            html.P('Alerts processed since 2019/11/01')
+            html.P('Since 2019/11/01')
         ], width=2
     )
 
@@ -89,16 +89,16 @@ def create_stat_row(object_stats):
     c3 = dbc.Col(
         children=[
             html.Br(),
-            html.H3(html.B(n_alert_classified)),
-            html.P('Alerts with classification since 2019/11/01')
+            html.H3(html.B('{:,}'.format(n_alert_classified))),
+            html.P('With classification')
         ], width=2
     )
 
     c4 = dbc.Col(
         children=[
             html.Br(),
-            html.H3(html.B(n_alert_unclassified)),
-            html.P('Alerts without classification since 2019/11/01')
+            html.H3(html.B('{:,}'.format(n_alert_unclassified))),
+            html.P('Without classification')
         ], width=2
     )
 

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -64,7 +64,7 @@ def create_stat_row(object_stats):
         children=[
             html.Br(),
             html.H3(html.B(night)),
-            html.P('Last night')
+            html.P('Last observing night')
         ], width=2
     )
     c1 = dbc.Col(
@@ -133,6 +133,44 @@ def timelines():
 
     return layout_
 
+def daily_stats():
+    """
+    """
+    layout_ = html.Div(
+        [
+            html.Br(),
+            dbc.Row(dbc.Col(id='dropdown_days'))
+            dbc.Row(
+                [
+                    dbc.Col(id='evolution', width=10)
+                ], justify="center", no_gutters=True
+            ),
+        ],
+    )
+
+    return layout_
+
+@app.callback(
+    Output('dropdown_days', 'children'),
+    Input('object-stats', 'children')
+)
+def generate_night_list(object_stats):
+    """
+    """
+    pdf = pd.read_json(object_stats)
+    labels = pdf['key:key'].apply(lambda x: x[4:8] + '-' + x[8:10] + '-' + x[10:12])
+
+    dropdown = dcc.Dropdown(
+        options=[
+            *[{'label': label, 'value': value} for label, values in zip(values, pdf['key:key'].values)]
+        ],
+        searchable=True,
+        clearable=True,
+        placeholder="Choose a date",
+    )
+
+    return dropdown
+
 def layout(is_mobile):
     """
     """
@@ -143,6 +181,7 @@ def layout(is_mobile):
         tabs_ = dbc.Tabs(
             [
                 dbc.Tab(heatmap_content(), label="Heatmap", label_style=label_style),
+                dbc.Tab(daily_stats(), label="Daily statistics", label_style=label_style),
                 dbc.Tab(timelines(), label="Timelines", label_style=label_style),
                 dbc.Tab(label="TNS", disabled=True),
             ]

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -37,7 +37,7 @@ def store_stat_query(name):
     # Query everything from this century
     name = 'ztf_20'
 
-    cols = 'basic:raw,basic:sci,basic:fields,basic:exposures'
+    cols = 'basic:raw,basic:sci,basic:fields,basic:exposures,class:Unknown'
     results = clientStats.scan(
         "",
         "key:key:{}".format(name),

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -105,7 +105,9 @@ Note `date` can be either a given night (YYYYMMDD), month (YYYYMM), year (YYYY),
 The schema of the dataframe is the following:
 
 {}
-""".format(pd.DataFrame([dic_names]).T.rename(columns={0:'description'}).to_markdown())
+
+All other fields starting with `class:` are crossmatch from the SIMBAD database.
+""".format(pd.DataFrame([dic_names]).T.rename(columns={0: 'description'}).to_markdown())
 
 @app.callback(
     Output('object-stats', 'children'),

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -147,13 +147,13 @@ def daily_stats():
         [
             html.Br(),
             dbc.Row(dbc.Col(id='dropdown_days_row')),
-            # dbc.Row(
-            #     [
-            #         dbc.Col(id="hist_sci_raw", width=3),
-            #         dbc.Col(id="hist_g_r", width=3),
-            #         dbc.Col(id="fields_exposures", width=3)
-            #     ]
-            # ),
+            dbc.Row(
+                [
+                    dbc.Col(id="hist_sci_raw", width=3),
+                    # dbc.Col(id="hist_g_r", width=3),
+                    # dbc.Col(id="fields_exposures", width=3)
+                ]
+            ),
             # dbc.Row(
             #     dbc.Col(id="daily_classification")
             # )

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -151,7 +151,8 @@ def daily_stats():
                 [
                     dbc.Col(id="hist_sci_raw", width=3),
                     dbc.Col(id="hist_classified", width=3),
-                    dbc.Col(id="hist_catalogued", width=3)
+                    dbc.Col(id="hist_catalogued", width=3),
+                    dbc.Col(id="hist_candidates", width=3)
                 ], justify='around'
             ),
             dbc.Row(

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -150,8 +150,8 @@ def daily_stats():
             dbc.Row(
                 [
                     dbc.Col(id="hist_sci_raw", width=3),
-                    # dbc.Col(id="hist_g_r", width=3),
-                    # dbc.Col(id="fields_exposures", width=3)
+                    dbc.Col(id="hist_g_r", width=3),
+                    dbc.Col(id="fields_exposures", width=3)
                 ]
             ),
             # dbc.Row(

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -194,8 +194,6 @@ def generate_col_list():
 def get_data_one_night(night):
     """
     """
-    # Query everything from this century
-
     cols = 'basic:raw,basic:sci,basic:fields,basic:exposures'
     results = clientStats.scan(
         "",

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -59,29 +59,46 @@ def create_stat_row(object_stats):
     pdf = pd.read_json(object_stats)
     n_ = pdf['key:key'].values[-1]
     night = n_[4:8] + '-' + n_[8:10] + '-' + n_[10:12]
-    c0 = dbc.Col(children=[html.Br(), html.H3(html.B(night)), html.P('Last night')], width=2)
-    c1 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['basic:raw'].values[-1])), html.P('Alerts received')], width=2)
-    c2 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['basic:sci'].values[-1])), html.P('Alerts processed')], width=2)
-    c3 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['basic:fields'].values[-1])), html.P('Fields visited')], width=2)
-    c4 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['basic:exposures'].values[-1])), html.P('Exposures taken')], width=2)
+    c0 = dbc.Col(
+        children=[
+            html.Br(),
+            html.H3(html.B(night)),
+            html.P('Last night')
+        ], width=2
+    )
+    c1 = dbc.Col(
+        children=[
+            html.Br(),
+            html.H3(html.B('{:,}'.format(pdf['basic:raw'].values[-1]))),
+            html.P('Alerts received')
+        ], width=2
+    )
+    c2 = dbc.Col(
+        children=[
+            html.Br(),
+            html.H3(html.B('{:,}'.format(pdf['basic:sci'].values[-1]))),
+            html.P('Alerts processed')
+        ], width=2
+    )
+    c3 = dbc.Col(
+        children=[
+            html.Br(),
+            html.H3(html.B(pdf['basic:fields'].values[-1])),
+            html.P('Fields visited')
+        ], width=2
+    )
+    c4 = dbc.Col(
+        children=[
+            html.Br(),
+            html.H3(html.B(pdf['basic:exposures'].values[-1])),
+            html.P('Exposures taken')
+        ], width=2
+    )
 
     row = [
         dbc.Col(width=1), c0, c1, c2, c3, c4, dbc.Col(width=1)
     ]
     return row
-
-def stat_card(value, title):
-    """
-    """
-    col = dbc.Col(
-        [
-            html.Br(),
-            html.H3(html.B(value)),
-            html.P(title)
-        ], width=2
-    )
-
-    return col
 
 def heatmap_content():
     """

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -31,7 +31,7 @@ Click on the different tabs to explore data.
 
 ## Heatmap
 
-The heatmap shows the number of alerts processed by Fink for each night
+The `Heatmap` tab shows the number of alerts processed by Fink for each night
 since the beginning of our operations (2019/11/01). The graph is color coded,
 dark cells represent a low number of processed alerts, while bright cells represent
 a high number of processed alerts.
@@ -52,7 +52,7 @@ Since there are many labels available, do not hesitate to zoom in to see more de
 
 ## Timelines
 
-This tab shows the evolution of several parameters over time. By default, we show the number of
+The `Timelines` tab shows the evolution of several parameters over time. By default, we show the number of
 processed alerts per night, since the beginning of operations. You can change the parameter to
 show by using the dropdown button. Fields starting with `SIMBAD:` are labels from the SIMBAD database.
 

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -50,8 +50,8 @@ def store_stat_query(name):
     return pdf.to_json()
 
 @app.callback(
-    [Output('stat_row', 'children')],
-    [Input('object-stats', 'children')]
+    Output('stat_row', 'children'),
+    Input('object-stats', 'children')
 )
 def create_stat_row(object_stats):
     """ Create links to external website. Used in the mobile app.
@@ -65,7 +65,7 @@ def create_stat_row(object_stats):
     row = [
         dbc.Col(width=1), c0, c1, c2, c3, c4, dbc.Col(width=1)
     ]
-    return html.Div(row)
+    return dbc.Row(row)
 
 def stat_card(value, title):
     """
@@ -134,7 +134,7 @@ def layout(is_mobile):
             [
                 html.Br(),
                 html.Br(),
-                dbc.Row(id='stat_row'),
+                html.Div(id='stat_row'),
                 dbc.Row(
                     [
                         html.Br(),

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -91,10 +91,10 @@ import pandas as pd
 # get stats for all the year 2021
 r = requests.post(
   'https://fink-portal.org/api/v1/statistics',
-  json={
+  json={{
     'date': '2021',
     'output-format': 'json'
-  }
+  }}
 )
 
 # Format output in a DataFrame
@@ -104,7 +104,6 @@ pdf = pd.read_json(r.content)
 Note `date` can be either a given night (YYYYMMDD), month (YYYYMM), year (YYYY), or eveything (empty string).
 The schema of the dataframe is the following:
 
-| field | description |
 {}
 """.format(pd.DataFrame([dic_names]).T.rename(columns={0:'description'}).to_markdown())
 

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -50,8 +50,8 @@ def store_stat_query(name):
     return pdf.to_json()
 
 @app.callback(
-    Output('stat_row', 'children'),
-    Input('object-stats', 'children')
+    [Output('stat_row', 'children')],
+    [Input('object-stats', 'children')]
 )
 def create_stat_row(object_stats):
     """ Create links to external website. Used in the mobile app.

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -57,7 +57,9 @@ def create_stat_row(object_stats):
     """ Create links to external website. Used in the mobile app.
     """
     pdf = pd.read_json(object_stats)
-    c0 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['key:key'].values[-1])), html.P('Last night')], width=2)
+    n_ = pdf['key:key'].values[-1]
+    night = n_[4:8] + '-' + n_[8:10] + '-' + n_[10:12]
+    c0 = dbc.Col(children=[html.Br(), html.H3(html.B(night)), html.P('Last night')], width=2)
     c1 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['basic:raw'].values[-1])), html.P('Alerts received')], width=2)
     c2 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['basic:sci'].values[-1])), html.P('Alerts processed')], width=2)
     c3 = dbc.Col(children=[html.Br(), html.H3(html.B(pdf['basic:fields'].values[-1])), html.P('Fields visited')], width=2)

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -24,6 +24,26 @@ import pandas as pd
 
 dcc.Location(id='url', refresh=False)
 
+dic_names = {
+    'basic:night': 'Observation date',
+    'basic:raw': 'Number of alerts received',
+    'basic:sci': 'Number of alerts processed (passing quality cuts)',
+    'basic:n_g': 'Number of measurements in the g band',
+    'basic:n_r': 'Number of measurements in the r band',
+    'basic:exposures': 'Number of exposures (30 seconds)',
+    'basic:fields': 'Number of fields visited',
+    'class:simbad_tot': 'Number of alerts with a counterpart in SIMBAD',
+    'class:simbad_gal': 'Number of alerts with a close-by candidate host-galaxy in SIMBAD',
+    'class:Solar System MPC': 'Number of alerts with a counterpart in MPC (SSO)',
+    'class:SN candidate': 'Number of alerts classified as SN by Fink',
+    'class:Early SN candidate': 'Number of alerts classified as early SN Ia by Fink',
+    'class:Kilonova candidate': 'Number of alerts classified as Kilonova by Fink',
+    'class:Microlensing candidate': 'Number of alerts classified as Microlensing by Fink',
+    'class:SN candidate': 'Number of alerts classified as SN by Fink',
+    'class:Solar System candidate': 'Number of alerts classified as SSO candidates by Fink',
+    'class:Tracklet': 'Number of alerts classified as satelitte glints or space debris by Fink',
+}
+
 @app.callback(
     Output('object-stats', 'children'),
     [
@@ -219,7 +239,12 @@ def generate_col_list():
     """
     schema = clientStats.schema()
     schema_list = list(schema.columnNames())
-    labels = [i.split(':')[1] for i in schema_list]
+    labels = [
+        i.replace('class', 'SIMBAD')
+        if i not in dic_names
+        else dic_names[i]
+        for i in schema_list
+    ]
 
     dropdown = dcc.Dropdown(
         options=[

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -162,7 +162,7 @@ def generate_night_list(object_stats):
 
     dropdown = dcc.Dropdown(
         options=[
-            *[{'label': label, 'value': value} for label, values in zip(values, pdf['key:key'].values)]
+            *[{'label': label, 'value': value} for label, value in zip(labels, pdf['key:key'].values)]
         ],
         searchable=True,
         clearable=True,

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -126,19 +126,25 @@ def heatmap_content():
 def timelines():
     """
     """
+    switch = html.Div(
+        [
+            dbc.Checklist(
+                options=[
+                    {"label": "Option 1", "value": 1},
+                ],
+                value=[],
+                id="switch-cumulative",
+                switch=True,
+            ),
+        ]
+    )
     layout_ = html.Div(
         [
             html.Br(),
             dbc.Row(
                 [
                     dbc.Col(generate_col_list(), width=10),
-                    dbc.Col(
-                        dbc.Switch(
-                            id="standalone-switch",
-                            label="Cumulative",
-                            value=False,
-                        ), width=2
-                    )
+                    dbc.Col(switch, width=2)
                 ], justify='around'
             ),
             dbc.Row(

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -150,13 +150,14 @@ def daily_stats():
             dbc.Row(
                 [
                     dbc.Col(id="hist_sci_raw", width=3),
-                    dbc.Col(id="hist_g_r", width=3),
+                    dbc.Col(id="hist_classified", width=3),
+                    # dbc.Col(id="hist_g_r", width=3),
                     dbc.Col(id="fields_exposures", width=3)
-                ]
+                ], justify='around'
             ),
-            # dbc.Row(
-            #     dbc.Col(id="daily_classification")
-            # )
+            dbc.Row(
+                dbc.Col(id="daily_classification", width=10)
+            )
         ],
     )
 
@@ -183,12 +184,13 @@ def generate_night_list():
         options=[
             *[
                 {'label': label, 'value': value}
-                for label, value in zip(labels[::-1], pdf['key:key'].values[::-1])]
+                for label, value in zip(labels[::-1], pdf['key:key'].values[::-1])
+            ]
         ],
         id='dropdown_days',
         searchable=True,
         clearable=True,
-        placeholder="Choose a date",
+        placeholder=labels[-1],
     )
 
     return dropdown

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -129,7 +129,18 @@ def timelines():
     layout_ = html.Div(
         [
             html.Br(),
-            dbc.Row(dbc.Col(generate_col_list())),
+            dbc.Row(
+                [
+                    dbc.Col(generate_col_list(), width=10),
+                    dbc.Col(
+                        dbc.Switch(
+                            id="standalone-switch",
+                            label="Cumulative",
+                            value=False,
+                        ), width=2
+                    )
+                ], justify='around'
+            ),
             dbc.Row(
                 [
                     dbc.Col(id='evolution', width=10)

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -42,6 +42,7 @@ dic_names = {
     'class:SN candidate': 'Number of alerts classified as SN by Fink',
     'class:Solar System candidate': 'Number of alerts classified as SSO candidates by Fink',
     'class:Tracklet': 'Number of alerts classified as satelitte glints or space debris by Fink',
+    'class:Unknown': 'Number of alerts without classification'
 }
 
 @app.callback(

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -151,12 +151,13 @@ def daily_stats():
                 [
                     dbc.Col(id="hist_sci_raw", width=3),
                     dbc.Col(id="hist_classified", width=3),
-                    # dbc.Col(id="hist_g_r", width=3),
-                    dbc.Col(id="fields_exposures", width=3)
+                    dbc.Col(id="hist_catalogued", width=3)
                 ], justify='around'
             ),
             dbc.Row(
-                dbc.Col(id="daily_classification", width=10)
+                [
+                    dbc.Col(id="daily_classification", width=10)
+                ], justify='around'
             )
         ],
     )

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -364,7 +364,8 @@ def layout(is_mobile):
                             'backgroundColor': 'rgb(248, 248, 248, .7)'
                         }
                     ),
-                    label="Help"
+                    label="Help",
+                    label_style=label_style
                 ),
             ]
         )

--- a/index.py
+++ b/index.py
@@ -1092,6 +1092,7 @@ navbar = dbc.Navbar(
                 # right align dropdown menu with ml-auto className
                 [
                     dbc.NavItem(dbc.NavLink('Search', href="{}".format(APIURL))),
+                    dbc.NavItem(dbc.NavLink('Statistics', href="{}/stats".format(APIURL))),
                     dbc.NavItem(dbc.NavLink('API', href="{}/api".format(APIURL))),
                     dbc.NavItem(dbc.NavLink('Tutorials', href="https://github.com/astrolabsoftware/fink-notebook-template")),
                     dropdown


### PR DESCRIPTION
This PR adds a new page to gather various statistics about Fink data. It contains 3 tabs:
- heatmap
- daily statistics
- timelines

A fourth one will join later concerning TNS confirmed data.

## Heatmap

The `Heatmap` tab shows the number of alerts processed by Fink for each night
since the beginning of our operations (2019/11/01). The graph is color coded,
dark cells represent a low number of processed alerts, while bright cells represent
a high number of processed alerts.

<img width="1039" alt="1-stat" src="https://user-images.githubusercontent.com/20426972/144219697-0ff632b3-2e7f-43e1-bf72-26890c2f4ce9.png">

## Daily statistics

The `Daily statistics` tab shows various statistics for a given observing night. By default,
we show the last observing night. The first row shows histograms for various indicators:

<img width="1435" alt="2-stat" src="https://user-images.githubusercontent.com/20426972/144219757-05322d6e-d500-445b-95be-ea321223e195.png">
- Quality cuts: difference between number of received alerts versus number of processed alerts. The difference is simmply due to the quality cuts in Fink selecting only the best quality alerts.
- Classification: Number of alerts that receive a tag by Fink, either from the Machine Learning classifiers, or from a crossmatch with catalogs. The rest is "unclassified".
- External catalogs: Number of alerts that have a counterpart either in the MPC catalog or in the SIMBAD database.
- Selected candidates: Number of alerts for a subset of classes: early type Ia supernova (SN Ia), supernovae or core-collapse (SNe), Kilonova, or Solar System candidates.

You can change the night by using the dropdown button

<img width="1301" alt="2b-stat" src="https://user-images.githubusercontent.com/20426972/144219813-6f41149e-9d8c-4e52-b9bb-5bcb0a0625ef.png">

The second row shows the number of alerts for all labels in Fink (from classifiers or crossmatch).

<img width="1062" alt="3-stat" src="https://user-images.githubusercontent.com/20426972/144219831-6160099f-4125-4e7b-84e2-e4c1f92309d4.png">

Since there are many labels available, do not hesitate to zoom in to see more details!

<img width="1041" alt="3b-stat" src="https://user-images.githubusercontent.com/20426972/144219851-829f17ae-fdd2-46e4-9e7f-653286cbbf07.png">

## Timelines

The `Timelines` tab shows the evolution of several parameters over time. By default, we show the number of
processed alerts per night, since the beginning of operations. 

<img width="1227" alt="4-stat" src="https://user-images.githubusercontent.com/20426972/144219884-68749a42-132e-4cde-a737-12eda17c0c94.png">


You can change the parameter to show by using the dropdown button. Fields starting with `SIMBAD:` are labels from the SIMBAD database. Note that you can also show the cumulative number of alerts over time by switching the button on the top right :-)

<img width="1243" alt="4b-stat" src="https://user-images.githubusercontent.com/20426972/144219908-f36924af-8e39-41e0-b17c-4a93224138c0.png">

## REST API

If you want to explore more statistics, or create your own dashboard based on Fink data,
you can do all of these yourself using the REST API. Here is an example using Python:

```python
import requests
import pandas as pd

# get stats for all the year 2021
r = requests.post(
  'https://fink-portal.org/api/v1/statistics',
  json={
    'date': '2021',
    'output-format': 'json'
  }
)

# Format output in a DataFrame
pdf = pd.read_json(r.content)
```

Note `date` can be either a given night (YYYYMMDD), month (YYYYMM), year (YYYY), or eveything (empty string).