### PR TITLE
Put flux units in Jansky & warn users about magnitude units

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ external_stylesheets = [
 external_scripts = [
     '//code.jquery.com/jquery-1.12.1.min.js',
     '//aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js',
-    '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML',
+    '//cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js',
 ]
 
 app = dash.Dash(

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -82,11 +82,8 @@ def card_lightcurve_summary():
                                     #### DC magnitude
                                     DC magnitude is computed by combining the nearest reference image catalog magnitude (`magnr`),
                                     differential magnitude (`magpsf`), and `isdiffpos` (positive or negative difference image detection) as follows:
-
                                     $$
-                                    \\begin{equation}
                                     m_{DC} = -2.5\\log_{10}(10^{-0.4m_{magnr}} + \\texttt{sign} 10^{-0.4m_{magpsf}})
-                                    \\end{equation}
                                     $$
 
                                     where `sign` = 1 if `isdiffpos` = 't' or `sign` = -1 if `isdiffpos` = 'f'.
@@ -98,11 +95,8 @@ def card_lightcurve_summary():
 
                                     #### DC flux
                                     DC flux (in Jansky) is constructed from DC magnitude by using the following:
-
                                     $$
-                                    \\begin{equation}
                                     f_{DC} = 3631 \\times 10^{-0.4m_{DC}}
-                                    \\end{equation}
                                     $$
 
                                     Note that we display the flux in milli-Jansky.

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -45,7 +45,7 @@ def card_lightcurve_summary():
                 id='lightcurve_cutouts',
                 style={
                     'width': '100%',
-                    'height': '25pc'
+                    'height': '30pc'
                 },
                 config={'displayModeBar': False}
             ),
@@ -106,7 +106,7 @@ def card_lightcurve_summary():
                         ],
                         value='info'
                     ),
