### PR TITLE
Allow multi-object search

### DIFF
--- a/apps/api.py
+++ b/apps/api.py
@@ -1510,7 +1510,7 @@ def return_object():
         cols = '*'
         truncated = False
 
-    if request.json['objectId'].contains(','):
+    if ',' in request.json['objectId']:
         splitids = request.json['objectId'].split(',')
         ids = ['key:key:{}'.format(i.strip()) for i in splitids]
         to_evaluate = ','.join(ids)

--- a/apps/api.py
+++ b/apps/api.py
@@ -1513,19 +1513,31 @@ def return_object():
     if ',' in request.json['objectId']:
         splitids = request.json['objectId'].split(',')
         ids = ['key:key:{}'.format(i.strip()) for i in splitids]
-        to_evaluate = ','.join(ids)
+        # to_evaluate = ','.join(ids)
     else:
-        to_evaluate = "key:key:{}".format(request.json['objectId'])
+        # to_evaluate = "key:key:{}".format(request.json['objectId'])
+        ids = ["key:key:{}".format(request.json['objectId'])]
 
     # We do not want to perform full scan if the objectid is a wildcard
     client.setLimit(1000)
 
-    results = client.scan(
-        "",
-        to_evaluate,
-        cols,
-        0, True, True
-    )
+    # results = client.scan(
+    #     "",
+    #     to_evaluate,
+    #     cols,
+    #     0, True, True
+    # )
+
+    # Get data from the main table
+    results = java.util.TreeMap()
+    for to_evaluate in ids:
+        result = client.scan(
+            "",
+            to_evaluate,
+            cols,
+            0, True, True
+        )
+        results.putAll(result)
 
     schema_client = client.schema()
 
@@ -1541,18 +1553,38 @@ def return_object():
 
     if 'withupperlim' in request.json and str(request.json['withupperlim']) == 'True':
         # upper limits
-        resultsU = clientU.scan(
-            "",
-            "{}".format(to_evaluate),
-            "*", 0, False, False
-        )
+        # resultsU = clientU.scan(
+        #     "",
+        #     "{}".format(to_evaluate),
+        #     "*", 0, False, False
+        # )
+
+        # upper limits
+        resultsU = java.util.TreeMap()
+        for to_evaluate in ids:
+            resultU = clientU.scan(
+                "",
+                to_evaluate,
+                "*",
+                0, False, False
+            )
+            resultsU.putAll(resultU)
 
         # bad quality
-        resultsUP = clientUV.scan(
-            "",
-            "{}".format(to_evaluate),
-            "*", 0, False, False
-        )
+        # resultsUP = clientUV.scan(
+        #     "",
+        #     "{}".format(to_evaluate),
+        #     "*", 0, False, False
+        # )
+        resultsUP = java.util.TreeMap()
+        for to_evaluate in ids:
+            resultUP = clientUV.scan(
+                "",
+                to_evaluate,
+                "*",
+                0, False, False
+            )
+            resultsUP.putAll(resultUP)
 
         pdfU = pd.DataFrame.from_dict(resultsU, orient='index')
         pdfUP = pd.DataFrame.from_dict(resultsUP, orient='index')

--- a/apps/api.py
+++ b/apps/api.py
@@ -1509,7 +1509,13 @@ def return_object():
     else:
         cols = '*'
         truncated = False
-    to_evaluate = "key:key:{}".format(request.json['objectId'])
+
+    if request.json['objectId'].contains(','):
+        splitids = request.json['objectId'].split(',')
+        ids = ['key:key:{}'.format(i.strip()) for i in splitids]
+        to_evaluate = ','.join(ids)
+    else:
+        to_evaluate = "key:key:{}".format(request.json['objectId'])
 
     # We do not want to perform full scan if the objectid is a wildcard
     client.setLimit(1000)

--- a/tests/api_single_object_test.py
+++ b/tests/api_single_object_test.py
@@ -151,6 +151,30 @@ def test_bad_request() -> None:
 
     assert pdf.empty
 
+def test_multiple_objects() -> None:
+    """
+    Examples
+    ---------
+    >>> test_multiple_objects()
+    """
+    OIDS_ = ['ZTF21abfmbix', 'ZTF21aaxtctv', 'ZTF21abfaohe']
+    OIDS = ','.join(OIDS_)
+    pdf = get_an_object(oid=OIDS)
+
+    n_oids = len(np.unique(pdf.groupby('i:objectId').count()['i:ra']))
+    assert n_oids == 3
+
+    n_oids_single = 0
+    len_object = 0
+    for oid in OIDS_:
+        pdf_ = get_an_object(oid=oid)
+        n_oid = len(np.unique(pdf_.groupby('i:objectId').count()['i:ra']))
+        n_oids_single += n_oid
+        len_object += len(pdf_)
+
+    assert n_oids == n_oids_single, '{} is not equal to {}'.format(n_oids, n_oids_single)
+    assert len_object == len(pdf), '{} is not equal to {}'.format(len_object, len(pdf))
+
 
 if __name__ == "__main__":
     """ Execute the test suite """


### PR DESCRIPTION
Closes #291 

Now one can query the data for many objects at the same time:

```python
import requests
import pandas as pd
import numpy as np

r = requests.post(
  'https://fink-portal.org/api/v1/objects',
  json={
    'objectId': 'ZTF19acmdpyr,ZTF21aaxtctv',
    'withupperlim': 'True'
  }
)

# Format output in a DataFrame
pdf = pd.read_json(r.content)
n_oids = len(np.unique(pdf.groupby('i:objectId').count()['i:ra']))
# 2 objects
```

The argument is a comma-separated list of ZTF object IDs.

Todo:
- [x] Update documentation.