### PR TITLE
Check if jd exists before sorting or grouping

### DIFF
--- a/apps/utils.py
+++ b/apps/utils.py
@@ -111,12 +111,13 @@ def format_hbase_output(
             pdfs['v:constellation'] = constellations
 
     # Display only the last alert
-    if group_alerts:
+    if group_alerts and ('i:jd' in pdfs.columns) and ('i:objectId' in pdfs.columns):
         pdfs['i:jd'] = pdfs['i:jd'].astype(float)
         pdfs = pdfs.loc[pdfs.groupby('i:objectId')['i:jd'].idxmax()]
 
     # sort values by time
-    pdfs = pdfs.sort_values('i:jd', ascending=False)
+    if 'i:jd' in pdfs.columns:
+        pdfs = pdfs.sort_values('i:jd', ascending=False)
 
     return pdfs
 

--- a/tests/api_classsearch_test.py
+++ b/tests/api_classsearch_test.py
@@ -119,11 +119,11 @@ def test_classsearch_and_date() -> None:
 
     assert np.alltrue(pdf['v:lastdate'].values >= '2021-11-01')
 
-def test_classsearch_and_cols() -> None:
+def test_classsearch_and_cols_with_sort() -> None:
     """
     Examples
     ---------
-    >>> test_classsearch_and_cols()
+    >>> test_classsearch_and_cols_with_sort()
     """
     pdf = classsearch(cols='i:jd,i:objectId')
 
@@ -134,6 +134,20 @@ def test_classsearch_and_cols() -> None:
     assert 'i:jd' in pdf.columns
     assert 'i:objectId' in pdf.columns
     assert 'v:classifation' not in pdf.columns
+
+def test_classsearch_and_cols_without_sort() -> None:
+    """
+    Examples
+    ---------
+    >>> test_classsearch_and_cols_without_sort()
+    """
+    pdf = classsearch(cols='i:objectId')
+
+    assert not pdf.empty
+
+    assert len(pdf.columns) == 1, len(pdf.columns)
+
+    assert 'i:objectId' in pdf.columns
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #293 

Check if `i:jd` exists before sorting or grouping.