### PR TITLE
Name resolver

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,4 +98,7 @@ clientSSOORB.connect(args['tablename'] + ".orb_cand", args['SCHEMAVER'])
 clientANOMALY = com.Lomikel.HBaser.HBaseClient(args['HBASEIP'], args['ZOOPORT']);
 clientANOMALY.connect(args['tablename'] + ".anomaly", args['SCHEMAVER'])
 
+clientTNSRESOL = com.Lomikel.HBaser.HBaseClient(args['HBASEIP'], args['ZOOPORT']);
+clientTNSRESOL.connect(args['tablename'] + ".tns_resolver", args['SCHEMAVER'])
+
 client.setLimit(nlimit);

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -625,7 +625,7 @@ args_resolver = [
     },
     {
         'name': 'name',
-        'required': False,
+        'required': True,
         'description': 'Object name to resolve'
     },
     {

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -628,6 +628,11 @@ args_resolver = [
         'required': True,
         'description': 'Object name to resolve'
     },
+    {
+        'name': 'internal_tns_name',
+        'required': True,
+        'description': 'ZTF name to resolve in TNS'
+    },
     # {
     #     'name': 'conesearch',
     #     'required': False,

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -634,6 +634,11 @@ args_resolver = [
         'description': 'If True, resolve ZTF* name.'
     },
     {
+        'name': 'nmax',
+        'required': False,
+        'description': 'Maximum number of match to return. Default is 10.'
+    },
+    {
         'name': 'output-format',
         'required': False,
         'description': 'Output format among json[default], csv, parquet, votable'

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -625,24 +625,14 @@ args_resolver = [
     },
     {
         'name': 'name',
-        'required': True,
+        'required': False,
         'description': 'Object name to resolve'
     },
     {
         'name': 'reverse',
         'required': False,
-        'description': 'If True, resolve ZTF* name. Only work with the TNS resolver.'
+        'description': 'If True, resolve ZTF* name.'
     },
-    # {
-    #     'name': 'conesearch',
-    #     'required': False,
-    #     'description': 'If specified, perform a conesearch around (`simbad` and `tns` only)'
-    # },
-    # {
-    #     'name': 'radius',
-    #     'required': False,
-    #     'description': 'If `conesearch` specified, perform a conesearch around the position found with a `radius` in arcsec. Maximum is 36,000 arcseconds (10 degrees).'
-    # },
     {
         'name': 'output-format',
         'required': False,

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -629,9 +629,9 @@ args_resolver = [
         'description': 'Object name to resolve'
     },
     {
-        'name': 'internal_tns_name',
-        'required': True,
-        'description': 'ZTF name to resolve in TNS'
+        'name': 'reverse',
+        'required': False,
+        'description': 'If True, resolve ZTF* name. Only work with the TNS resolver.'
     },
     # {
     #     'name': 'conesearch',

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1334,10 +1334,10 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
         )
 
         check = pd.read_xml(io.BytesIO(r.content))
-        if 'INFO' in check.columns:
-            return pd.DataFrame()
-        elif 'Resolver' in check.columns:
+        if 'Resolver' in check.columns:
             pdfs = pd.read_xml(io.BytesIO(r.content), xpath='.//Resolver')
+        else:
+            pdfs = pd.DataFrame()
     elif resolver == 'ssodnet':
         pass
 

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1307,12 +1307,14 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
     if resolver == 'tns':
         if name == "":
             # return the full table
+            clientTNSRESOL.setEvaluation("ra >= 0")
             results = clientTNSRESOL.scan(
                 "",
-                "key:key:",
+                "",
                 "*",
                 0, False, False
             )
+            clientTNSRESOL.setEvaluation("")
         else:
             # TNS poll -- take the first 10 occurences
             clientTNSRESOL.setLimit(10)

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1307,13 +1307,22 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
     if resolver == 'tns':
         # TNS poll -- take the first 10 occurences
         clientTNSRESOL.setLimit(10)
-        to_evaluate = "key:key:{}".format(name)
-        results = clientTNSRESOL.scan(
-            "",
-            to_evaluate,
-            "*",
-            0, False, False
-        )
+        if 'internal_tns_name' in payload:
+            to_evaluate = "d:internalname:{}".format(payload['internal_tns_name'])
+            results = clientTNSRESOL.scan(
+                "",
+                to_evaluate,
+                "*",
+                0, False, False
+            )
+        else:
+            to_evaluate = "key:key:{}".format(name)
+            results = clientTNSRESOL.scan(
+                "",
+                to_evaluate,
+                "*",
+                0, False, False
+            )
         schema_client = clientTNSRESOL.schema()
 
         # Restore default limits

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1307,8 +1307,8 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
     if resolver == 'tns':
         # TNS poll -- take the first 10 occurences
         clientTNSRESOL.setLimit(10)
-        if 'internal_tns_name' in payload:
-            to_evaluate = "d:internalname:{}".format(payload['internal_tns_name'])
+        if 'reverse' in payload:
+            to_evaluate = "d:internalname:{}".format(name)
             results = clientTNSRESOL.scan(
                 "",
                 to_evaluate,

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1303,21 +1303,23 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
     """
     resolver = payload['resolver']
     name = payload['name']
+    if 'nmax' in payload:
+        nmax = payload['nmax']
+    else:
+        nmax = 10
 
     if resolver == 'tns':
         if name == "":
             # return the full table
-            clientTNSRESOL.setEvaluation("ra >= 0")
             results = clientTNSRESOL.scan(
                 "",
                 "",
                 "*",
                 0, False, False
             )
-            clientTNSRESOL.setEvaluation("")
         else:
-            # TNS poll -- take the first 10 occurences
-            clientTNSRESOL.setLimit(10)
+            # TNS poll -- take the first nmax occurences
+            clientTNSRESOL.setLimit(nmax)
             if 'reverse' in payload:
                 to_evaluate = "d:internalname:{}".format(name)
                 results = clientTNSRESOL.scan(
@@ -1342,7 +1344,7 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
     elif resolver == 'simbad':
         if 'reverse' in payload:
             to_evaluate = "key:key:{}".format(name)
-            client.setLimit(10)
+            client.setLimit(nmax)
             results = client.scan(
                 "",
                 to_evaluate,
@@ -1364,7 +1366,7 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
     elif resolver == 'ssodnet':
         if 'reverse' in payload:
             to_evaluate = "key:key:{}".format(name)
-            client.setLimit(10)
+            client.setLimit(nmax)
             results = client.scan(
                 "",
                 to_evaluate,

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1294,10 +1294,10 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
     ----------
     out: pandas dataframe
     """
-    kind = payload['kind']
+    resolver = payload['resolver']
     name = payload['name']
 
-    if kind == 'tns':
+    if resolver == 'tns':
         # TNS poll
         clientTNSRESOL.setLimit(nalerts)
         to_evaluate = "key:key:{}".format(name)
@@ -1313,9 +1313,9 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
         clientTNSRESOL.setLimit(nlimit)
 
         pdfs = pd.DataFrame.from_dict(results, orient='index')
-    elif kind == 'simbad':
+    elif resolver == 'simbad':
         pass
-    elif kind == 'ssodnet':
+    elif resolver == 'ssodnet':
         pass
 
     return pdfs

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1307,7 +1307,6 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
     if resolver == 'tns':
         # TNS poll -- take the first 10 occurences
         clientTNSRESOL.setLimit(10)
-        clientTNSRESOL.setReversed(True)
         if 'reverse' in payload:
             to_evaluate = "d:internalname:{}".format(name)
             results = clientTNSRESOL.scan(
@@ -1327,15 +1326,12 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
 
         # Restore default limits
         clientTNSRESOL.setLimit(nlimit)
-        clientTNSRESOL.setReversed(False)
 
         pdfs = pd.DataFrame.from_dict(results, orient='index')
     elif resolver == 'simbad':
-
         if 'reverse' in payload:
             to_evaluate = "key:key:{}".format(name)
             client.setLimit(10)
-            client.setReversed(True)
             results = client.scan(
                 "",
                 to_evaluate,
@@ -1343,7 +1339,6 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
                 0, False, False
             )
             client.setLimit(nlimit)
-            client.setReversed(False)
             pdfs = pd.DataFrame.from_dict(results, orient='index')
         else:
             r = requests.get(

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1339,7 +1339,7 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
             results = client.scan(
                 "",
                 to_evaluate,
-                "i:objectId,d:cdsxmatch",
+                "i:objectId,d:cdsxmatch,i:ra,i:dec",
                 0, False, False
             )
             client.setLimit(nlimit)

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1305,27 +1305,36 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
     name = payload['name']
 
     if resolver == 'tns':
-        # TNS poll -- take the first 10 occurences
-        clientTNSRESOL.setLimit(10)
-        if 'reverse' in payload:
-            to_evaluate = "d:internalname:{}".format(name)
+        if name == "":
+            # return the full table
             results = clientTNSRESOL.scan(
                 "",
-                to_evaluate,
+                "key:key:",
                 "*",
                 0, False, False
             )
         else:
-            to_evaluate = "key:key:{}".format(name)
-            results = clientTNSRESOL.scan(
-                "",
-                to_evaluate,
-                "*",
-                0, False, False
-            )
+            # TNS poll -- take the first 10 occurences
+            clientTNSRESOL.setLimit(10)
+            if 'reverse' in payload:
+                to_evaluate = "d:internalname:{}".format(name)
+                results = clientTNSRESOL.scan(
+                    "",
+                    to_evaluate,
+                    "*",
+                    0, False, False
+                )
+            else:
+                to_evaluate = "key:key:{}".format(name)
+                results = clientTNSRESOL.scan(
+                    "",
+                    to_evaluate,
+                    "*",
+                    0, False, False
+                )
 
-        # Restore default limits
-        clientTNSRESOL.setLimit(nlimit)
+            # Restore default limits
+            clientTNSRESOL.setLimit(nlimit)
 
         pdfs = pd.DataFrame.from_dict(results, orient='index')
     elif resolver == 'simbad':
@@ -1357,7 +1366,7 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
             results = client.scan(
                 "",
                 to_evaluate,
-                "i:objectId,i:ssnamenr,i:ra,i:dec",
+                "i:objectId,i:ssnamenr",
                 0, False, False
             )
             client.setLimit(nlimit)

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1298,8 +1298,8 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
     name = payload['name']
 
     if resolver == 'tns':
-        # TNS poll
-        clientTNSRESOL.setLimit(nalerts)
+        # TNS poll -- take the first 10 occurences
+        clientTNSRESOL.setLimit(10)
         to_evaluate = "key:key:{}".format(name)
         results = clientTNSRESOL.scan(
             "",

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1352,15 +1352,15 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
                 pdfs = pd.DataFrame()
     elif resolver == 'ssodnet':
         if 'reverse' in payload:
-            to_evaluate = "d:objectId:{}".format(name)
-            clientSSO.setLimit(10)
-            results = clientSSO.scan(
+            to_evaluate = "key:key:{}".format(name)
+            client.setLimit(10)
+            results = client.scan(
                 "",
                 to_evaluate,
-                "i:ssnamenr,d:cdsxmatch,i:ra,i:dec",
+                "i:objectId,i:ssnamenr,i:ra,i:dec",
                 0, False, False
             )
-            clientSSO.setLimit(nlimit)
+            client.setLimit(nlimit)
             pdfs = pd.DataFrame.from_dict(results, orient='index')
         else:
             r = requests.get(

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1323,14 +1323,21 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
                 "*",
                 0, False, False
             )
-        schema_client = clientTNSRESOL.schema()
 
         # Restore default limits
         clientTNSRESOL.setLimit(nlimit)
 
         pdfs = pd.DataFrame.from_dict(results, orient='index')
     elif resolver == 'simbad':
-        pass
+        r = requests.get(
+            'http://cds.unistra.fr/cgi-bin/nph-sesame/-oxp/~S?{}'.format(name)
+        )
+
+        check = pd.read_xml(io.BytesIO(r.content))
+        if 'INFO' in check.columns:
+            return pd.DataFrame()
+        elif 'Resolver' in check.columns:
+            pdfs = pd.read_xml(io.BytesIO(r.content), xpath='.//Resolver')
     elif resolver == 'ssodnet':
         pass
 

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1351,6 +1351,26 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
             else:
                 pdfs = pd.DataFrame()
     elif resolver == 'ssodnet':
-        pass
+        if 'reverse' in payload:
+            to_evaluate = "d:objectId:{}".format(name)
+            clientSSO.setLimit(10)
+            results = clientSSO.scan(
+                "",
+                to_evaluate,
+                "i:ssnamenr,d:cdsxmatch,i:ra,i:dec",
+                0, False, False
+            )
+            clientSSO.setLimit(nlimit)
+            pdfs = pd.DataFrame.from_dict(results, orient='index')
+        else:
+            r = requests.get(
+                'https://api.ssodnet.imcce.fr/quaero/1/sso/instant-search?q={}'.format(name)
+            )
+
+            total = r.json()['total']
+            if total > 0:
+                pdfs = pd.DataFrame(r.json()['data'])
+            else:
+                pdfs = pd.DataFrame()
 
     return pdfs

--- a/requirements.txt
+++ b/requirements.txt
@@ -114,7 +114,7 @@ networkx==2.6.3
 numba==0.51.2
 numpy==1.19.2
 packaging==20.4
-pandas==1.1.2
+pandas==1.3.1
 parso==0.7.1
 pexpect==4.8.0
 pickleshare==0.7.5

--- a/tests/api_resolver_test.py
+++ b/tests/api_resolver_test.py
@@ -92,6 +92,20 @@ def test_reverse_tns_resolver() -> None:
 
     assert pdf['d:fullname'].values[0] == 'SN 2023Q', pdf.columns
 
+def test_nmax() -> None:
+    """
+    Examples
+    ---------
+    >>> test_nmax()
+    """
+    pdf = resolver(resolver='tns', name='SN 2023', nmax=20)
+
+    # Not empty
+    assert not pdf.empty
+
+    # One object found
+    assert len(pdf) == 20
+
 def test_simbad_resolver() -> None:
     """
     Examples

--- a/tests/api_resolver_test.py
+++ b/tests/api_resolver_test.py
@@ -1,0 +1,181 @@
+# Copyright 2023 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import requests
+import pandas as pd
+import numpy as np
+
+from astropy.io import votable
+
+import io
+import sys
+
+APIURL = sys.argv[1]
+
+def resolver(resolver='', name='', nmax=10, reverse=None, output_format='json'):
+    """ Perform a conesearch in the Science Portal using the Fink REST API
+    """
+    payload = {
+        'resolver': resolver,
+        'name': name,
+        'nmax': nmax,
+        'output-format': output_format
+    }
+
+    if reverse is not None:
+        payload.update(
+            {
+                'reverse': True,
+            }
+        )
+
+    r = requests.post(
+        '{}/api/v1/resolver'.format(APIURL),
+        json=payload
+    )
+
+    if output_format == 'json':
+        # Format output in a DataFrame
+        pdf = pd.read_json(io.BytesIO(r.content))
+    elif output_format == 'csv':
+        pdf = pd.read_csv(io.BytesIO(r.content))
+    elif output_format == 'parquet':
+        pdf = pd.read_parquet(io.BytesIO(r.content))
+    elif output_format == 'votable':
+        vt = votable.parse(io.BytesIO(r.content))
+        pdf = vt.get_first_table().to_table().to_pandas()
+
+    return pdf
+
+def test_tns_resolver() -> None:
+    """
+    Examples
+    ---------
+    >>> test_tns_resolver()
+    """
+    pdf = resolver(resolver='tns', name='SN 2023')
+
+    # Not empty
+    assert not pdf.empty
+
+    # One object found
+    assert len(pdf) == 10
+
+    cols = ['d:declination', 'd:fullname', 'd:internalname', 'd:ra', 'd:type']
+    for col in cols:
+        assert col in pdf.columns, col
+
+def test_reverse_tns_resolver() -> None:
+    """
+    Examples
+    ---------
+    >>> test_reverse_tns_resolver()
+    """
+    pdf = resolver(resolver='tns', name='ZTF23aaaahln', reverse=True)
+
+    # Not empty
+    assert not pdf.empty
+
+    # One object found
+    assert len(pdf) == 1
+
+    assert pdf['d:fullname'].values[0] == 'SN 2023Q', pdf.columns
+
+def test_simbad_resolver() -> None:
+    """
+    Examples
+    ---------
+    >>> test_simbad_resolver()
+    """
+    pdf = resolver(resolver='simbad', name='Markarian 2')
+
+    # Not empty
+    assert not pdf.empty
+
+    # One object found
+    assert len(pdf) == 1
+
+    assert pdf['oname'].values[0] == 'Mrk 2', pdf['oname']
+
+    cols = [
+        'name', 'oid', 'oname', 'otype',
+        'jpos', 'jradeg', 'jdedeg',
+        'refPos', 'Vel', 'MType', 'nrefs'
+    ]
+    for col in cols:
+        assert col in pdf.columns, [col, pdf.columns]
+
+def test_reverse_simbad_resolver() -> None:
+    """
+    Examples
+    ---------
+    >>> test_reverse_simbad_resolver()
+    """
+    pdf = resolver(resolver='simbad', name='ZTF18aabfjoi', reverse=True)
+
+    # Not empty
+    assert not pdf.empty
+
+    # One object found
+    assert len(pdf) == 5, len(pdf)
+
+    assert pdf['d:cdsxmatch'].values[0] == 'GinGroup', pdf['d:cdsxmatch'].values
+
+def test_ssodnet_resolver() -> None:
+    """
+    Examples
+    ---------
+    >>> test_ssodnet_resolver()
+    """
+    pdf = resolver(resolver='ssodnet', name='33803')
+
+    # Not empty
+    assert not pdf.empty
+
+    # One object found
+    assert len(pdf) == 10
+
+    assert '1999 VK210' in pdf['name'].values, pdf['name'].values
+
+    cols = [
+        'type', 'system', 'class', 'updated',
+        'ephemeris', 'physical-ephemeris',
+        'aliases', 'links', 'id', 'name', 'parent'
+    ]
+    for col in cols:
+        assert col in pdf.columns, [col, pdf.columns]
+
+def test_reverse_ssodnet_resolver() -> None:
+    """
+    Examples
+    ---------
+    >>> test_reverse_ssodnet_resolver()
+    """
+    pdf = resolver(resolver='ssodnet', name='ZTF23aabccya', reverse=True)
+
+    # Not empty
+    assert not pdf.empty
+
+    # One object found
+    assert len(pdf) == 1, len(pdf)
+
+    assert pdf['i:ssnamenr'].values[0] == 33803, pdf['i:ssnamenr'].values
+
+
+if __name__ == "__main__":
+    """ Execute the test suite """
+    import sys
+    import doctest
+
+    sys.exit(doctest.testmod()[0])

--- a/tests/api_resolver_test.py
+++ b/tests/api_resolver_test.py
@@ -23,13 +23,12 @@ import sys
 
 APIURL = sys.argv[1]
 
-def resolver(resolver='', name='', nmax=10, reverse=None, output_format='json'):
+def resolver(resolver='', name='', nmax=None, reverse=None, output_format='json'):
     """ Perform a conesearch in the Science Portal using the Fink REST API
     """
     payload = {
         'resolver': resolver,
         'name': name,
-        'nmax': nmax,
         'output-format': output_format
     }
 
@@ -37,6 +36,13 @@ def resolver(resolver='', name='', nmax=10, reverse=None, output_format='json'):
         payload.update(
             {
                 'reverse': True,
+            }
+        )
+
+    if nmax is not None:
+        payload.update(
+            {
+                'nmax': nmax,
             }
         )
 


### PR DESCRIPTION
This PR introduces a name resolver (see #476 ). Names can be resolved in 3 different ways: 
1. using SIMBAD (Sesame service)
2. using SSODNET (for asteroids)
3. using TNS

For all, there is also a reverse resolver, that is given a ZTF objectId, what is the match in these catalogs. Note that SSODNET and TNS allow auto-completion, but not SIMBAD.

```python
r = requests.post(
  'https://fink-portal.org/api/v1/resolver',
  json={
    'resolver': 'tns',
    'name': 'SN 2023',
    'nmax': 10
  }
)
```