-                ], value='info'
+                ]
             )
         ], radius='xl', p='md', shadow='xl', withBorder=True
     )

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -72,14 +72,14 @@ def card_lightcurve_summary():
                             dmc.AccordionPanel(
                                 dcc.Markdown(
                                     """
-                                    #### Difference magnitude
+                                    ##### Difference magnitude
 
                                     Circles (&#9679;) with error bars show valid alerts that pass the Fink quality cuts.
                                     In addition, the _Difference magnitude_ view shows:
                                     - upper triangles with errors (&#9650;), representing alert measurements that do not satisfy Fink quality cuts, but are nevetheless contained in the history of valid alerts and used by classifiers.
                                     - lower triangles (&#9661;), representing 5-sigma mag limit in difference image based on PSF-fit photometry contained in the history of valid alerts.
 
-                                    #### DC magnitude
+                                    ##### DC magnitude
                                     DC magnitude is computed by combining the nearest reference image catalog magnitude (`magnr`),
                                     differential magnitude (`magpsf`), and `isdiffpos` (positive or negative difference image detection) as follows:
                                     $$
@@ -87,13 +87,13 @@ def card_lightcurve_summary():
                                     $$
 
                                     where `sign` = 1 if `isdiffpos` = 't' or `sign` = -1 if `isdiffpos` = 'f'.
-                                    Before using the nearest reference image source magnitude (magnr), you will need
+                                    Before using the nearest reference image source magnitude (`magnr`), you will need
                                     to ensure the source is close enough to be considered an association
-                                    (e.g., `distnr` <~ 1.5 arcsec). It is also advised you check the other associated metrics
+                                    (e.g., `distnr` $\\leq$ 1.5 arcsec). It is also advised you check the other associated metrics
                                     (`chinr` and/or `sharpnr`) to ensure it is a point source. ZTF recommends
-                                    0.5 <~ `chinr` <~ 1.5 and/or -0.5 <~ `sharpnr` <~ 0.5.
+                                    0.5 $\\leq$ `chinr` $\\leq$ 1.5 and/or -0.5 $\\leq$ `sharpnr` $\\leq$ 0.5.
 
-                                    #### DC flux
+                                    ##### DC flux
                                     DC flux (in Jansky) is constructed from DC magnitude by using the following:
                                     $$
                                     f_{DC} = 3631 \\times 10^{-0.4m_{DC}}

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -68,8 +68,8 @@ def card_lightcurve_summary():
                 children=[
                     dmc.AccordionItem(
                         [
-                            dmc.AccordionPanel("Information"),
-                            dmc.AccordionControl(
+                            dmc.AccordionControl("Information"),
+                            dmc.AccordionPanel(
                                 dcc.Markdown(
                                     """
                                     Circles (&#9679;) with error bars show valid alerts that pass the Fink quality cuts.

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -72,17 +72,47 @@ def card_lightcurve_summary():
                             dmc.AccordionPanel(
                                 dcc.Markdown(
                                     """
+                                    #### Difference magnitude
+
                                     Circles (&#9679;) with error bars show valid alerts that pass the Fink quality cuts.
                                     In addition, the _Difference magnitude_ view shows:
                                     - upper triangles with errors (&#9650;), representing alert measurements that do not satisfy Fink quality cuts, but are nevetheless contained in the history of valid alerts and used by classifiers.
                                     - lower triangles (&#9661;), representing 5-sigma mag limit in difference image based on PSF-fit photometry contained in the history of valid alerts.
+
+                                    #### DC magnitude
+                                    DC magnitude is computed by combining the nearest reference image catalog magnitude (`magnr`),
+                                    differential magnitude (`magpsf`), and `isdiffpos` (positive or negative difference image detection) as follows:
+
+                                    $$
+                                    \begin{equation}
+                                    m_{DC} = -2.5\log_{10}(10^{-0.4m_{magnr}} + sign10^{-0.4m_{magpsf}})
+                                    \end{equation}
+                                    $$
+
+                                    where `sign` = 1 if `isdiffpos` = 't' or `sign` = -1 if `isdiffpos` = 'f'.
+                                    Before using the nearest reference image source magnitude (magnr), you will need
+                                    to ensure the source is close enough to be considered an association
+                                    (e.g., `distnr` <~ 1.5 arcsec). It is also advised you check the other associated metrics
+                                    (`chinr` and/or `sharpnr`) to ensure it is a point source. ZTF recommends
+                                    0.5 <~ `chinr` <~ 1.5 and/or -0.5 <~ `sharpnr` <~ 0.5.
+
+                                    #### DC flux
+                                    DC flux (in Jansky) is constructed from DC magnitude by using the following:
+
+                                    $$
+                                    \begin{equation}
+                                    f_{DC} = 3631 \times 10^{-0.4m_{DC}}
+                                    \end{equation}
+                                    $$
+
+                                    Note that we display the flux in milli-Jansky.
                                     """
                                 )
                             ),
                         ],
                         value='info'
                     ),
-                ],
+                ], value='info'
             )
         ], radius='xl', p='md', shadow='xl', withBorder=True
     )

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -77,7 +77,7 @@ def card_lightcurve_summary():
                                     Circles (&#9679;) with error bars show valid alerts that pass the Fink quality cuts.
                                     In addition, the _Difference magnitude_ view shows:
                                     - upper triangles with errors (&#9650;), representing alert measurements that do not satisfy Fink quality cuts, but are nevetheless contained in the history of valid alerts and used by classifiers.
-                                    - lower triangles (&#9661;), representing 5-sigma mag limit in difference image based on PSF-fit photometry contained in the history of valid alerts.
+                                    - lower triangles (&#9661;), representing 5-sigma magnitude limit in difference image based on PSF-fit photometry contained in the history of valid alerts.
 
                                     ##### DC magnitude
                                     DC magnitude is computed by combining the nearest reference image catalog magnitude (`magnr`),

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -84,9 +84,9 @@ def card_lightcurve_summary():
                                     differential magnitude (`magpsf`), and `isdiffpos` (positive or negative difference image detection) as follows:
 
                                     $$
-                                    \begin{equation}
-                                    m_{DC} = -2.5\log_{10}(10^{-0.4m_{magnr}} + sign10^{-0.4m_{magpsf}})
-                                    \end{equation}
+                                    \\begin{equation}
+                                    m_{DC} = -2.5\\log_{10}(10^{-0.4m_{magnr}} + \\texttt{sign} 10^{-0.4m_{magpsf}})
+                                    \\end{equation}
                                     $$
 
                                     where `sign` = 1 if `isdiffpos` = 't' or `sign` = -1 if `isdiffpos` = 'f'.
@@ -100,13 +100,13 @@ def card_lightcurve_summary():
                                     DC flux (in Jansky) is constructed from DC magnitude by using the following:
 
                                     $$
-                                    \begin{equation}
-                                    f_{DC} = 3631 \times 10^{-0.4m_{DC}}
-                                    \end{equation}
+                                    \\begin{equation}
+                                    f_{DC} = 3631 \\times 10^{-0.4m_{DC}}
+                                    \\end{equation}
                                     $$
 
                                     Note that we display the flux in milli-Jansky.
-                                    """
+                                    """, mathjax=True
                                 )
                             ),
                         ],

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -70,9 +70,9 @@ colors_ = [
 ]
 
 all_radio_options = {
-    "Difference magnitude": ["Difference magnitude", "DC magnitude", "DC apparent flux"],
-    "DC magnitude": ["Difference magnitude", "DC magnitude", "DC apparent flux"],
-    "DC apparent flux": ["Difference magnitude", "DC magnitude", "DC apparent flux"]
+    "Difference magnitude": ["Difference magnitude", "DC magnitude", "DC flux"],
+    "DC magnitude": ["Difference magnitude", "DC magnitude", "DC flux"],
+    "DC flux": ["Difference magnitude", "DC magnitude", "DC flux"]
 }
 
 layout_lightcurve = dict(
@@ -751,7 +751,7 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
         layout_lightcurve['yaxis']['title'] = 'Apparent DC magnitude'
         layout_lightcurve['yaxis']['autorange'] = 'reversed'
         scale = 1.0
-    elif switch == "DC apparent flux":
+    elif switch == "DC flux":
         # inplace replacement
         mag, err = np.transpose(
             [

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -734,6 +734,7 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
     if switch == "Difference magnitude":
         layout_lightcurve['yaxis']['title'] = 'Difference magnitude'
         layout_lightcurve['yaxis']['autorange'] = 'reversed'
+        scale = 1.0
     elif switch == "DC magnitude":
         # inplace replacement
         mag, err = np.transpose(
@@ -749,6 +750,7 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
         )
         layout_lightcurve['yaxis']['title'] = 'Apparent DC magnitude'
         layout_lightcurve['yaxis']['autorange'] = 'reversed'
+        scale = 1.0
     elif switch == "DC apparent flux":
         # inplace replacement
         mag, err = np.transpose(
@@ -762,8 +764,9 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
                 )
             ]
         )
-        layout_lightcurve['yaxis']['title'] = 'Apparent DC flux'
+        layout_lightcurve['yaxis']['title'] = 'Apparent DC flux (milliJansky)'
         layout_lightcurve['yaxis']['autorange'] = True
+        scale = 1e3
 
     hovertemplate = r"""
     <b>%{yaxis.title.text}</b>: %{y:.2f} &plusmn; %{error_y.array:.2f}<br>
@@ -775,10 +778,10 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
         'data': [
             {
                 'x': dates[pdf['i:fid'] == 1],
-                'y': mag[pdf['i:fid'] == 1],
+                'y': mag[pdf['i:fid'] == 1] * scale,
                 'error_y': {
                     'type': 'data',
-                    'array': err[pdf['i:fid'] == 1],
+                    'array': err[pdf['i:fid'] == 1] * scale,
                     'visible': True,
                     'color': COLORS_ZTF[0]
                 },
@@ -793,10 +796,10 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
             },
             {
                 'x': dates[pdf['i:fid'] == 2],
-                'y': mag[pdf['i:fid'] == 2],
+                'y': mag[pdf['i:fid'] == 2] * scale,
                 'error_y': {
                     'type': 'data',
-                    'array': err[pdf['i:fid'] == 2],
+                    'array': err[pdf['i:fid'] == 2] * scale,
                     'visible': True,
                     'color': COLORS_ZTF[1]
                 },

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -943,7 +943,7 @@ def draw_lightcurve_sn(pathname: str, object_data, object_upper, object_upperval
     # shortcuts
     mag = pdf['i:magpsf']
     err = pdf['i:sigmapsf']
-    layout_lightcurve['yaxis']['title'] = 'Apparent DC magnitude'
+    layout_lightcurve['yaxis']['title'] = 'Difference magnitude'
     layout_lightcurve['yaxis']['autorange'] = 'reversed'
 
     hovertemplate = r"""

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -943,18 +943,6 @@ def draw_lightcurve_sn(pathname: str, object_data, object_upper, object_upperval
     # shortcuts
     mag = pdf['i:magpsf']
     err = pdf['i:sigmapsf']
-    # inplace replacement
-    mag, err = np.transpose(
-        [
-            dc_mag(*args) for args in zip(
-                mag.astype(float).values,
-                err.astype(float).values,
-                pdf['i:magnr'].astype(float).values,
-                pdf['i:sigmagnr'].astype(float).values,
-                pdf['i:isdiffpos'].values
-            )
-        ]
-    )
     layout_lightcurve['yaxis']['title'] = 'Apparent DC magnitude'
     layout_lightcurve['yaxis']['autorange'] = 'reversed'
 

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -438,7 +438,11 @@ def tabs(pdf, is_mobile):
         chinr = pdf['i:chinr'].values[0]
         sharpnr = pdf['i:sharpnr'].values[0]
         if is_source_behind(distnr, chinr, sharpnr):
-            extra_div = dbc.Alert("It looks like there is a source behind. You might want to check the DC magnitude instead.", color="danger")
+            extra_div = dbc.Alert(
+                "It looks like there is a point source behind. You might want to check the DC magnitude instead.",
+                dismissable=True,
+                is_open=True,
+                color="danger")
         else:
             extra_div = html.Div()
         tabs_ = dmc.Tabs(

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -442,7 +442,8 @@ def tabs(pdf, is_mobile):
                 "It looks like there is a point source behind. You might want to check the DC magnitude instead.",
                 dismissable=True,
                 is_open=True,
-                color="danger")
+                color="light"
+            )
         else:
             extra_div = html.Div()
         tabs_ = dmc.Tabs(

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -48,6 +48,7 @@ from apps.utils import get_miriade_data
 from apps.utils import pil_to_b64
 from apps.utils import generate_qr
 from apps.utils import class_colors
+from apps.utils import is_varstar
 
 from fink_utils.xmatch.simbad import get_simbad_labels
 
@@ -55,11 +56,12 @@ from app import APIURL
 
 dcc.Location(id='url', refresh=False)
 
-def tab1_content():
+def tab1_content(extra_div):
     """ Summary tab
     """
     tab1_content_ = html.Div([
         dmc.Space(h=10),
+        extra_div,
         dbc.Row(
             [
                 dbc.Col(
@@ -433,6 +435,13 @@ def tabs(pdf, is_mobile):
     if is_mobile:
         tabs_ = tab_mobile_content(pdf)
     else:
+        distnr = pdf['i:distnr'].values[0]
+        chinr = pdf['i:chinr'].values[0]
+        sharpnr = pdf['i:sharpnr'].values[0]
+        if is_varstar(distnr, chinr, sharpnr):
+            extra_div = dbc.Alert("It looks like there is a source behind. You might want to check the DC magnitude instead.".format(name[1:]), color="danger")
+        else:
+            extra_div = html.Div()
         tabs_ = dmc.Tabs(
             [
                 dmc.TabsList(
@@ -446,7 +455,7 @@ def tabs(pdf, is_mobile):
                         dmc.Tab("GRB", value="GRB", disabled=True)
                     ], position='right'
                 ),
-                dmc.TabsPanel(tab1_content(), value="Summary"),
+                dmc.TabsPanel(tab1_content(extra_div), value="Summary"),
                 dmc.TabsPanel(tab2_content(), value="Supernovae"),
                 dmc.TabsPanel(tab3_content(), value="Variable stars"),
                 dmc.TabsPanel(tab4_content(), value="Microlensing"),

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -439,7 +439,7 @@ def tabs(pdf, is_mobile):
         chinr = pdf['i:chinr'].values[0]
         sharpnr = pdf['i:sharpnr'].values[0]
         if is_varstar(distnr, chinr, sharpnr):
-            extra_div = dbc.Alert("It looks like there is a source behind. You might want to check the DC magnitude instead.".format(name[1:]), color="danger")
+            extra_div = dbc.Alert("It looks like there is a source behind. You might want to check the DC magnitude instead.", color="danger")
         else:
             extra_div = html.Div()
         tabs_ = dmc.Tabs(

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -48,7 +48,7 @@ from apps.utils import get_miriade_data
 from apps.utils import pil_to_b64
 from apps.utils import generate_qr
 from apps.utils import class_colors
-from apps.utils import is_varstar
+from apps.utils import is_source_behind
 
 from fink_utils.xmatch.simbad import get_simbad_labels
 
@@ -61,7 +61,6 @@ def tab1_content(extra_div):
     """
     tab1_content_ = html.Div([
         dmc.Space(h=10),
-        extra_div,
         dbc.Row(
             [
                 dbc.Col(
@@ -77,6 +76,7 @@ def tab1_content(extra_div):
                 ),
             ], justify='around'
         ),
+        extra_div,
         dbc.Row([
             dbc.Col(card_lightcurve_summary(), width=8),
             dbc.Col(id="card_id_col", width=4)
@@ -438,7 +438,7 @@ def tabs(pdf, is_mobile):
         distnr = pdf['i:distnr'].values[0]
         chinr = pdf['i:chinr'].values[0]
         sharpnr = pdf['i:sharpnr'].values[0]
-        if is_varstar(distnr, chinr, sharpnr):
+        if is_source_behind(distnr, chinr, sharpnr):
             extra_div = dbc.Alert("It looks like there is a source behind. You might want to check the DC magnitude instead.", color="danger")
         else:
             extra_div = html.Div()

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -76,9 +76,8 @@ def tab1_content(extra_div):
                 ),
             ], justify='around'
         ),
-        extra_div,
         dbc.Row([
-            dbc.Col(card_lightcurve_summary(), width=8),
+            dbc.Col([extra_div, card_lightcurve_summary()], width=8),
             dbc.Col(id="card_id_col", width=4)
         ]),
     ])

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -766,10 +766,24 @@ def generate_qr(data):
 
     return img
 
-def is_varstar(distnr, chinr, sharpnr):
+def is_source_behind(distnr: float, chinr: float, sharpnr: float) -> bool:
     """ Check if the alert is behind a source
+
+    Parameters
+    ----------
+    distnr: float
+        Distance to nearest source in reference image PSF-catalog within 30 arcsec [pixels]
+    chinr: float
+        DAOPhot chi parameter of nearest source in reference image PSF-catalog within 30 arcsec
+    sharpnr: float
+        DAOPhot sharp parameter of nearest source in reference image PSF-catalog within 30 arcsec
+
+    Returns
+    ----------
+    out: bool
+        True if there is a source behind. False otherwise.
     """
-    cond1 = distnr <= 1.5
+    cond1 = (distnr >= 0) & (distnr <= 1.5)
     cond2 = (chinr >= 0.5) & (chinr <= 1.5)
     cond3 = np.abs(sharpnr) <= 0.5
     return cond1 & cond2 & cond3

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -765,3 +765,12 @@ def generate_qr(data):
     )
 
     return img
+
+def is_varstar(distnr, chinr, sharpnr):
+    """ Check if the alert is behind a source
+    """
+    cond1 = distnr <= 1.5
+    cond2 = (chinr >= 0.5) & (chinr <= 1.5)
+    cond3 = np.abs(sharpnr) <= 0.5
+    return cond1 & cond2 & cond3
+

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -786,5 +786,5 @@ def is_source_behind(distnr: float, chinr: float, sharpnr: float) -> bool:
     cond1 = (distnr >= 0) & (distnr <= 1.5)
     cond2 = (chinr >= 0.5) & (chinr <= 1.5)
     cond3 = np.abs(sharpnr) <= 0.5
-    return cond1 & cond2 & cond3
+    return cond1 & (cond2 | cond3)
 


### PR DESCRIPTION
This PR brings two modifications:
- Flux is in (milli)Jansky now
- If a point source is detected behind the alert, we warn the user that DC magnitude are more relevant

In addition, lightcurve documentation has been updated. This PR does not solve all, and more needs to be added later (especially see discussion in #446)