### PR TITLE
Group by alerts to get unique list

### DIFF
--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -669,7 +669,8 @@ def columns_arguments():
             {'name': 'g-r', 'type': 'double', 'doc': 'Last g-r measurement for this object.'},
             {'name': 'rate(g-r)', 'type': 'double', 'doc': 'g-r rate in mag/day (between last and first available g-r measurements).'},
             {'name': 'lastdate', 'type': 'string', 'doc': 'Human readable datetime for the alert (from the i:jd field).'},
-            {'name': 'firstdate', 'type': 'string', 'doc': 'Human readable datetime of first detection (from the i:jd field).'},
+            {'name': 'firstdate', 'type': 'string', 'doc': 'Human readable datetime for the first detection of the object (from the i:jdstarthist field).'},
+            {'name': 'lapse', 'type': 'string', 'doc': 'Number of days between first and last detection.'},
         ]
     )
 

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -668,7 +668,8 @@ def columns_arguments():
             {'name': 'classification', 'type': 'string', 'doc': 'Fink inferred classification. See https://fink-portal.org/api/v1/classes'},
             {'name': 'g-r', 'type': 'double', 'doc': 'Last g-r measurement for this object.'},
             {'name': 'rate(g-r)', 'type': 'double', 'doc': 'g-r rate in mag/day (between last and first available g-r measurements).'},
-            {'name': 'lastdate', 'type': 'string', 'doc': 'Datetime for the alert (from the i:jd field).'},
+            {'name': 'lastdate', 'type': 'string', 'doc': 'Human readable datetime for the alert (from the i:jd field).'},
+            {'name': 'firstdate', 'type': 'string', 'doc': 'Human readable datetime of first detection (from the i:jd field).'},
         ]
     )
 

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -459,6 +459,9 @@ def return_latests_pdf(payload: dict) -> pd.DataFrame:
         schema_client = clientT.schema()
         group_alerts = False
 
+        # Restore default limits
+        clientT.setLimit(nlimit)
+
     # We want to return alerts
     # color computation is disabled
     pdfs = format_hbase_output(

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -422,6 +422,7 @@ def return_latests_pdf(payload: dict) -> pd.DataFrame:
         )
         schema_client = clientTNS.schema()
         group_alerts = True
+        clientTNS.setLimit(nlimit)
     elif payload['class'].startswith('(SIMBAD)') or payload['class'] != 'allclasses':
         if payload['class'].startswith('(SIMBAD)'):
             classname = payload['class'].split('(SIMBAD) ')[1]
@@ -444,6 +445,7 @@ def return_latests_pdf(payload: dict) -> pd.DataFrame:
         )
         schema_client = clientS.schema()
         group_alerts = False
