### PR TITLE
[API] Endpoint to retrieve anomalous alerts

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,4 +95,7 @@ clientSSOCAND.connect(args['tablename'] + ".sso_cand", args['SCHEMAVER'])
 clientSSOORB = com.Lomikel.HBaser.HBaseClient(args['HBASEIP'], args['ZOOPORT']);
 clientSSOORB.connect(args['tablename'] + ".orb_cand", args['SCHEMAVER'])
 
+clientANOMALY = com.Lomikel.HBaser.HBaseClient(args['HBASEIP'], args['ZOOPORT']);
+clientANOMALY.connect(args['tablename'] + ".anomaly", args['SCHEMAVER'])
+
 client.setLimit(nlimit);

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -24,6 +24,7 @@ from apps.api.doc import api_doc_summary, api_doc_object, api_doc_explorer
 from apps.api.doc import api_doc_latests, api_doc_sso, api_doc_tracklets
 from apps.api.doc import api_doc_cutout, api_doc_xmatch, api_doc_bayestar
 from apps.api.doc import api_doc_stats, api_doc_random, api_doc_ssocand
+from apps.api.doc import api_doc_anomaly
 
 from apps.api.utils import return_object_pdf, return_explorer_pdf
 from apps.api.utils import return_latests_pdf, return_sso_pdf
@@ -184,6 +185,17 @@ def layout(is_mobile):
                                         }
                                     ),
                                 ], label="Statistics", label_style = {"color": "#000"}
