### PR TITLE
Cast fields before transfering data

### DIFF
--- a/assets/spark_elasticc_transfer.py
+++ b/assets/spark_elasticc_transfer.py
@@ -256,6 +256,8 @@ def main(args):
         cnames[cnames.index('timestamp')] = 'cast(timestamp as string) as timestamp'
         cnames[cnames.index('brokerIngestTimestamp')] = 'cast(brokerIngestTimestamp as string) as brokerIngestTimestamp'
         cnames[cnames.index('classId')] = 'cast(classId as integer) as classId'
+        cnames[cnames.index('diaSource')] = 'struct(diaSource.*) as diaSource'
+        cnames[cnames.index('diaObject')] = 'struct(diaObject.*) as diaObject'
 
     # Wrap alert data
     df = df.selectExpr(cnames)

--- a/assets/spark_elasticc_transfer.py
+++ b/assets/spark_elasticc_transfer.py
@@ -254,6 +254,7 @@ def main(args):
         # Cast fields to ease the distribution
         cnames = df.columns
         cnames[cnames.index('timestamp')] = 'cast(timestamp as string) as timestamp'
+        cnames[cnames.index('brokerIngestTimestamp')] = 'cast(brokerIngestTimestamp as string) as brokerIngestTimestamp'
         cnames[cnames.index('classId')] = 'cast(classId as integer) as classId'
 
     # Wrap alert data

--- a/tests/api_resolver_test.py
+++ b/tests/api_resolver_test.py
@@ -166,7 +166,7 @@ def test_ssodnet_resolver() -> None:
     # One object found
     assert len(pdf) == 10
 
-    assert '1999 VK210' in pdf['name'].values, pdf['name'].values
+    assert 'Julienpeloton' in pdf['name'].values, pdf['name'].values
 
     cols = [
         'type', 'system', 'class', 'updated',


### PR DESCRIPTION
With the recent change when generating the data schema (#471), some fields were not correctly casted before the distribution. This PR fixes this (only for Elasticc data source).