### PR TITLE
Speed up query performances by disabling color computation

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -1919,7 +1919,12 @@ def latest_objects():
         group_alerts = False
 
     # We want to return alerts
-    pdfs = format_hbase_output(results, schema_client, group_alerts=group_alerts)
+    # color computation is disabled
+    pdfs = format_hbase_output(
+        results, schema_client,
+        group_alerts=group_alerts,
+        extract_color=False
+    )
 
     if output_format == 'json':
         return pdfs.to_json(orient='records')
@@ -2249,7 +2254,9 @@ def return_cutouts():
     # Format the results
     schema_client = client.schema()
     pdf = format_hbase_output(
-        results, schema_client, group_alerts=False, truncated=truncated
+        results, schema_client,
+        group_alerts=False, truncated=truncated,
+        extract_color=False
     )
 
     # Extract only the alert of interest

--- a/apps/api.py
+++ b/apps/api.py
@@ -1923,7 +1923,8 @@ def latest_objects():
     pdfs = format_hbase_output(
         results, schema_client,
         group_alerts=group_alerts,
-        extract_color=False
+        extract_color=False,
+        with_constellation=False
     )
 
     if output_format == 'json':

--- a/apps/api.py
+++ b/apps/api.py
@@ -1924,7 +1924,7 @@ def latest_objects():
         results, schema_client,
         group_alerts=group_alerts,
         extract_color=False,
-        with_constellation=False
+        with_constellation=True
     )
 
     if output_format == 'json':

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -2939,7 +2939,6 @@ def plot_stat_evolution(pathname, param_name, switch):
         text=newcol,
     )
     fig.update_traces(
-        texttemplate='%{text:.2s}',
         textposition='outside',
         marker_color='rgb(21, 40, 79)'
     )

--- a/tests/api_performance_test.py
+++ b/tests/api_performance_test.py
@@ -1,0 +1,76 @@
+# Copyright 2022 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import requests
+import pandas as pd
+import numpy as np
+import time
+
+import io
+import sys
+
+APIURL = sys.argv[1]
+
+def classsearch(myclass='Solar System MPC', n=100000, startdate='2022-03-03', stopdate='2022-03-04', output_format='json'):
+    """ Perform a heavy class search in the Science Portal using the Fink REST API
+    """
+    payload = {
+        'class': myclass,
+        'n': n,
+        'output_format': output_format
+    }
+
+    if startdate is not None:
+        payload.update(
+            {
+                'startdate': startdate,
+                'stopdate': stopdate
+            }
+        )
+
+    r = requests.post(
+        '{}/api/v1/latests'.format(APIURL),
+        json=payload
+    )
+
+    if output_format == 'json':
+        # Format output in a DataFrame
+        pdf = pd.read_json(r.content)
+    elif output_format == 'csv':
+        pdf = pd.read_csv(io.BytesIO(r.content))
+    elif output_format == 'parquet':
+        pdf = pd.read_parquet(io.BytesIO(r.content))
+
+    return pdf
+
+def test_heavy_classsearch() -> None:
+    """
+    Examples
+    ---------
+    >>> test_heavy_classsearch()
+    """
+    t0 = time.time()
+    pdf = classsearch()
+    dt = time.time() - t0
+
+    # less than 45 seconds to get 21,000 objects
+    assert dt < 45, 'Spent {} seconds in querying for MPC objects -- too long!'.format(dt)
+
+
+if __name__ == "__main__":
+    """ Execute the test suite """
+    import sys
+    import doctest
+
+    sys.exit(doctest.testmod()[0])


### PR DESCRIPTION
Closes #282 

If a query returns many objects, the computation of color slows down enormously the query execution time. For 20,000 objects one goes from 15 seconds to more than 180 seconds (timeout error).

It is available only when using the `objects` endpoint.