### PR TITLE
Add support for satelitte glints and space debris

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,6 +84,9 @@ clientUV.connect(tablename + ".uppervalid", SCHEMAVER)
 clientSSO = com.Lomikel.HBaser.HBaseClient(IPADDR, ZOOPORT);
 clientSSO.connect(tablename + ".ssnamenr", SCHEMAVER)
 
+clientTRCK = com.Lomikel.HBaser.HBaseClient(IPADDR, ZOOPORT);
+clientTRCK.connect(tablename + ".tracklet", SCHEMAVER)
+
 clientTNS = com.Lomikel.HBaser.HBaseClient(IPADDR, ZOOPORT);
 clientTNS.connect(tablename + ".tns", SCHEMAVER)
 

--- a/apps/api.py
+++ b/apps/api.py
@@ -2091,9 +2091,13 @@ def return_tracklet():
     if 'date' in request.json:
         designation = request.json['date']
     else:
-        designation = ''
+        rep = {
+            'status': 'error',
+            'text': "You need tp specify a date at the format YYYY-MM-DD hh:mm:ss\n"
+        }
+        return Response(str(rep), 400)
 
-    designation = 'TRCK_' + designation.replace('-', '').replace(' ', '_')
+    designation = 'TRCK_' + designation.replace('-', '').replace(':', '').replace(' ', '_')
 
     # Note the trailing _
     to_evaluate = "key:key:{}".format(payload)

--- a/apps/api.py
+++ b/apps/api.py
@@ -2097,7 +2097,7 @@ def return_tracklet():
         }
         return Response(str(rep), 400)
 
-    designation = 'TRCK_' + designation.replace('-', '').replace(':', '').replace(' ', '_')
+    payload = 'TRCK_' + designation.replace('-', '').replace(':', '').replace(' ', '_')
 
     # Note the trailing _
     to_evaluate = "key:key:{}".format(payload)

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -422,6 +422,26 @@ def card_sso_radec():
     card = html.Div(id='sso_radec')
     return card
 
