### PR TITLE
[Stats] Mobile version

### DIFF
--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -195,7 +195,7 @@ def create_stat_row(object_stats):
     c0_, c1_, c2_, c3_, c4_ = create_stat_generic(pdf)
 
     r0 = dbc.Row(
-        children=[dbc.Col([c0_, html.Br()], width=10)],
+        children=[dbc.Col(children=[c0_, html.Br()], width=10)],
         justify='center',
         style={
             'border-right': '1px solid #c4c0c0',
@@ -207,7 +207,7 @@ def create_stat_row(object_stats):
     )
 
     r1 = dbc.Row(
-        children=[dbc.Col([c1_, html.Br()], width=10)],
+        children=[dbc.Col(children=[c1_, html.Br()], width=10)],
         justify='center',
         style={
             'border-right': '1px solid #c4c0c0',

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -213,6 +213,14 @@ def create_stat_row(object_stats):
         rowify(c3_),
         html.Br(),
         rowify(c4_),
+        html.Br(), html.Br(),
+        dbc.Card(
+            dbc.CardBody(
+                dcc.Markdown('_Connect with a bigger screen to explore more statistics_')
+            ), style={
+                'backgroundColor': 'rgb(248, 248, 248, .7)'
+            }
+        ),
     ]
 
     return row

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -194,31 +194,27 @@ def create_stat_row(object_stats):
     pdf = pd.read_json(object_stats)
     c0_, c1_, c2_, c3_, c4_ = create_stat_generic(pdf)
 
-    r0 = dbc.Row(
-        children=[dbc.Col(children=[c0_, html.Br()], width=10)],
+    rowify = lambda x: dbc.Row(
+        children=[dbc.Col(children=x, width=10)],
         justify='center',
         style={
-            'border-right': '1px solid #c4c0c0',
-            'border-left': '1px solid #c4c0c0',
-            'border-bottom': '1px solid #c4c0c0',
-            'border-radius': '0px 0px 25px 25px',
             "text-align": "center"
         }
     )
 
-    r1 = dbc.Row(
-        children=[dbc.Col(children=[c1_, html.Br()], width=10)],
-        justify='center',
-        style={
-            'border-right': '1px solid #c4c0c0',
-            'border-left': '1px solid #c4c0c0',
-            'border-bottom': '1px solid #c4c0c0',
-            'border-radius': '0px 0px 25px 25px',
-            "text-align": "center"
-        }
-    )
+    row = [
+        html.Br(), html.Br(),
+        rowify(c0_),
+        html.Br(),
+        rowify(c1_),
+        html.Br(),
+        rowify(c2_),
+        html.Br(),
+        rowify(c3_),
+        html.Br(),
+        rowify(c4_),
+    ]
 
-    row = [dbc.Row(), r0, r1]
     return row
 
 def create_stat_generic(pdf):

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -195,7 +195,9 @@ def create_stat_row(object_stats):
     c0_, c1_, c2_, c3_, c4_ = create_stat_generic(pdf)
 
     r0 = dbc.Row(
-        children=c0_, style={
+        children=[dbc.Col(c0_, width=10)],
+        justify='center',
+        style={
             'border-right': '1px solid #c4c0c0',
             'border-left': '1px solid #c4c0c0',
             'border-bottom': '1px solid #c4c0c0',
@@ -205,7 +207,9 @@ def create_stat_row(object_stats):
     )
 
     r1 = dbc.Row(
-        children=c1_, style={
+        children=[dbc.Col(c1_, width=10)],
+        justify='center',
+        style={
             'border-right': '1px solid #c4c0c0',
             'border-left': '1px solid #c4c0c0',
             'border-bottom': '1px solid #c4c0c0',

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -195,7 +195,7 @@ def create_stat_row(object_stats):
     c0_, c1_, c2_, c3_, c4_ = create_stat_generic(pdf)
 
     r0 = dbc.Row(
-        children=[dbc.Col(c0_, width=10)],
+        children=[dbc.Col([c0_, html.Br()], width=10)],
         justify='center',
         style={
             'border-right': '1px solid #c4c0c0',
@@ -207,7 +207,7 @@ def create_stat_row(object_stats):
     )
 
     r1 = dbc.Row(
-        children=[dbc.Col(c1_, width=10)],
+        children=[dbc.Col([c1_, html.Br()], width=10)],
         justify='center',
         style={
             'border-right': '1px solid #c4c0c0',
@@ -218,7 +218,7 @@ def create_stat_row(object_stats):
         }
     )
 
-    row = [r0, r1]
+    row = [dbc.Row(), r0, r1]
     return row
 
 def create_stat_generic(pdf):


### PR DESCRIPTION
It is rather difficult to display plots and use them on a mobile device. Therefore the mobile version of the statistics page is light, and contains only basic statistics:

<img width="333" alt="Screenshot 2021-12-03 at 14 23 25" src="https://user-images.githubusercontent.com/20426972/144609646-4cddf491-780a-4809-95c6-522d81b90fac.png">