+                            ),
+                            dbc.Tab(
+                                [
+                                    dbc.Card(
+                                        dbc.CardBody(
+                                            dcc.Markdown(api_doc_anomaly)
+                                        ), style={
+                                            'backgroundColor': 'rgb(248, 248, 248, .7)'
+                                        }
+                                    ),
+                                ], label="Anomaly detection", label_style = {"color": "#000"}
                             ),
                             dbc.Tab(
                                 [

--- a/apps/api/doc.py
+++ b/apps/api/doc.py
@@ -1241,3 +1241,37 @@ Depending on `kind`, you would get information on:
 - `lightcurves`: photometry of objects related to candidate orbits
 - `orbParams`: orbital parameters for orbit candidates
 """
+
+api_doc_anomaly = """
+## Explore Anomaly detections
+
+This service lets you query the information about anomalous objects in Fink. Each night, Fink selects and stores
+the top 10 alerts with the most anomalous scores.
+
+The list of arguments for retrieving alert data can be found at https://fink-portal.org/api/v1/anomaly.
+
+In python, you would use
+
+```python
+import io
+import requests
+import pandas as pd
+
+r = requests.post(
+  'https://fink-portal.org/api/v1/anomaly',
+  json={
+    'n': int, # Mandatory. Number of objects to retrieve
+    'start_date': str, # Optional. YYYY-MM-DD. Default is 2023-01-25
+    'stop_date': str, # Optional. Only for lightcurves. Default is today
+    'columns': str, # Optional. Comma-separated column names to retrieve. Default is all columns.
+    'output-format': str
+  }
+)
+
+# Format output in a DataFrame
+pdf = pd.read_json(io.BytesIO(r.content))
+```
+
+Note that you will only have the alert data. If you want then to retrieve the object data, you
+can use the https://fink-portal.org/api/v1/object service.
+"""

--- a/apps/api/doc.py
+++ b/apps/api/doc.py
@@ -1246,7 +1246,7 @@ api_doc_anomaly = """
 ## Explore Anomaly detections
 
 This service lets you query the information about anomalous objects in Fink. Each night, Fink selects and stores
-the top 10 alerts with the most anomalous scores.
+the top 10 alerts with the most anomalous scores. The Science module was deployed and start producing scores on 2023-01-25.
 
 The list of arguments for retrieving alert data can be found at https://fink-portal.org/api/v1/anomaly.
 
@@ -1260,9 +1260,9 @@ import pandas as pd
 r = requests.post(
   'https://fink-portal.org/api/v1/anomaly',
   json={
-    'n': int, # Mandatory. Number of objects to retrieve
+    'n': int, # Optional. Number of objects to retrieve between `stop_date` and `start_date`. Default is 10.
     'start_date': str, # Optional. YYYY-MM-DD. Default is 2023-01-25
-    'stop_date': str, # Optional. Only for lightcurves. Default is today
+    'stop_date': str, # Optional. YYYY-MM-DD. Default is today
     'columns': str, # Optional. Comma-separated column names to retrieve. Default is all columns.
     'output-format': str
   }

--- a/apps/api/doc.py
+++ b/apps/api/doc.py
@@ -1272,6 +1272,95 @@ r = requests.post(
 pdf = pd.read_json(io.BytesIO(r.content))
 ```
 
-Note that you will only have the alert data. If you want then to retrieve the object data, you
-can use the https://fink-portal.org/api/v1/object service.
+This table has full _alert_ schema, and you can easily gets statistics, example:
+
+```python
+# retrieve all anomalies
+import io
+import requests
+import pandas as pd
+
+r = requests.post(
+  'https://fink-portal.org/api/v1/anomaly',
+  json={
+    'n': 10000, # on purpose large
+    'stop_date': '2023-05-22',
+    'columns': 'i:objectId,d:cdsxmatch,i:magpsf'
+  }
+)
+pdf = pd.read_json(io.BytesIO(r.content))
+
+pdf.groupby('d:cdsxmatch').agg({'i:objectId': 'count'}).sort_values('i:objectId', ascending=False)
+
+               i:objectId
+d:cdsxmatch
+CataclyV*             191
+Unknown               170
+Mira                   65
+RRLyr                  63
+LPV*                   52
+EB*_Candidate          21
+EB*                    20
+Star                   14
+CV*_Candidate          10
+Fail 504               10
+Blazar                  6
+V*                      6
+WD*_Candidate           4
+YSO_Candidate           4
+PulsV*                  3
+Fail 500                3
+YSO                     3
+Fail 503                2
+SN                      2
+LP*_Candidate           1
+BLLac                   1
+QSO                     1
+Radio                   1
+Seyfert_1               1
+TTau*                   1
+Em*                     1
+ClG                     1
+V*?_Candidate           1
+BlueStraggler           1
+AGN                     1
+```
+Note the `Fail X` labels are when the CDS xmatch service fails with error code X (web service).
+But because this table has full _alert_ schema, if you want full object data,
+you need to call then the `/api/v1/object` service. Example:
+
+```python
+# retrieve last 10 anomaly objectIds
+import io
+import requests
+import pandas as pd
+
+r = requests.post(
+  'https://fink-portal.org/api/v1/anomaly',
+  json={
+    'n': 10,
+    'columns': 'i:objectId'
+  }
+)
+
+# Format output in a DataFrame
+oids = [i['i:objectId'] for i in r.json()]
+
+# retrieve full objects data
+r = requests.post(
+  'https://fink-portal.org/api/v1/objects',
+  json={
+    'objectId': ','.join(oids),
+    'columns': 'i:objectId,i:magpsf,i:sigmapsf,d:anomaly_score,d:cdsxmatch',
+    'output-format': 'json'
+  }
+)
+
+# Format output in a DataFrame
+pdf = pd.read_json(io.BytesIO(r.content))
+```
+
+Note the first time, the `/api/v1/object` query can be long (especially if
+you are dealing with variable stars), but then data is cached on the server,
+and subsequent queries are much faster.
 """

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1242,6 +1242,10 @@ def return_anomalous_objects_pdf(payload: dict) -> pd.DataFrame:
     else:
         jd_stop = Time(payload['stop_date']).jd
 
+    if jd_stop == jd_start:
+        # allow to get unique day
+        jd_stop += 1
+
     if 'columns' in payload:
         cols = payload['columns'].replace(" ", "")
     else:

--- a/tests/api_anomaly_test.py
+++ b/tests/api_anomaly_test.py
@@ -29,7 +29,7 @@ def anomalysearch(n=10, start_date=None, stop_date=None, output_format='json', c
         'output-format': output_format
     }
 
-    if startdate is not None:
+    if start_date is not None:
         payload.update(
             {
                 'start_date': start_date,

--- a/tests/api_anomaly_test.py
+++ b/tests/api_anomaly_test.py
@@ -1,0 +1,149 @@
+# Copyright 2023 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import requests
+import pandas as pd
+import numpy as np
+
+import io
+import sys
+
+APIURL = sys.argv[1]
+
+def anomalysearch(n=10, start_date=None, stop_date=None, output_format='json', cols=None):
+    """ Perform a search for anomaly
+    """
+    payload = {
+        'n': n,
+        'output-format': output_format
+    }
+
+    if startdate is not None:
+        payload.update(
+            {
+                'start_date': start_date,
+                'stop_date': stop_date
+            }
+        )
+
+    if cols is not None:
+        payload.update({'columns': cols})
+
+    r = requests.post(
+        '{}/api/v1/anomaly'.format(APIURL),
+        json=payload
+    )
+
+    if output_format == 'json':
+        # Format output in a DataFrame
+        pdf = pd.read_json(io.BytesIO(r.content))
+    elif output_format == 'csv':
+        pdf = pd.read_csv(io.BytesIO(r.content))
+    elif output_format == 'parquet':
+        pdf = pd.read_parquet(io.BytesIO(r.content))
+    elif output_format == 'votable':
+        vt = votable.parse(io.BytesIO(r.content))
+        pdf = vt.get_first_table().to_table().to_pandas()
+
+    return pdf
+
+def test_simple_anomaly() -> None:
+    """
+    Examples
+    ---------
+    >>> test_simple_anomaly()
+    """
+    pdf = anomalysearch()
+
+    assert not pdf.empty
+
+    assert len(pdf) == 10, len(pdf)
+
+    assert np.alltrue(pdf['d:anomaly_score'].values < 0)
+
+def test_anomaly_and_date() -> None:
+    """
+    Examples
+    ---------
+    >>> test_anomaly_and_date()
+    """
+    pdf = anomalysearch(start_date='2023-01-25', stopdate='2023-01-25')
+
+    assert not pdf.empty
+
+    assert len(pdf) == 10, len(pdf)
+
+    assert 'ZTF23aaaatwl' in pdf['i:objectId'].values
+
+def test_anomaly_and_cols_with_sort() -> None:
+    """
+    Examples
+    ---------
+    >>> test_anomaly_and_cols_with_sort()
+    """
+    pdf = anomalysearch(cols='i:jd,i:objectId')
+
+    assert not pdf.empty
+
+    assert len(pdf.columns) == 2, len(pdf.columns)
+
+    assert 'i:jd' in pdf.columns
+    assert 'i:objectId' in pdf.columns
+    assert 'v:classifation' not in pdf.columns
+
+def test_query_url() -> None:
+    """
+    Examples
+    ---------
+    >>> test_query_url()
+    """
+    pdf1 = anomalysearch()
+
+    url = "{}/api/v1/anomaly?n=10&output-format=json".format(APIURL)
+    r = requests.get(url)
+    pdf2 = pd.read_json(io.BytesIO(r.content))
+
+    # subset of cols to avoid type issues
+    cols = ['d:anomaly_score']
+
+    isclose = np.isclose(pdf1[cols], pdf2[cols])
+    assert np.alltrue(isclose)
+
+def test_various_outputs() -> None:
+    """
+    Examples
+    ---------
+    >>> test_various_outputs()
+    """
+    pdf1 = anomalysearch(output_format='json')
+
+    for fmt in ['csv', 'parquet', 'votable']:
+        pdf2 = anomalysearch(output_format=fmt)
+
+        # subset of cols to avoid type issues
+        cols1 = ['d:anomaly_score']
+
+        # https://docs.astropy.org/en/stable/io/votable/api_exceptions.html#w02-x-attribute-y-is-invalid-must-be-a-standard-xml-id
+        cols2 = cols1 if fmt != 'votable' else ['d_anomaly_score']
+
+        isclose = np.isclose(pdf1[cols1], pdf2[cols2])
+        assert np.alltrue(isclose), fmt
+
+
+if __name__ == "__main__":
+    """ Execute the test suite """
+    import sys
+    import doctest
+
+    sys.exit(doctest.testmod()[0])

--- a/tests/api_anomaly_test.py
+++ b/tests/api_anomaly_test.py
@@ -16,6 +16,8 @@ import requests
 import pandas as pd
 import numpy as np
 
+from astropy.io import votable
+
 import io
 import sys
 
@@ -78,7 +80,7 @@ def test_anomaly_and_date() -> None:
     ---------
     >>> test_anomaly_and_date()
     """
-    pdf = anomalysearch(start_date='2023-01-25', stopdate='2023-01-25')
+    pdf = anomalysearch(start_date='2023-01-25', stop_date='2023-01-25')
 
     assert not pdf.empty
 


### PR DESCRIPTION
Closes #450 

This endpoint gets data from the `ztf.anomaly` HBase table. Each night, this table receives 10 alerts with the most anomalous scores. This table has full _alert_ schema, and you can easily gets statistics:

```python
# retrieve all anomalies
import io
import requests
import pandas as pd

r = requests.post(
  'https://fink-portal.org/api/v1/anomaly',
  json={
    'n': 10000, # on purpose large
    'columns': 'i:objectId,d:cdsxmatch,i:magpsf'
  }
)
pdf = pd.read_json(io.BytesIO(r.content))

pdf.groupby('d:cdsxmatch').agg({'i:objectId': 'count'}).sort_values('i:objectId', ascending=False)

               i:objectId
d:cdsxmatch              
CataclyV*             191
Unknown               170
Mira                   65
RRLyr                  63
LPV*                   52
EB*_Candidate          21
EB*                    20
Star                   14
CV*_Candidate          10
Fail 504               10
Blazar                  6
V*                      6
WD*_Candidate           4
YSO_Candidate           4
PulsV*                  3
Fail 500                3
YSO                     3
Fail 503                2
SN                      2
LP*_Candidate           1
BLLac                   1
QSO                     1
Radio                   1
Seyfert_1               1
TTau*                   1
Em*                     1
ClG                     1
V*?_Candidate           1
BlueStraggler           1
AGN                     1
```
Note the `Fail X` labels are when the CDS xmatch service fails with error code X (web service). But because this table has full _alert_ schema, if you want full object data, you need to call then the `/api/v1/object` service. Example:

```python
# retrieve last 10 anomaly objectIds
import io
import requests
import pandas as pd

r = requests.post(
  'https://fink-portal.org/api/v1/anomaly',
  json={
    'n': 10,
    'columns': 'i:objectId'
  }
)

# Format output in a DataFrame
oids = [i['i:objectId'] for i in r.json()]

# retrieve full objects data
r = requests.post(
  'https://fink-portal.org/api/v1/objects',
  json={
    'objectId': ','.join(oids),
    'columns': 'i:objectId,i:magpsf,i:sigmapsf,d:anomaly_score,d:cdsxmatch',
    'output-format': 'json'
  }
)

# Format output in a DataFrame
pdf = pd.read_json(io.BytesIO(r.content))
```

Note the first time, the `/api/v1/object` query can be long (especially if you are dealing with variable stars), but then data is cached on the server, and subsequent queries are much faster.