+def card_tracklet_lightcurve():
+    """ Add a card to display tracklet lightcurve
+    Returns
+    ----------
+    card: dbc.Card
+        Card with the tracklet lightcurve
+    """
+    card = html.Div(id='tracklet_lightcurve')
+    return card
+
+def card_tracklet_radec():
+    """ Add a card to display tracklet radec
+    Returns
+    ----------
+    card: dbc.Card
+        Card with the tracklet radec
+    """
+    card = html.Div(id='tracklet_radec')
+    return card
+
 def card_sso_skymap():
     """ Display the sky map in the explorer tab results (Aladin lite)
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2080,9 +2080,10 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         color="info"
     )
 
-    toast = html.Div(
+    info = dbc.Row(
         [
-            dbc.Button(
+            dbc.Col(alert, width=8),
+            dbc.Col(dbc.Button(
                 "Information",
                 id="simple-toast-toggle",
                 color="secondary",
@@ -2090,21 +2091,20 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
                 className="mb-3",
                 n_clicks=0,
                 block=True
-            ),
-            dbc.Toast(
-                [dcc.Markdown(msg)],
-                id="simple-toast",
-                header="Fink tracklets",
-                icon="primary",
-                dismissable=True,
-                is_open=False
-            ),
+            ), width=4),
         ]
     )
 
     card = [
-        alert,
-        toast,
+        info,
+        dbc.Toast(
+            [dcc.Markdown(msg)],
+            id="simple-toast",
+            header="Fink tracklets",
+            icon="primary",
+            dismissable=True,
+            is_open=False
+        ),
         dbc.Card(
             dbc.CardBody(graph),
             className="mt-3"

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -24,7 +24,7 @@ import requests
 
 import dash
 import dash_table
-from dash.dependencies import Input, Output
+from dash.dependencies import Input, Output, State
 import plotly.graph_objects as go
 import plotly.express as px
 from plotly.subplots import make_subplots
@@ -310,6 +310,33 @@ layout_sso_radec = dict(
     }
 )
 
+layout_tracklet_lightcurve = dict(
+    automargin=True,
+    margin=dict(l=50, r=30, b=0, t=0),
+    hovermode="closest",
+    hoverlabel={
+        'align': "left"
+    },
+    legend=dict(
+        font=dict(size=10),
+        orientation="h",
+        xanchor="right",
+        x=1,
+        y=1.2,
+        bgcolor='rgba(218, 223, 225, 0.3)'
+    ),
+    yaxis={
+        'autorange': 'reversed',
+        'title': 'Magnitude',
+        'automargin': True
+    },
+    xaxis={
+        'autorange': 'reversed',
+        'title': 'Right Ascension',
+        'automargin': True
+    }
+)
+
 def extract_scores(data: java.util.TreeMap) -> pd.DataFrame:
     """ Extract SN scores from the data
     """
@@ -333,6 +360,7 @@ def plot_classbar(pdf, is_mobile=False):
         'SN candidate': 'orange',
         'Kilonova candidate': 'blue',
         'Microlensing candidate': 'green',
+        'Tracklet': "rgb(204,255,204)",
         'Solar System MPC': "rgb(254,224,144)",
         'Solar System candidate': "rgb(171,217,233)",
         'Ambiguous': 'rgb(116,196,118)',
@@ -1915,6 +1943,244 @@ def draw_sso_radec(pathname: str, object_sso) -> dict:
                     zip(
                         pdf['i:objectId'],
                         pdf['i:jd'].apply(lambda x: float(x) - 2400000.5),
+                    )
+                ),
+                'hovertemplate': hovertemplate,
+                'marker': {
+                    'size': 12,
+                    'color': '#d62728',
+                    'symbol': 'circle-open-dot'}
+            }
+        ],
+        "layout": layout_sso_radec
+    }
+    graph = dcc.Graph(
+        figure=figure,
+        style={
+            'width': '100%',
+            'height': '15pc'
+        },
+        config={'displayModeBar': False}
+    )
+    card = dbc.Card(
+        dbc.CardBody(graph),
+        className="mt-3"
+    )
+    return card
+
+@app.callback(
+    Output('tracklet_lightcurve', 'children'),
+    [
+        Input('url', 'pathname'),
+        Input('object-tracklet', 'children')
+    ])
+def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
+    """ Draw tracklet object lightcurve with errorbars
+
+    Parameters
+    ----------
+    pathname: str
+        Pathname of the current webpage (should be /ZTF19...).
+
+    Returns
+    ----------
+    figure: dict
+
+    """
+    pdf = pd.read_json(object_tracklet)
+    if pdf.empty:
+        msg = """
+        Object not associated to a tracklet
+        """
+        return html.Div([html.Br(), dbc.Alert(msg, color="danger")])
+
+    # type conversion
+    pdf['i:fid'] = pdf['i:fid'].apply(lambda x: int(x))
+
+    # shortcuts
+    mag = pdf['i:magpsf']
+    err = pdf['i:sigmapsf']
+
+    layout_tracklet_lightcurve['yaxis']['title'] = 'Difference magnitude'
+    layout_tracklet_lightcurve['yaxis']['autorange'] = 'reversed'
+
+    hovertemplate = r"""
+    <b>objectId</b>: %{customdata[0]}<br>
+    <b>%{yaxis.title.text}</b>: %{y:.2f} &plusmn; %{error_y.array:.2f}<br>
+    <b>%{xaxis.title.text}</b>: %{x:.2f}<br>
+    <b>Date</b>: %{customdata[1]}
+    <extra></extra>
+    """
+
+    def generate_plot(filt, marker, color, showlegend):
+        if filt == 1:
+            name = 'g band'
+        else:
+            name = 'r band'
+        dic = {
+            'x': pdf['i:ra'][pdf['i:fid'] == filt],
+            'y': mag[pdf['i:fid'] == filt],
+            'error_y': {
+                'type': 'data',
+                'array': err[pdf['i:fid'] == filt],
+                'visible': True,
+                'color': color
+            },
+            'mode': 'markers',
+            'name': name,
+            'showlegend': showlegend,
+            'customdata': list(
+                zip(
+                    pdf['i:objectId'][pdf['i:fid'] == filt],
+                    pdf['v:lastdate'][pdf['i:fid'] == filt]
+                )
+            ),
+            'hovertemplate': hovertemplate,
+            'marker': {
+                'size': 12,
+                'color': color,
+                'symbol': marker}
+        }
+        return dic
+
+    data_ = []
+    for filt in np.unique(pdf['i:fid']):
+        if filt == 1:
+            data_.append(generate_plot(1, marker='o', color='#1f77b4', showlegend=True))
+        elif filt == 2:
+            data_.append(generate_plot(2, marker='o', color='#ff7f0e', showlegend=True))
+
+    figure = {
+        'data': data_,
+        "layout": layout_tracklet_lightcurve
+    }
+
+    graph = dcc.Graph(
+        figure=figure,
+        style={
+            'width': '100%',
+            'height': '15pc'
+        },
+        config={'displayModeBar': False}
+    )
+
+    msg = """
+    Tracklets are discrete tracks (several spatially connected dots)
+    seen on one or more exposures. This is somehow similar to solar
+    system objects, expect that these objects are probably human-made,
+    they are typically fast moving, and they seem to orbit
+    around the Earth (this type of orbit is also tight to
+    the detection method we use). The rotation period, in hour, is inferred from the
+    velocity estimate of the object assuming a circular orbit.
+    The velocity is computed by integrating the distance between subsequent measurements:
+    ```
+    v = sum_i[x(i+1) - x(i)] / dt, i=alert
+    ```
+    If the tracklet spans several exposures, we discard exposures with less than 5 alerts.
+    Discarded alerts are shown with cross markers, while alerts used to estimate the period are
+    shown with circle markers.
+    """
+    card_info = dbc.Card(
+        dbc.CardBody(
+            dcc.Markdown(msg)
+        ), style={
+            'backgroundColor': 'rgb(248, 248, 248, .7)'
+        }
+    )
+
+    alert = dbc.Alert(
+        "Tracklet ID: {} -- Inferred period: {:.1f} hours".format(
+            pdf['d:tracklet'].values[0],
+            period
+        ),
+        color="info"
+    )
+
+    toast = html.Div(
+        [
+            dbc.Button(
+                "Information",
+                id="simple-toast-toggle",
+                color="secondary",
+                outline=True,
+                className="mb-3",
+                n_clicks=0,
+                block=True
+            ),
+            dbc.Toast(
+                [dcc.Markdown(msg)],
+                id="simple-toast",
+                header="Fink tracklets",
+                icon="primary",
+                dismissable=True,
+                is_open=False
+            ),
+        ]
+    )
+
+    card = [
+        alert,
+        toast,
+        dbc.Card(
+            dbc.CardBody(graph),
+            className="mt-3"
+        )
+    ]
+    return card
+
+@app.callback(
+    Output("simple-toast", "is_open"),
+    [Input("simple-toast-toggle", "n_clicks")],
+    [State("simple-toast", "is_open")],
+)
+def open_toast(n, is_open):
+    if n:
+        return not is_open
+    return is_open
+
+@app.callback(
+    Output('tracklet_radec', 'children'),
+    [
+        Input('url', 'pathname'),
+        Input('object-tracklet', 'children')
+    ])
+def draw_tracklet_radec(pathname: str, object_tracklet) -> dict:
+    """ Draw tracklet object radec
+    Parameters
+    ----------
+    pathname: str
+        Pathname of the current webpage (should be /ZTF19...).
+    Returns
+    ----------
+    figure: dict
+    """
+    pdf = pd.read_json(object_tracklet)
+    if pdf.empty:
+        msg = ""
+        return msg
+
+    # shortcuts
+    ra = pdf['i:ra'].apply(lambda x: float(x))
+    dec = pdf['i:dec'].apply(lambda x: float(x))
+
+    hovertemplate = r"""
+    <b>objectId</b>: %{customdata[0]}<br>
+    <b>%{yaxis.title.text}</b>: %{y:.2f}<br>
+    <b>%{xaxis.title.text}</b>: %{x:.2f}<br>
+    <b>Date</b>: %{customdata[1]}
+    <extra></extra>
+    """
+    figure = {
+        'data': [
+            {
+                'x': ra,
+                'y': dec,
+                'mode': 'markers',
+                'name': 'Observations',
+                'customdata': list(
+                    zip(
+                        pdf['i:objectId'],
+                        pdf['v:lastdate']
                     )
                 ),
                 'hovertemplate': hovertemplate,

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2064,15 +2064,6 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         config={'displayModeBar': False}
     )
 
-    msg = """
-    Tracklets are discrete tracks (several spatially connected dots)
-    seen on one or more exposures. This is somehow similar to solar
-    system objects, expect that these objects are probably human-made,
-    they are typically fast moving, and they seem to orbit
-    around the Earth. Satelitte glints and space debris would typically produce
-    such signals.
-    """
-
     alert = dbc.Alert(
         "Tracklet ID: {}".format(
             pdf['d:tracklet'].values[0],
@@ -2080,47 +2071,14 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
         color="info"
     )
 
-    info = dbc.Row(
-        [
-            dbc.Col(alert, width=8),
-            dbc.Col(dbc.Button(
-                "Information",
-                id="simple-toast-toggle",
-                color="secondary",
-                outline=True,
-                className="mb-3",
-                n_clicks=0,
-                block=True
-            ), width=4),
-        ]
-    )
-
     card = [
-        info,
-        dbc.Toast(
-            [dcc.Markdown(msg)],
-            id="simple-toast",
-            header="Fink tracklets",
-            icon="primary",
-            dismissable=True,
-            is_open=False
-        ),
+        alert,
         dbc.Card(
             dbc.CardBody(graph),
             className="mt-3"
         )
     ]
     return card
-
-@app.callback(
-    Output("simple-toast", "is_open"),
-    [Input("simple-toast-toggle", "n_clicks")],
-    [State("simple-toast", "is_open")],
-)
-def open_toast(n, is_open):
-    if n:
-        return not is_open
-    return is_open
 
 @app.callback(
     Output('tracklet_radec', 'children'),

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2069,29 +2069,13 @@ def draw_tracklet_lightcurve(pathname: str, object_tracklet) -> dict:
     seen on one or more exposures. This is somehow similar to solar
     system objects, expect that these objects are probably human-made,
     they are typically fast moving, and they seem to orbit
-    around the Earth (this type of orbit is also tight to
-    the detection method we use). The rotation period, in hour, is inferred from the
-    velocity estimate of the object assuming a circular orbit.
-    The velocity is computed by integrating the distance between subsequent measurements:
-    ```
-    v = sum_i[x(i+1) - x(i)] / dt, i=alert
-    ```
-    If the tracklet spans several exposures, we discard exposures with less than 5 alerts.
-    Discarded alerts are shown with cross markers, while alerts used to estimate the period are
-    shown with circle markers.
+    around the Earth. Satelitte glints and space debris would typically produce
+    such signals.
     """
