### PR TITLE
Force column width for the SSO layout

### DIFF
--- a/apps/summary.py
+++ b/apps/summary.py
@@ -115,7 +115,7 @@ def tab5_content(pdf):
     tab5_content_ = html.Div([
         dbc.Row(
             [
-                dbc.Col([card_sso_lightcurve(), card_sso_radec()]),
+                dbc.Col([card_sso_lightcurve(), card_sso_radec()], width=8),
                 dbc.Col([card_sso_mpc_params(ssnamenr)], width=4)
             ]
         ),


### PR DESCRIPTION
Closes #241

Without the fix:

<img width="1007" alt="Screenshot 2021-12-06 at 09 39 08" src="https://user-images.githubusercontent.com/20426972/144814215-2f27a899-daf3-46f6-b47d-21d7ac2feee6.png">

With the fix:
<img width="1000" alt="Screenshot 2021-12-06 at 09 39 16" src="https://user-images.githubusercontent.com/20426972/144814228-9b29d52b-b734-4e58-b2a2-45256a3eef57.png">