+        clientS.setLimit(nlimit)
     elif payload['class'] == 'allclasses':
         clientT.setLimit(nalerts)
         clientT.setRangeScan(True)

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -106,6 +106,7 @@ def format_hbase_output(
 
         # Human readable time
         pdfs['v:lastdate'] = pdfs['i:jd'].apply(convert_jd)
+        pdfs['v:firstdate'] = pdfs['i:jdstarthist'].apply(convert_jd)
 
         if with_constellation:
             coords = SkyCoord(

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -107,6 +107,7 @@ def format_hbase_output(
         # Human readable time
         pdfs['v:lastdate'] = pdfs['i:jd'].apply(convert_jd)
         pdfs['v:firstdate'] = pdfs['i:jdstarthist'].apply(convert_jd)
+        pdfs['v:lapse'] = pdfs['i:jd'] - pdfs['i:jdstarthist']
 
         if with_constellation:
             coords = SkyCoord(

--- a/assets/simbad_types.csv
+++ b/assets/simbad_types.csv
@@ -177,6 +177,7 @@ Flare*
 FUOr
 Erupt*RCrB
 RCrB_Candidate
+RSG*_Candidate
 RotV*
 RotV*alf2CVn
 Pulsar

--- a/index.py
+++ b/index.py
@@ -651,7 +651,7 @@ def input_type(chip_value):
             {'label': 'Simbad crossmatch', 'disabled': True, 'value': 'None'},
             *[{'label': '(SIMBAD) ' + simtype, 'value': '(SIMBAD) ' + simtype} for simtype in simbad_types]
         ]
-        placeholder = "Start typing or choose a class. We will display the last 100 alerts for this class."
+        placeholder = "All classes"
         return {}, options, placeholder
     else:
         return {'display': 'none'}, [], ''
@@ -679,7 +679,7 @@ def chips_values(chip_value, val):
     elif chip_value == "Date Search":
         return "    Search alerts inside a time window. See Help for the syntax", val
     elif chip_value == "Class Search":
-        return "    Show last 100 alerts for a particular class", val
+        return "    Choose a class below. We will display the last 100 alerts for this class.", val
     elif chip_value == "SSO":
         return "    Enter a valid IAU number. See Help for more information", val
     elif chip_value == "Tracklet":

--- a/index.py
+++ b/index.py
@@ -442,7 +442,7 @@ def display_table_results(table, is_mobile):
     fink_additional_fields = [
         'v:constellation', 'v:g-r', 'v:rate(g-r)',
         'v:classification',
-        'v:lastdate', 'v:firstdate'
+        'v:lastdate', 'v:firstdate', 'v:lapse'
     ]
 
     dropdown = dcc.Dropdown(

--- a/index.py
+++ b/index.py
@@ -469,43 +469,31 @@ def display_table_results(table, is_mobile):
     if is_mobile:
         width_dropdown = 8
         width_preview = 4
-
-        return dbc.Container([
-            html.Br(),
-            dbc.Row(
-                [
-                    dbc.Col(dropdown, width=width_dropdown),
-                    dbc.Col(modal_quickview, width=width_preview)
-                ]
-            ),
-            html.Br(),
-            table
-        ], fluid=True)
     else:
         width_dropdown = 10
         width_preview = 2
 
-        return dbc.Container([
-            html.Br(),
-            dbc.Row(
-                [
-                    dbc.Col(dropdown, width=width_dropdown),
-                    dbc.Col(modal_quickview, width=width_preview)
-                ]
-            ),
-            dbc.Row(
-                [
-                    dbc.Col(switch, width=width_preview),
-                    dbc.Popover(
-                        [dbc.PopoverBody(switch_description)],
-                        target="alert-object-switch",
-                        trigger="hover",
-                        placement="top"
-                    ),
-                ], justify='between'
-            ),
-            table
-        ], fluid=True)
+    return dbc.Container([
+        html.Br(),
+        dbc.Row(
+            [
+                dbc.Col(dropdown, width=width_dropdown),
+                dbc.Col(modal_quickview, width=width_preview)
+            ]
+        ),
+        dbc.Row(
+            [
+                dbc.Col(switch, width=width_preview),
+                dbc.Popover(
+                    [dbc.PopoverBody(switch_description)],
+                    target="alert-object-switch",
+                    trigger="hover",
+                    placement="top"
+                ),
+            ], justify='between'
+        ),
+        table
+    ], fluid=True)
 
 @app.callback(
     Output('aladin-lite-div-skymap', 'run'),

--- a/index.py
+++ b/index.py
@@ -500,6 +500,7 @@ def display_table_results(table, is_mobile):
                         [dbc.PopoverBody(switch_description)],
                         target="alert-object-switch",
                         trigger="hover",
+                        placement="top"
                     ),
                 ], justify='between'
             ),

--- a/index.py
+++ b/index.py
@@ -485,13 +485,16 @@ def display_table_results(table, is_mobile):
 
         return dbc.Container([
             html.Br(),
-            dbc.Row(dbc.Col(switch)),
-            html.Br(),
             dbc.Row(
                 [
-                    dbc.Col(dropdown, width=width_dropdown),
-                    dbc.Col(modal_quickview, width=width_preview)
+                    dbc.Col(dropdown, width=12),
                 ]
+            ),
+            dbc.Row(
+                [
+                    dbc.Col(switch),
+                    dbc.Col(modal_quickview)
+                ], justify='between'
             ),
             html.Br(),
             table

--- a/index.py
+++ b/index.py
@@ -852,7 +852,9 @@ def results(query, query_type, dropdown_option, is_mobile, searchurl, results):
         0: not results found, 1: results found
     """
     colnames_to_display = [
-        'i:objectId', 'i:ra', 'i:dec', 'v:lastdate', 'v:classification', 'i:ndethist'
+        'i:objectId', 'i:ra', 'i:dec',
+        'v:lastdate', 'v:classification', 'i:ndethist',
+        'v:lapse'
     ]
 
     # catch parameters sent from URL

--- a/index.py
+++ b/index.py
@@ -492,8 +492,8 @@ def display_table_results(table, is_mobile):
             ),
             dbc.Row(
                 [
-                    dbc.Col(switch),
-                    dbc.Col(modal_quickview)
+                    dbc.Col(switch, width=width_preview),
+                    dbc.Col(modal_quickview, width=width_preview)
                 ], justify='between'
             ),
             html.Br(),

--- a/index.py
+++ b/index.py
@@ -487,16 +487,15 @@ def display_table_results(table, is_mobile):
             html.Br(),
             dbc.Row(
                 [
-                    dbc.Col(dropdown, width=12),
+                    dbc.Col(dropdown, width=width_dropdown),
+                    dbc.Col(modal_quickview, width=width_preview)
                 ]
             ),
             dbc.Row(
                 [
                     dbc.Col(switch, width=width_preview),
-                    dbc.Col(modal_quickview, width=width_preview)
                 ], justify='between'
             ),
-            html.Br(),
             table
         ], fluid=True)
 

--- a/index.py
+++ b/index.py
@@ -459,9 +459,9 @@ def display_table_results(table, is_mobile):
     switch = dmc.Switch(
         size="md",
         radius="xl",
-        label="Enable this option",
+        label="Objects",
         color="orange",
-        checked=True
+        checked=False
     )
 
     if is_mobile:

--- a/index.py
+++ b/index.py
@@ -457,8 +457,8 @@ def display_table_results(table, is_mobile):
     )
 
     switch = dmc.Switch(
-        size="lg",
-        radius="sm",
+        size="md",
+        radius="xl",
         label="Enable this option",
         color="orange",
         checked=True

--- a/index.py
+++ b/index.py
@@ -489,10 +489,10 @@ def display_table_results(table, is_mobile):
             dbc.Row(
                 [
                     dbc.Col(dropdown, width=width_dropdown),
-                    dbc.Col(switch, width=width_switch),
                     dbc.Col(modal_quickview, width=width_preview)
                 ]
             ),
+            dbc.Row(dbc.Col(switch, width=width_switch)),
             html.Br(),
             table
         ], fluid=True)

--- a/index.py
+++ b/index.py
@@ -817,7 +817,7 @@ def update_table(field_dropdown, groupby, data, columns):
         return data, columns
     elif groupby is True:
         pdf = pd.DataFrame.from_dict(data)
-        pdf.drop_duplicates(subset='i:objectId', keep="first")
+        pdf = pdf.drop_duplicates(subset='i:objectId', keep="first")
         data = pdf.to_dict('records')
         return data, columns
     else:

--- a/index.py
+++ b/index.py
@@ -456,19 +456,12 @@ def display_table_results(table, is_mobile):
         placeholder="Add more fields to the table",
     )
 
-    switch = dmc.Chips(
-        data=[
-            {"value": "object", "label": "object"},
-        ],
-        id="alert-object-switch",
-        value='alert',
+    switch = dmc.Switch(
+        size="lg",
+        radius="sm",
+        label="Enable this option",
         color="orange",
-        radius="xl",
-        size="sm",
-        spacing="xl",
-        variant="outline",
-        position='center',
-        multiple=True,
+        checked=True
     )
 
     if is_mobile:

--- a/index.py
+++ b/index.py
@@ -692,10 +692,11 @@ def chips_values(chip_value, val):
     [
         Input("submit", "n_clicks"),
         Input("search_bar_input", "n_submit"),
+        Input("select", "options"),
         Input("url", "search")
     ],
 )
-def logo(ns, nss, searchurl):
+def logo(ns, nss, options, searchurl):
     """ Show the logo in the start page (and hide it otherwise)
     """
     ctx = dash.callback_context
@@ -719,7 +720,7 @@ def logo(ns, nss, searchurl):
     else:
         button_id = ctx.triggered[0]["prop_id"].split(".")[0]
 
-    if button_id in ["submit", "search_bar_input"] or searchurl != '':
+    if (button_id in ["submit", "search_bar_input"]) or (searchurl != '') or (options != []):
         return []
     else:
         return logo
@@ -843,12 +844,6 @@ def results(query, query_type, dropdown_option, is_mobile, searchurl, results):
     colnames_to_display = [
         'i:objectId', 'i:ra', 'i:dec', 'v:lastdate', 'v:classification', 'i:ndethist'
     ]
-
-    ctx = dash.callback_context
-    button_id = ctx.triggered[0]["prop_id"].split(".")[0]
-
-    #if button_id != "submit" and searchurl == '':
-    #    raise PreventUpdate
 
     # catch parameters sent from URL
     # override any other options

--- a/index.py
+++ b/index.py
@@ -456,17 +456,19 @@ def display_table_results(table, is_mobile):
         placeholder="Add more fields to the table",
     )
 
-    switch = html.Div(
-        [
-            dbc.Checklist(
-                options=[
-                    {"label": "Object view", "value": 1},
-                ],
-                value=0,
-                id="alert-object-switch",
-                switch=True,
-            ),
-        ]
+    switch = dmc.Chips(
+        data=[
+            {"value": "object", "label": "object"},
+        ],
+        id="alert-object-switch",
+        value='alert',
+        color="orange",
+        radius="xl",
+        size="sm",
+        spacing="xl",
+        variant="outline",
+        position='center',
+        multiple=True,
     )
 
     if is_mobile:

--- a/index.py
+++ b/index.py
@@ -439,7 +439,11 @@ def display_table_results(table, is_mobile):
     schema_list = list(schema.columnNames())
     fink_fields = [i for i in schema_list if i.startswith('d:')]
     ztf_fields = [i for i in schema_list if i.startswith('i:')]
-    fink_additional_fields = ['v:constellation', 'v:g-r', 'v:rate(g-r)', 'v:classification', 'v:lastdate']
+    fink_additional_fields = [
+        'v:constellation', 'v:g-r', 'v:rate(g-r)',
+        'v:classification',
+        'v:lastdate', 'v:firstdate'
+    ]
 
     dropdown = dcc.Dropdown(
         id='field-dropdown2',

--- a/index.py
+++ b/index.py
@@ -456,11 +456,18 @@ def display_table_results(table, is_mobile):
         placeholder="Add more fields to the table",
     )
 
-    switch = dbc.Switch(
-        id="alert-object-switch",
-        label="Object view",
-        value=False,
-    ),
+    switch = html.Div(
+        [
+            dbc.Checklist(
+                options=[
+                    {"label": "Object view", "value": 1},
+                ],
+                value=0,
+                id="alert-object-switch",
+                switch=True,
+            ),
+        ]
+    )
 
     if is_mobile:
         width_dropdown = 8

--- a/index.py
+++ b/index.py
@@ -486,6 +486,7 @@ def display_table_results(table, is_mobile):
         return dbc.Container([
             html.Br(),
             dbc.Row(dbc.Col(switch)),
+            html.Br(),
             dbc.Row(
                 [
                     dbc.Col(dropdown, width=width_dropdown),

--- a/index.py
+++ b/index.py
@@ -459,7 +459,7 @@ def display_table_results(table, is_mobile):
     switch = dmc.Switch(
         size="md",
         radius="xl",
-        label="Objects",
+        label="Unique objects",
         color="orange",
         checked=False
     )

--- a/index.py
+++ b/index.py
@@ -485,13 +485,13 @@ def display_table_results(table, is_mobile):
 
         return dbc.Container([
             html.Br(),
+            dbc.Row(dbc.Col(switch)),
             dbc.Row(
                 [
                     dbc.Col(dropdown, width=width_dropdown),
                     dbc.Col(modal_quickview, width=width_preview)
                 ]
             ),
-            dbc.Row(dbc.Col(switch)),
             html.Br(),
             table
         ], fluid=True)

--- a/index.py
+++ b/index.py
@@ -461,8 +461,10 @@ def display_table_results(table, is_mobile):
         radius="xl",
         label="Unique objects",
         color="orange",
-        checked=False
+        checked=False,
+        id="alert-object-switch"
     )
+    switch_description = "Toggle the switch to list each object only once. Only the latest alert will be displayed."
 
     if is_mobile:
         width_dropdown = 8
@@ -494,6 +496,11 @@ def display_table_results(table, is_mobile):
             dbc.Row(
                 [
                     dbc.Col(switch, width=width_preview),
+                    dbc.Popover(
+                        [dbc.PopoverBody(switch_description)],
+                        target="alert-object-switch",
+                        trigger="hover",
+                    ),
                 ], justify='between'
             ),
             table

--- a/index.py
+++ b/index.py
@@ -784,14 +784,15 @@ def populate_result_table(data, columns, is_mobile):
         Output("result_table", "columns"),
     ],
     [
-        Input('field-dropdown2', 'value')
+        Input('field-dropdown2', 'value'),
+        Input('alert-object-switch', 'checked')
     ],
     [
         State("result_table", "data"),
         State("result_table", "columns"),
     ]
 )
-def update_table(field_dropdown, data, columns):
+def update_table(field_dropdown, groupby, data, columns):
     """ Update table by adding new columns (no server call)
     """
     changed_id = [p['prop_id'] for p in dash.callback_context.triggered][0]
@@ -813,6 +814,11 @@ def update_table(field_dropdown, data, columns):
             # 'hideable': True,
         })
 
+        return data, columns
+    elif groupby is True:
+        pdf = pd.DataFrame.from_dict(data)
+        pdf.drop_duplicates(subset='i:objectId', keep="first")
+        data = pdf.to_dict('records')
         return data, columns
     else:
         raise PreventUpdate

--- a/index.py
+++ b/index.py
@@ -480,8 +480,7 @@ def display_table_results(table, is_mobile):
             table
         ], fluid=True)
     else:
-        width_dropdown = 8
-        width_switch = 2
+        width_dropdown = 10
         width_preview = 2
 
         return dbc.Container([
@@ -492,7 +491,7 @@ def display_table_results(table, is_mobile):
                     dbc.Col(modal_quickview, width=width_preview)
                 ]
             ),
-            dbc.Row(dbc.Col(switch, width=width_switch)),
+            dbc.Row(dbc.Col(switch)),
             html.Br(),
             table
         ], fluid=True)

--- a/index.py
+++ b/index.py
@@ -456,24 +456,44 @@ def display_table_results(table, is_mobile):
         placeholder="Add more fields to the table",
     )
 
+    switch = dbc.Switch(
+        id="alert-object-switch",
+        label="Object view",
+        value=False,
+    ),
+
     if is_mobile:
         width_dropdown = 8
         width_preview = 4
+
+        return dbc.Container([
+            html.Br(),
+            dbc.Row(
+                [
+                    dbc.Col(dropdown, width=width_dropdown),
+                    dbc.Col(modal_quickview, width=width_preview)
+                ]
+            ),
+            html.Br(),
+            table
+        ], fluid=True)
     else:
-        width_dropdown = 10
+        width_dropdown = 8
+        width_switch = 2
         width_preview = 2
 
-    return dbc.Container([
-        html.Br(),
-        dbc.Row(
-            [
-                dbc.Col(dropdown, width=width_dropdown),
-                dbc.Col(modal_quickview, width=width_preview)
-            ]
-        ),
-        html.Br(),
-        table
-    ], fluid=True)
+        return dbc.Container([
+            html.Br(),
+            dbc.Row(
+                [
+                    dbc.Col(dropdown, width=width_dropdown),
+                    dbc.Col(switch, width=width_switch),
+                    dbc.Col(modal_quickview, width=width_preview)
+                ]
+            ),
+            html.Br(),
+            table
+        ], fluid=True)
 
 @app.callback(
     Output('aladin-lite-div-skymap', 'run'),

--- a/tests/api_single_object_test.py
+++ b/tests/api_single_object_test.py
@@ -96,7 +96,7 @@ def test_column_length() -> None:
     """
     pdf = get_an_object(oid=OID)
 
-    assert len(pdf.columns) == 129, 'I count {} columns'.format(len(pdf.columns))
+    assert len(pdf.columns) == 131, 'I count {} columns'.format(len(pdf.columns))
 
 def test_withupperlim() -> None:
     """


### PR DESCRIPTION
Closes #311 

This PR introduces a number of things on the Science Portal:
- A new button that gives the capability to group by alerts by name to only output a list of unique names. The last alert (in time) is kept.
- A new column `v:firstdate` which is the human readable datetime for the first variation of the object (from `i:jdstarthist`)
- A new column `v:lapse` which is the number of days between first and last detection.

<img width="1440" alt="Screenshot 2022-06-07 at 10 06 16" src="https://user-images.githubusercontent.com/20426972/172329182-8e605799-1618-4e93-a60c-678e55e0eb1d.png">

Limitation: once the grouping by alert name is performed, one cannot go back to the full list (the table is overwritten). In order to get full results, the query needs to be re-ran.

One can  easily then filter results by their age by adding `v:lapse` and sorting:

<img width="1231" alt="Screenshot 2022-06-07 at 10 08 58" src="https://user-images.githubusercontent.com/20426972/172329819-ecac791d-1e59-41a2-9791-5103c41405af.png">



The API is untouched, although new columns are available in the results (only when transferring all columns though).