-    card_info = dbc.Card(
-        dbc.CardBody(
-            dcc.Markdown(msg)
-        ), style={
-            'backgroundColor': 'rgb(248, 248, 248, .7)'
-        }
-    )
 
     alert = dbc.Alert(
-        "Tracklet ID: {} -- Inferred period: {:.1f} hours".format(
+        "Tracklet ID: {}".format(
             pdf['d:tracklet'].values[0],
-            period
         ),
         color="info"
     )

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -33,7 +33,7 @@ from apps.cards import card_variable_plot, card_variable_button
 from apps.cards import card_explanation_variable, card_explanation_mulens
 from apps.cards import card_mulens_plot, card_mulens_button, card_mulens_param
 from apps.cards import card_sso_lightcurve, card_sso_radec, card_sso_mpc_params
- from apps.cards import card_tracklet_lightcurve, card_tracklet_radec
+from apps.cards import card_tracklet_lightcurve, card_tracklet_radec
 from apps.plotting import plot_classbar
 from apps.plotting import all_radio_options
 

--- a/assets/fink_types.csv
+++ b/assets/fink_types.csv
@@ -2,6 +2,7 @@ Early SN Ia candidate
 Kilonova candidate
 SN candidate
 Microlensing candidate
+Tracklet
 Solar System MPC
 Solar System candidate
 Ambiguous

--- a/index.py
+++ b/index.py
@@ -94,7 +94,7 @@ Choose a class of interest using the drop-down menu to see the 100 latest alerts
 
 ##### Solar System Objects (SSO)
 
-Search for Solar System Object in the Fink database.
+Search for Solar System Objects in the Fink database.
 The numbers or designations are taken from the MPC archive.
 When searching for a particular asteroid or comet, it is best to use the IAU number,
 as in 4209 for asteroid "4209 Briggs". You can also try for numbered comet (e.g. 10P),
@@ -114,6 +114,14 @@ Here are some examples of valid queries:
   * C/2020V2, C/2020R2
 
 Note for designation, you can also use space (2010 JO69 or C/2020 V2).
+
+
+##### Tracklet data
+
+Search for Tracklet Objects in the Fink database.
+
+You have the choice to specify the date in the format `YYYY-MM-DD hh:mm:ss` or
+any short versions such as `YYY-MM-DD` or `YYYY-MM-DD hh`.
 """
 
 msg_info = """
@@ -644,6 +652,8 @@ def chips_values(chip_value, val):
         return "    Show last 100 alerts for a particular class", val
     elif chip_value == "SSO":
         return "    Enter a valid IAU number. See Help for more information", val
+    elif chip_value == "Tracklet":
+        return "    Enter a date to get satellite glints or debris. See Help for more information", val
     else:
         return default, ""
 
@@ -840,6 +850,16 @@ def results(ns, query, query_type, dropdown_option, is_mobile, searchurl, result
                 'n_or_d': query_
             }
         )
