### PR TITLE
Add responsive menubar to complement current togglable sidebar.

### DIFF
--- a/index.py
+++ b/index.py
@@ -1132,14 +1132,113 @@ navbar = dmc.Header(
     zIndex=1000,
     p=0,
     m=0,
+    className="shadow-sm",
     children=[
         dmc.Space(h=10),
         dmc.Container(
             fluid=True,
             children=dmc.Group(
                 position="apart",
-                align="flex-start",
+                align="flex-end",
                 children=[
+                    dmc.Group(
+                        position="left",
+                        align="flex-start",
+                        children=[
+                            dmc.Anchor(
+                                dmc.Group([
+                                    dmc.ThemeIcon(
+                                        DashIconify(
+                                            icon="ion:search-outline",
+                                            width=22,
+                                        ),
+                                        radius=30,
+                                        size=32,
+                                        variant="outline",
+                                        color="gray",
+                                    ),
+                                    dmc.MediaQuery(
+                                        "Search",
+                                        smallerThan="sm",
+                                        styles={"display": "none"},
+                                    ),
+                                ], spacing='xs'),
+                                href='/',
+                                variant='text',
+                                style={"textTransform": "capitalize", "textDecoration": "none"},
+                                color="gray",
+                            ),
+                            dmc.Anchor(
+                                dmc.Group([
+                                    dmc.ThemeIcon(
+                                        DashIconify(
+                                            icon="ion:cloud-download-outline",
+                                            width=22,
+                                        ),
+                                        radius=30,
+                                        size=32,
+                                        variant="outline",
+                                        color="gray",
+                                    ),
+                                    dmc.MediaQuery(
+                                        "Data Transfer",
+                                        smallerThan="sm",
+                                        styles={"display": "none"},
+                                    ),
+                                ], spacing='xs'),
+                                href='/download',
+                                variant='text',
+                                style={"textTransform": "capitalize", "textDecoration": "none"},
+                                color="gray",
+                            ),
+                            dmc.Anchor(
+                                dmc.Group([
+                                    dmc.ThemeIcon(
+                                        DashIconify(
+                                            icon="ion:infinite-outline",
+                                            width=22,
+                                        ),
+                                        radius=30,
+                                        size=32,
+                                        variant="outline",
+                                        color="gray",
+                                    ),
+                                    dmc.MediaQuery(
+                                        "Gravitational Waves",
+                                        smallerThan="sm",
+                                        styles={"display": "none"},
+                                    ),
+                                ], spacing='xs'),
+                                href='/gw',
+                                variant='text',
+                                style={"textTransform": "capitalize", "textDecoration": "none"},
+                                color="gray",
+                            ),
+                            dmc.Anchor(
+                                dmc.Group([
+                                    dmc.ThemeIcon(
+                                        DashIconify(
+                                            icon="ion:stats-chart-outline",
+                                            width=22,
+                                        ),
+                                        radius=30,
+                                        size=32,
+                                        variant="outline",
+                                        color="gray",
+                                    ),
+                                    dmc.MediaQuery(
+                                        "Statistics",
+                                        smallerThan="sm",
+                                        styles={"display": "none"},
+                                    ),
+                                ], spacing='xs'),
+                                href='/stats',
+                                variant='text',
+                                style={"textTransform": "capitalize", "textDecoration": "none"},
+                                color="gray",
+                            ),
+                        ]
+                    ),
                     dmc.ActionIcon(
                         DashIconify(icon="dashicons:menu", width=30), id="drawer-button", n_clicks=0
                     ),

--- a/index.py
+++ b/index.py
@@ -1141,10 +1141,15 @@ navbar = dmc.Header(
                 position="apart",
                 align="flex-end",
                 children=[
+                    # Right menu
                     dmc.Group(
                         position="left",
                         align="flex-start",
                         children=[
+                            # Burger
+                            dmc.ActionIcon(
+                                DashIconify(icon="dashicons:menu", width=30), id="drawer-button", n_clicks=0
+                            ),
                             dmc.Anchor(
                                 dmc.Group([
                                     dmc.ThemeIcon(
@@ -1214,6 +1219,13 @@ navbar = dmc.Header(
                                 style={"textTransform": "capitalize", "textDecoration": "none"},
                                 color="gray",
                             ),
+                        ],
+                    ),
+                    # Left menu
+                    dmc.Group(
+                        position="right",
+                        align="flex-end",
+                        children=[
                             dmc.Anchor(
                                 dmc.Group([
                                     dmc.ThemeIcon(
@@ -1239,9 +1251,7 @@ navbar = dmc.Header(
                             ),
                         ]
                     ),
-                    dmc.ActionIcon(
-                        DashIconify(icon="dashicons:menu", width=30), id="drawer-button", n_clicks=0
-                    ),
+                    # Sidebar
                     dmc.Drawer(
                         children=[
                             dmc.Divider(


### PR DESCRIPTION
Idea is to have most important pages directly accessible without additional clicking.
<img width="830" alt="Screenshot 2023-12-07 at 11 24 14" src="https://github.com/astrolabsoftware/fink-science-portal/assets/6555548/5d41516a-007c-403b-819d-807d9a29d4a4">
<img width="551" alt="Screenshot 2023-12-07 at 11 24 34" src="https://github.com/astrolabsoftware/fink-science-portal/assets/6555548/038f3bda-b265-4213-a64c-667615b7fb6a">

Points for discussion:
- Burger menu moved to the right to somehow fill that emtpy spot (sidebar still opens on the left). Probably when authentication will be implemented the avatar / user menu would go there, and the burger will return to leftmost slot.
- Do we need Fink logo in the leftmost spot? Would probably visually conflict with current 'search' entry. 
- Small shadow is added for the whole header to slightly better separate it from the page content. Probably will need some adjustment when backgrounds are changed.