+    elif query_type == 'Tracklet':
+        # strip from spaces
+        payload = {
+            'date': query
+        }
+
+        r = requests.post(
+            '{}/api/v1/tracklet'.format(APIURL),
+            json=payload
+        )
     elif query_type == 'Conesearch':
         args = [i.strip() for i in query.split(',')]
         if len(args) == 3:
@@ -981,6 +1001,9 @@ def open_noresults(n, results, query, query_type, dropdown_option, searchurl):
         elif query_type == 'SSO':
             header = "Search by Solar System Object ID"
             text = "{} ({}) not found".format(query, str(query).replace(' ', ''))
+        elif query_type == 'Tracklet':
+            header = "Search by Tracklet ID"
+            text = "{} not found".format(query)
         elif query_type == 'Conesearch':
             header = "Conesearch"
             text = "No alerts found for (RA, Dec, radius) = {}".format(
@@ -1130,6 +1153,7 @@ def display_page(pathname, is_mobile):
                             {"value": "Date Search", "label": "Date Search"},
                             {"value": "Class Search", "label": "Class Search"},
                             {"value": "SSO", "label": "SSO"},
+                            {"value": "Tracklet", "label": "Tracklet"},
                         ],
                         id="dropdown-query",
                         value='objectId',

--- a/index.py
+++ b/index.py
@@ -127,6 +127,7 @@ any short versions such as `YYY-MM-DD` or `YYYY-MM-DD hh`. E.g. try:
 
 - 2020-08-10
 - 2021-10-22 09:19
+- 2020-07-16 04:58:48
 """
 
 msg_info = """

--- a/index.py
+++ b/index.py
@@ -621,6 +621,7 @@ def input_type(chip_value):
             {'label': 'Microlensing candidates', 'value': 'Microlensing candidate'},
             {'label': 'Solar System (MPC)', 'value': 'Solar System MPC'},
             {'label': 'Solar System (candidates)', 'value': 'Solar System candidate'},
+            {'label': 'Tracklet (space debris & satellite glints)', 'value': 'Tracklet'},
             {'label': 'Ambiguous', 'value': 'Ambiguous'},
             {'label': 'TNS classified data', 'disabled': True, 'value': 'None'},
             *[{'label': '(TNS) ' + simtype, 'value': '(TNS) ' + simtype} for simtype in tns_types],

--- a/index.py
+++ b/index.py
@@ -125,7 +125,7 @@ produced by satellite glints or space debris.
 You have the choice to specify the date in the format `YYYY-MM-DD hh:mm:ss` or
 any short versions such as `YYY-MM-DD` or `YYYY-MM-DD hh`. E.g. try:
 
-- 2020-10-08
+- 2020-08-10
 - 2021-10-22 09:19
 """
 

--- a/index.py
+++ b/index.py
@@ -118,10 +118,15 @@ Note for designation, you can also use space (2010 JO69 or C/2020 V2).
 
 ##### Tracklet data
 
-Search for Tracklet Objects in the Fink database.
+Search for Tracklet Objects in the Fink database. Tracklets are fast
+moving objects, typically orbiting around the Earth. They are most likely
+produced by satellite glints or space debris.
 
 You have the choice to specify the date in the format `YYYY-MM-DD hh:mm:ss` or
-any short versions such as `YYY-MM-DD` or `YYYY-MM-DD hh`.
+any short versions such as `YYY-MM-DD` or `YYYY-MM-DD hh`. E.g. try:
+
+- 2020-10-08
+- 2021-10-22 09:19
 """
 
 msg_info = """
@@ -525,6 +530,7 @@ def display_skymap(validation, data, columns, activetab):
             'SN candidate': 'orange',
             'Kilonova candidate': 'blue',
             'Microlensing candidate': 'green',
+            'Tracklet': "rgb(204,255,204)",
             'Solar System MPC': "rgb(254,224,144)",
             'Solar System candidate': "rgb(171,217,233)",
             'Ambiguous': 'rgb(116,196,118)',


### PR DESCRIPTION
Closes #203 

This PR exposes tracklet data to the users. A tracklet is a set of spatially connected alerts (typically belonging to the same exposure) from a fast moving object. This is somehow similar to solar system object, expect that these objects are mainly man-made and they typically orbit around the Earth. The tracklet data can be accessed in different ways:
- search by class
- search for tracklets

more information at https://fink-portal.org/api.

## Search by class

Tracklets are an object class like the other classes. Hence you can look for these using the class search:

<img width="1439" alt="Screenshot 2022-01-19 at 14 37 19" src="https://user-images.githubusercontent.com/20426972/150143759-57ba8c9b-13c5-4f71-be90-c428bfc18436.png">

In the API you would just use:

```python
import requests
import pandas as pd

# Get latests 100 alerts belonging to tracklet
r = requests.post(
  'https://fink-portal.org/api/v1/latests',
  json={
    'class': 'Tracklet',
    'n': '100'
  }
)

# Format output in a DataFrame
pdf = pd.read_json(r.content)
```

Look for the column `pdf["tracklet"]` to find out individual tracklets.

## Search by Tracklet

In order to get tracklet data, you need to specify the date in the format `YYYY-MM-DD hh:mm:ss`.
Note you can also specify bigger interval, e.g. `YYYY-MM-DD` to get all tracklets for one day,
or `YYYY-MM-DD hh` to get all tracklets for one hour.

<img width="1440" alt="Screenshot 2022-01-19 at 14 38 03" src="https://user-images.githubusercontent.com/20426972/150144228-31789d49-8706-4438-88f6-3e6c1fd09b2c.png">

In a unix shell, you would simply use

```bash
# Get tracklet data for the night 2021-08-10
curl -H "Content-Type: application/json" -X POST -d '{"date":"2021-08-10", "output-format":"csv"}' http://134.158.75.151:24000/api/v1/tracklet -o trck_20210810.csv
```

In python, you would use

```python
import requests
import pandas as pd

# Get all tracklet data for the night 2021-08-10
r = requests.post(
  'http://134.158.75.151:24000/api/v1/tracklet',
  json={
    'date': '2021-08-10',
    'output-format': 'json'
  }
)

# Format output in a DataFrame
pdf = pd.read_json(r.content)
```
You can also specify up to the second if you know the exposure time:

```python
# Get tracklet data TRCK_20211022_091949
r = requests.post(
  'http://134.158.75.151:24000/api/v1/tracklet',
  json={
    'id': '2021-10-22 09:19:49',
    'output-format': 'json'
  }
)
```

Finally if there are several tracklets in one exposure, you can select the one you want:

```python
# Get first tracklet TRCK_20211022_091949_00
r = requests.post(
  'http://134.158.75.151:24000/api/v1/tracklet',
  json={
    'id': '2021-10-22 09:19:49 00',
    'output-format': 'json'
  }
)
```

They are ordered by two digits 00, 01, 02, ...

## Tracklet data display

The tracklet data (if it exists) is displayed on the right most tab of an alert belonging to that tracklet:

<img width="1440" alt="Screenshot 2022-01-19 at 14 50 11" src="https://user-images.githubusercontent.com/20426972/150144863-985d8138-a003-4d9f-8133-456eb9bd616d.png">


Alternatively, you can also display the tracklet when querying the results, using the Sky Map tab:

<img width="1440" alt="Screenshot 2022-01-19 at 14 56 34" src="https://user-images.githubusercontent.com/20426972/150144825-f6b54926-2695-443a-9c3c-f13a7316f087.png">


Todo: see #203 