### PR TITLE
Improvements for the search page

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ background_callback_manager = DiskcacheManager(cache)
 args = yaml.load(open('config.yml'), yaml.Loader)
 
 APIURL = args['APIURL']
+LOCALAPI = args.get('LOCALAPI', False)
 
 # bootstrap theme
 external_stylesheets = [

--- a/apps/api/doc.py
+++ b/apps/api/doc.py
@@ -266,7 +266,7 @@ only display the data from the last alert. To get a full history about an object
 you should use the `Retrieve single object data` service instead.
 
 Currently, you cannot query using several conditions.
-You must choose among `Search by Object ID` (group 0), `Conesearch` (group 1), or `Search by Date` (group 2).
+You must choose among `Search by Object ID` and `Conesearch` / `Search by Date`.
 In a future release, you will be able to combine searches.
 The list of arguments for querying the Fink alert database can be found at https://fink-portal.org/api/v1/explorer.
 
@@ -365,8 +365,8 @@ r = requests.post(
     'ra': '193.822',
     'dec': '2.89732',
     'radius': '5',
-    'startdate_conesearch': '2021-06-25 05:59:37.000',
-    'window_days_conesearch': 7
+    'startdate': '2021-06-25 05:59:37.000',
+    'window': 7
   }
 )
 
@@ -386,8 +386,8 @@ The numbers close to markers show the number of objects returned by the conesear
 
 ### Search by Date
 
-Choose a starting date and a time window to see all alerts in this period.
-Dates are in UTC, and the time window in minutes.
+Choose a starting date and stopping date or a time window to see all alerts in this period.
+Dates are in UTC, and the time window in days (but should not exceed 3 hours).
 Example of valid search:
 
 * 2021-07-01 05:59:37.000
@@ -396,10 +396,10 @@ In a unix shell, you would simply use
 
 ```bash
 # Get all objects between 2021-07-01 05:59:37.000 and 2021-07-01 06:09:37.000 UTC
-curl -H "Content-Type: application/json" -X POST -d '{"startdate":"2021-07-01 05:59:37.000", "window":"10"}' https://fink-portal.org/api/v1/explorer -o datesearch.json
+curl -H "Content-Type: application/json" -X POST -d '{"startdate":"2021-07-01 05:59:37.000", "window":"0.007"}' https://fink-portal.org/api/v1/explorer -o datesearch.json
 
 # you can also specify parameters in the URL, e.g. with wget:
-wget "https://fink-portal.org/api/v1/explorer?startdate=2021-07-01 05:59:37.000&window=10&output-format=json" -O datesearch.json
+wget "https://fink-portal.org/api/v1/explorer?startdate=2021-07-01 05:59:37.000&window=0.007&output-format=json" -O datesearch.json
 ```
 
 In python, you would use
@@ -413,7 +413,7 @@ r = requests.post(
   'https://fink-portal.org/api/v1/explorer',
   json={
     'startdate': '2021-07-01 05:59:37.000',
-    'window': '10'
+    'window': '0.007'
   }
 )
 

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -1087,19 +1087,19 @@ def card_search_result(row, i):
                     dbc.Row(
                         [
                             dbc.Col(
+                                id={'type': 'search_results_cutouts', 'objectId': row['i:objectId'], 'index': i},
+                                width='auto'
+                            ),
+                            dbc.Col(
                                 dcc.Markdown(
                                     text,
                                     style={'white-space': 'pre-wrap'},
                                 ),
-                                sm='auto',
+                                width='auto',
                             ),
                             dbc.Col(
                                 id={'type': 'search_results_lightcurve', 'objectId': row['i:objectId'], 'index': i},
-                                sm='auto',
-                            ),
-                            dbc.Col(
-                                id={'type': 'search_results_cutouts', 'objectId': row['i:objectId'], 'index': i},
-                                sm='auto'
+                                xs=12, md=True,
                             ),
                         ],
                         justify='start',

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -962,6 +962,10 @@ def card_search_result(row, i):
     """
     badges = []
 
+    name = row['i:objectId']
+    if name[0] == '[': # Markdownified
+        name = row['i:objectId'].split('[')[1].split(']')[0]
+
     # Handle different variants for key names from different API entry points
     for key in ['v:classification', 'd:classification']:
         if key in row:
@@ -1074,20 +1078,20 @@ def card_search_result(row, i):
                     html.A(
                         dmc.Group(
                             [
-                                dmc.Text("{}".format(row['i:objectId']), weight=700, size=26),
+                                dmc.Text("{}".format(name), weight=700, size=26),
                                 dmc.Space(w='sm'),
                                 *badges
                             ],
                             spacing=3,
                         ),
-                        href='/{}'.format(row['i:objectId']),
+                        href='/{}'.format(name),
                         target='_blank',
                         className='text-decoration-none',
                     ),
                     dbc.Row(
                         [
                             dbc.Col(
-                                id={'type': 'search_results_cutouts', 'objectId': row['i:objectId'], 'index': i},
+                                id={'type': 'search_results_cutouts', 'objectId': name, 'index': i},
                                 width='auto'
                             ),
                             dbc.Col(
@@ -1098,7 +1102,7 @@ def card_search_result(row, i):
                                 width='auto',
                             ),
                             dbc.Col(
-                                id={'type': 'search_results_lightcurve', 'objectId': row['i:objectId'], 'index': i},
+                                id={'type': 'search_results_lightcurve', 'objectId': name, 'index': i},
                                 xs=12, md=True,
                             ),
                         ],

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -309,7 +309,7 @@ def create_external_links_brokers(objectId):
             dbc.Col(
                 dbc.Button(
                     className='btn btn-default btn-circle btn-lg',
-                    style={'background-image': 'url(/assets/buttons/logo_antares.png)', 'background-size': 'cover'},
+                    style={'background-image': 'url(/assets/buttons/logo_antares.png)', 'background-size': 'contain'},
                     color='dark',
                     outline=True,
                     id='antares',
@@ -826,9 +826,6 @@ def card_id1(object_data, object_uppervalid, object_upper):
     else:
         nupper = 0
 
-    simbad_types = get_simbad_labels('old_and_new')
-    simbad_types = sorted(simbad_types, key=lambda s: s.lower())
-
     badges = []
     for c in np.unique(pdf['v:classification']):
         if c in simbad_types:
@@ -850,6 +847,79 @@ def card_id1(object_data, object_uppervalid, object_upper):
     tns_badge = generate_tns_badge(pdf['i:objectId'].values[0])
     if tns_badge is not None:
         badges.append(tns_badge)
+
+    ssnamenr = pdf['i:ssnamenr'].values[0]
+    if ssnamenr and ssnamenr != 'null':
+        badges.append(
+            dmc.Badge(
+                "SSO: {}".format(ssnamenr),
+                color='yellow',
+                variant="dot",
+            )
+        )
+
+    distnr = pdf['i:distnr'].values[0]
+    if distnr:
+        if is_source_behind(distnr):
+            ztf_badge = dmc.Tooltip(
+                dmc.Badge(
+                    "ZTF: {:.1f}\"".format(distnr),
+                    color='cyan',
+                    variant="dot",
+                    style={'border-color': 'red'},
+                ),
+                label="There is a source behind in ZTF reference image. You might want to check the DC magnitude plot, and get DR photometry to see its long-term behaviour",
+                color='red',
+                className='d-inline',
+                id='badge_ztf',
+                multiline=True,
+            )
+        else:
+            ztf_badge = dmc.Tooltip(
+                dmc.Badge(
+                    "ZTF: {:.1f}\"".format(distnr),
+                    color='cyan',
+                    variant="dot",
+                ),
+                label="Distance to closest object in ZTF reference image",
+                color='cyan',
+                className='d-inline',
+                multiline=True,
+            )
+
+        badges.append(ztf_badge)
+
+    distpsnr = pdf['i:distpsnr1'].values[0]
+    if distpsnr:
+        badges.append(
+            dmc.Tooltip(
+                dmc.Badge(
+                    "PS1: {:.1f}\"".format(distpsnr),
+                    color='teal',
+                    variant="dot",
+                ),
+                label="Distance to closest object in Pan-STARRS DR1 catalogue",
+                color='teal',
+                className='d-inline',
+                multiline=True,
+            )
+        )
+
+    distgaia =  pdf['i:neargaia'].values[0]
+    if distgaia:
+        badges.append(
+            dmc.Tooltip(
+                dmc.Badge(
+                    "Gaia: {:.1f}\"".format(distgaia),
+                    color='teal',
+                    variant="dot",
+                ),
+                label="Distance to closest object in Gaia DR3 catalogue",
+                color='teal',
+                className='d-inline',
+                multiline=True,
+            )
+        )
 
     meta_name = generate_metadata_name(pdf['i:objectId'].values[0])
     if meta_name is not None:

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -1075,19 +1075,22 @@ def card_search_result(row, i):
     jdstart = row.get('i:jdstarthist')
     lastdate = row.get('i:lastdate', Time(jdend, format='jd').iso)
 
+    coords = SkyCoord(row['i:ra'], row['i:dec'], unit='deg')
+
     text = """
     `{}` detection(s) in `{:.1f}` days
     First: `{}`
     Last: `{}`
-    Eq: `{}`
+    Equ: `{} {}`
     Gal: `{}`
     """.format(
         ndethist,
         jdend - jdstart,
         Time(jdstart, format='jd').iso[:19],
         lastdate[:19],
-        SkyCoord(row['i:ra'], row['i:dec'], unit='deg').to_string(style='hmsdms', sep=' '),
-        SkyCoord(row['i:ra'], row['i:dec'], unit='deg').galactic.to_string(style='decimal'),
+        coords.ra.to_string(pad=True, unit='hour', precision=2, sep=' '),
+        coords.dec.to_string(pad=True, unit='deg', alwayssign=True, precision=1, sep=' '),
+        coords.galactic.to_string(style='decimal'),
     )
 
     if 'v:separation_degree' in row:

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -858,6 +858,16 @@ def card_id1(object_data, object_uppervalid, object_upper):
             )
         )
 
+    tracklet = pdf['d:tracklet'].values[0]
+    if tracklet and tracklet != 'null':
+        badges.append(
+            dmc.Badge(
+                "{}".format(tracklet),
+                color='violet',
+                variant="dot",
+            )
+        )
+
     distnr = pdf['i:distnr'].values[0]
     if distnr:
         if is_source_behind(distnr):
@@ -1000,6 +1010,16 @@ def card_search_result(row, i):
             )
         )
 
+    tracklet = row.get('d:tracklet')
+    if tracklet and tracklet != 'null':
+        badges.append(
+            dmc.Badge(
+                "{}".format(tracklet),
+                variant='outline',
+                color='violet',
+                size='md'
+            )
+        )
 
     # Nearby objects
     distnr = row.get('i:distnr')

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -1070,6 +1070,11 @@ def card_search_result(row, i):
         SkyCoord(row['i:ra'], row['i:dec'], unit='deg').galactic.to_string(style='decimal'),
     )
 
+    if 'v:separation_degree' in row:
+        corner_str = "{:.1f}''".format(row['v:separation_degree']*3600)
+    else:
+        corner_str = str(i)
+
     item = dbc.Card(
         [
             # dbc.CardHeader(
@@ -1108,6 +1113,14 @@ def card_search_result(row, i):
                         ],
                         justify='start',
                         className='g-2',
+                    ),
+                    # Upper right corner badge
+                    dbc.Badge(
+                        corner_str,
+                        color="light",
+                        pill=True,
+                        text_color="dark",
+                        className="position-absolute top-0 start-100 translate-middle border",
                     ),
                 ]
             )

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -26,11 +26,11 @@ from apps.utils import generate_qr
 from apps.utils import class_colors
 from apps.utils import simbad_types
 from apps.utils import loading, help_popover
+from apps.utils import request_api
 
 from fink_utils.xmatch.simbad import get_simbad_labels
 from fink_utils.photometry.utils import is_source_behind
 
-import requests
 import pandas as pd
 import numpy as np
 import urllib
@@ -744,17 +744,18 @@ def generate_tns_badge(oid):
     ----------
     badge: dmc.Badge or None
     """
-    r = requests.post(
-        '{}/api/v1/resolver'.format(APIURL),
+    r = request_api(
+        '/api/v1/resolver',
         json={
             'resolver': 'tns',
             'name': oid,
             'reverse': True
-        }
+        },
+        get_json=True
     )
 
-    if r.json() != []:
-        payload = r.json()[-1]
+    if r != []:
+        payload = r[-1]
 
         if payload['d:type'] != 'nan':
             msg = 'TNS: {} ({})'.format(payload['d:fullname'], payload['d:type'])
@@ -782,15 +783,16 @@ def generate_metadata_name(oid):
     ----------
     name: str
     """
-    r = requests.post(
-        '{}/api/v1/metadata'.format(APIURL),
+    r = request_api(
+        '/api/v1/metadata',
         json={
             'objectId': oid,
-        }
+        },
+        get_json=True
     )
 
-    if r.json() != []:
-        name = r.json()[0]['d:internal_name']
+    if r != []:
+        name = r[0]['d:internal_name']
     else:
         name = None
 

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -34,6 +34,7 @@ import requests
 import pandas as pd
 import numpy as np
 import urllib
+import textwrap
 
 from astropy.time import Time
 from astropy.coordinates import SkyCoord
@@ -1092,6 +1093,12 @@ def card_search_result(row, i):
         coords.dec.to_string(pad=True, unit='deg', alwayssign=True, precision=1, sep=' '),
         coords.galactic.to_string(style='decimal'),
     )
+
+    text = textwrap.dedent(text)
+    if 'i:rb' in row:
+        text += "RealBogus: `{:.2f}`\n".format(row['i:rb'])
+    if 'd:anomaly_score' in row:
+        text += "Anomaly score: `{:.2f}`\n".format(row['d:anomaly_score'])
 
     if 'v:separation_degree' in row:
         corner_str = "{:.1f}''".format(row['v:separation_degree']*3600)

--- a/apps/gw.py
+++ b/apps/gw.py
@@ -23,7 +23,6 @@ import visdcc
 import io
 import gzip
 import time
-import requests
 import pandas as pd
 import healpy as hp
 import numpy as np
@@ -36,7 +35,7 @@ import astropy.units as u
 from app import app, APIURL
 from apps.utils import markdownify_objectid, convert_jd, simbad_types, class_colors
 from apps.utils import extract_bayestar_query_url
-
+from apps.utils import request_api
 
 def extract_moc(fn, credible_level):
     """
@@ -117,8 +116,8 @@ def query_bayestar(submit, credible_level, superevent_name, searchurl):
     except URLError:
         return "error"
 
-    r = requests.post(
-        '{}/api/v1/bayestar'.format(APIURL),
+    r = request_api(
+        '/api/v1/bayestar',
         json={
             'bayestar': str(data),
             'credible_level': float(credible_level),
@@ -126,7 +125,7 @@ def query_bayestar(submit, credible_level, superevent_name, searchurl):
         }
     )
 
-    pdf = pd.read_json(io.BytesIO(r.content))
+    pdf = pd.read_json(r)
 
     # return pdf.to_json(), "done"
     return pdf.to_json()

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -101,6 +101,7 @@ def parse_query(string, timeout=None):
       - for tracklets, it is always 'tracklet'
       - for resolved objects or coordinates, it is `conesearch` even if no radius is specified
       - for SSO objects it is always `sso`
+      - if `after` keyword is specified it is `daterange`
 
     Parameters
     ----------
@@ -321,6 +322,10 @@ def parse_query(string, timeout=None):
         query['action'] = 'class'
         query['params']['class'] = 'All classes'
         query['hint'] = 'Latest objects / {}'.format(query['params']['last'])
+
+    elif 'after' in query['params']:
+        query['action'] = 'daterange'
+        query['hint'] = 'Date range search'
 
     else:
         query['action'] = 'unknown'

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -129,6 +129,9 @@ def parse_query(string, timeout=None):
         'string': string,
     }
 
+    if not string:
+        return query
+
     string = string.replace(',', ' ') # TODO: preserve quoted commas?..
 
     # Sanitize the times to ISO format so that they parse as single tokens

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -318,6 +318,10 @@ def parse_query(string, timeout=None):
         query['action'] = 'anomaly'
         query['hint'] = 'Anomaly search'
 
+    elif 'random' in query['params']:
+        query['action'] = 'random'
+        query['hint'] = 'Random search / {} objects'.format(query['params']['random'])
+
     elif 'class' in query['params']:
         query['action'] = 'class'
         query['hint'] = 'Class based search / {}'.format(query['params']['class'])
@@ -325,7 +329,7 @@ def parse_query(string, timeout=None):
     elif 'last' in query['params']:
         query['action'] = 'class'
         query['params']['class'] = 'All classes'
-        query['hint'] = 'Latest objects / {}'.format(query['params']['last'])
+        query['hint'] = 'Latest objects / {}, {} objects'.format(query['params']['class'], query['params']['last'])
 
     elif 'after' in query['params']:
         query['action'] = 'daterange'

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -1,14 +1,14 @@
 import shlex
 import regex as re # For partial matching
-import requests
 import functools
 
 import numpy as np
 
 from app import APIURL
+from apps.utils import request_api
 
 @functools.lru_cache(maxsize=320)
-def call_resolver(data, kind, timeout=None, reverse=False, **kwargs):
+def call_resolver(data, kind, reverse=False, **kwargs):
     """ Call Fink resolver
 
     Parameters
@@ -34,13 +34,13 @@ def call_resolver(data, kind, timeout=None, reverse=False, **kwargs):
 
     try:
         if kind == 'ztf':
-            r = requests.post(
-                '{}/api/v1/objects'.format(APIURL),
+            payload = request_api(
+                '/api/v1/objects',
                 json={
                     'objectId': data,
                     'columns': "i:ra,i:dec",
                 },
-                timeout=timeout
+                get_json=True,
             )
         else:
             params = {
@@ -50,14 +50,12 @@ def call_resolver(data, kind, timeout=None, reverse=False, **kwargs):
             }
             params.update(kwargs)
 
-            r = requests.post(
-                '{}/api/v1/resolver'.format(APIURL),
+            payload = request_api(
+                '/api/v1/resolver',
                 json=params,
-                timeout=timeout
+                get_json=True
             )
-
-        payload = r.json()
-    except requests.exceptions.ReadTimeout:
+    except:
         payload = None
 
     return payload

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -275,7 +275,7 @@ def parse_query(string, timeout=None):
             if res:
                 query['object'] = res[0]['oname']
                 query['type'] = 'simbad'
-                query['hint'] = 'Simbad object'
+                query['hint'] = 'Simbad object / {}'.format(res[0]['otype'])
                 query['params']['ra'] = res[0]['jradeg']
                 query['params']['dec'] = res[0]['jdedeg']
 
@@ -310,12 +310,12 @@ def parse_query(string, timeout=None):
 
     elif 'class' in query['params']:
         query['action'] = 'class'
-        query['hint'] = 'Class based search'
+        query['hint'] = 'Class based search / {}'.format(query['params']['class'])
 
     elif 'last' in query['params']:
         query['action'] = 'class'
         query['params']['class'] = 'All classes'
-        query['hint'] = 'Latest objects'
+        query['hint'] = 'Latest objects / {}'.format(query['params']['last'])
 
     else:
         query['action'] = 'unknown'

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -171,15 +171,15 @@ def parse_query(string, timeout=None):
             if m:
                 value = float(m[1])
                 if m[4] == 'd':
-                    value /= 1
+                    value *= 3600
                 elif m[4] == 'm' or m[4] == '\'':
-                    value /= 60
+                    value *= 60
                 elif m[4] == 's' or m[4] == '"':
-                    value /= 3600
+                    value *= 1
                 else:
                     # Default is no change, except for 'r' key
                     if key == 'r':
-                        value /= 3600
+                        value *= 1
 
             query['params'][key] = value
 
@@ -196,7 +196,7 @@ def parse_query(string, timeout=None):
             query['params']['ra'] = float(m[1])
             query['params']['dec'] = float(m[2])
             if m[4] is not None:
-                query['params']['r'] = float(m[4])/3600
+                query['params']['r'] = float(m[4])
 
             query['object'] = string
             query['type'] = 'coordinates'
@@ -222,7 +222,7 @@ def parse_query(string, timeout=None):
                     query['params']['dec'] *= -1
 
                 if m[9] is not None:
-                    query['params']['r'] = float(m[9])/3600
+                    query['params']['r'] = float(m[9])
 
                 query['object'] = string
                 query['type'] = 'coordinates'

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -314,6 +314,10 @@ def parse_query(string, timeout=None):
     elif query['type'] == 'sso' or 'sso' in query['params']:
         query['action'] = 'sso'
 
+    elif query['params'].get('class') == 'Anomaly':
+        query['action'] = 'anomaly'
+        query['hint'] = 'Anomaly search'
+
     elif 'class' in query['params']:
         query['action'] = 'class'
         query['hint'] = 'Class based search / {}'.format(query['params']['class'])

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -154,7 +154,7 @@ def parse_query(string, timeout=None):
         # Try to locate well-defined object name patterns
         for pattern in name_patterns:
             if pattern.get('min') and len(token) >= pattern.get('min'):
-                m = re.match(pattern['pattern'], token, partial=True)
+                m = re.match(pattern['pattern'], token, re.IGNORECASE, partial=True)
                 if m:
                     query['object'] = token
                     query['type'] = pattern['type']
@@ -172,7 +172,7 @@ def parse_query(string, timeout=None):
         # Try to parse keyword parameters, either as key:value or key=value
         m = re.match(r'^(\w+)[=:](.*?)$', token)
         if m:
-            key = m[1]
+            key = m[1].lower()
             value = m[2]
             # Special handling for numbers, possibly ending with d/m/s for degrees etc
             m = re.match(r'^([+-]?(\d+)(.\d+)?)([dms\'"]?)$', value)
@@ -304,9 +304,11 @@ def parse_query(string, timeout=None):
 
     elif query['type'] == 'ztf':
         query['action'] = 'objectid'
+        #TODO: uppercase the ZTF prefix!
 
     elif query['type'] == 'tracklet':
         query['action'] = 'tracklet'
+        query['object'] = query['object'].upper()
 
     elif query['type'] == 'sso' or 'sso' in query['params']:
         query['action'] = 'sso'

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -1,0 +1,300 @@
+import shlex
+import regex as re # For partial matching
+import requests
+import functools
+
+import numpy as np
+
+from app import APIURL
+
+@functools.lru_cache(maxsize=320)
+def call_resolver(data, kind, timeout=None, reverse=False):
+    """ Call Fink resolver
+
+    Parameters
+    ----------
+    data: str
+        Query payload
+    kind: str
+        Resolver name: ssodnet, tns, simbad
+
+    Returns
+    ----------
+    payload: dict
+        Payload returned by the /api/v1/resolver endpoint
+    """
+
+    if kind == 'tns':
+        # Normalize AT name to have whitespace before year
+        m = re.match('^(AT|SN)\s*([12]\w+)$', data, re.IGNORECASE)
+        if m:
+            data = m[1].upper() + ' ' + m[2]
+
+    try:
+        if kind == 'ztf':
+            r = requests.post(
+                '{}/api/v1/objects'.format(APIURL),
+                json={
+                    'objectId': data,
+                    'columns': "i:ra,i:dec",
+                },
+                timeout=timeout
+            )
+        else:
+            r = requests.post(
+                '{}/api/v1/resolver'.format(APIURL),
+                json={
+                    'resolver': kind,
+                    'name': str(data),
+                    'reverse': reverse,
+                },
+                timeout=timeout
+            )
+
+        payload = r.json()
+    except requests.exceptions.ReadTimeout:
+        payload = None
+
+    return payload
+
+name_patterns = [
+    {
+        'type': 'ztf',
+        'pattern': '^ZTF[12]\d\w{7}$',
+        'hint': 'ZTF objectId (format ZTFyyccccccc)',
+        'min': 3
+    },
+    {
+        'type': 'tracklet',
+        'pattern': '^TRCK_\d{8}_\d{6}_\d{2}$',
+        'hint': 'tracklet (format TRCK_YYYYMMDD_HHMMSS_NN)',
+        'min': 4
+    },
+    # {
+    #     'type': 'at',
+    #     'pattern': '^AT[12]\d{3}\w{3}$',
+    #     'hint': 'AT: ATyyyyccc',
+    #     'min': 3
+    # },
+]
+
+def parse_query(string, timeout=None):
+    """ Parse (probably incomplete) query
+
+    Order is as follows:
+    1. Extract object names (partially) matching some patterns
+    2. Extract keyword parameters, either key:value or key=value
+    3. Try to interpret the rest as coordinates as follows:
+      - Pair of degrees
+      - HH MM SS.S [+-]?DD MM SS.S
+      - HH:MM:SS.S [+-]?DD:MM:SS.S
+      - HHhMMhSS.Ss [+-]?DDhMMhSS.Ss
+      - optionally, use one more number as a radius, in either arcseconds, minutes or degrees
+    4. The rest is resolved through several Fink resolvers
+    5. Finally, the action is suggested based on the parameters
+      - for ZTF objectIds it is 'objectid' unless the radius `r` is explicitly given and the match is not partial (then it is 'conesearch')
+      - for tracklets, it is always 'tracklet'
+      - for resolved objects or coordinates, it is `conesearch` even if no radius is specified
+      - for SSO objects it is always `sso`
+
+    Parameters
+    ----------
+    string: str
+        String to parse
+
+    Returns
+    ----------
+    Dictionary containing the following keys:
+      - object: object name
+      - type: object type derived from name parsing
+      - hint: some human-readable description of what was parsed
+      - action: suggested action for the query
+      - params: dictionary with keyword parameters (ra, dec, r, ...)
+      - string: original query string
+    """
+    # Results schema
+    query = {
+        'object': None,
+        'type': None,
+        'partial': False,
+        'hint': None,
+        'action': None,
+        'params': {},
+        'completions': [],
+        'string': string,
+    }
+
+    string = string.replace(',', ' ') # TODO: preserve quoted commas?..
+
+    try:
+        tokens = shlex.split(string, posix=True) # It will also handle quoted strings
+    except:
+        return query
+
+    unparsed = []
+
+    for token in tokens:
+        is_parsed = False
+        # Try to locate well-defined object name patterns
+        for pattern in name_patterns:
+            if pattern.get('min') and len(token) >= pattern.get('min'):
+                m = re.match(pattern['pattern'], token, partial=True)
+                if m:
+                    query['object'] = token
+                    query['type'] = pattern['type']
+                    query['hint'] = pattern['hint']
+                    query['partial'] = m.partial
+                    is_parsed = True
+
+                    if m.partial:
+                        query['hint'] = query['hint'] + ' (partial)'
+                    break
+
+        if is_parsed:
+            continue
+
+        # Try to parse keyword parameters, either as key:value or key=value
+        m = re.match('^(\w+)[=:]([^:=]*?)$', token)
+        if m:
+            key = m[1]
+            value = m[2]
+            # Special handling for numbers, possibly ending with d/m/s for degrees etc
+            m = re.match('^([+-]?(\d+)(.\d+)?)([dms\'"]?)$', value)
+            if m:
+                value = float(m[1])
+                if m[4] == 'd':
+                    value /= 1
+                elif m[4] == 'm' or m[4] == '\'':
+                    value /= 60
+                elif m[4] == 's' or m[4] == '"':
+                    value /= 3600
+                else:
+                    # Default is no change, except for 'r' key
+                    if key == 'r':
+                        value /= 3600
+
+            query['params'][key] = value
+
+        else:
+            unparsed.append(token)
+
+    string = " ".join(unparsed)
+
+    # Parse the rest of the query string as coordinates, if any
+    if len(string) and not query['object']:
+        # Pair of decimal degrees
+        m = re.search("^(\d+\.?\d*)\s+([+-]?\d+\.?\d*)(\s+(\d+\.?\d*))?$", string)
+        if m:
+            query['params']['ra'] = float(m[1])
+            query['params']['dec'] = float(m[2])
+            if m[4] is not None:
+                query['params']['r'] = float(m[4])/3600
+
+            query['object'] = string
+            query['type'] = 'coordinates'
+            query['hint'] = 'Decimal coordinates'
+
+            if m[4] is not None:
+                query['hint'] += ' with radius'
+
+        else:
+            # HMS DMS
+            m = re.search(
+                "^(\d{1,2})\s+(\d{1,2})\s+(\d{1,2}\.?\d*)\s+([+-])?\s*(\d{1,3})\s+(\d{1,2})\s+(\d{1,2}\.?\d*)(\s+(\d+\.?\d*))?$",
+                string
+            ) or re.search(
+                "^(\d{1,2})[:h](\d{1,2})[:m](\d{1,2}\.?\d*)[s]?\s+([+-])?\s*(\d{1,3})[d:](\d{1,2})[m:](\d{1,2}\.?\d*)[s]?(\s+(\d+\.?\d*))?$",
+                string
+            )
+            if m:
+                query['params']['ra'] = (float(m[1]) + float(m[2])/60 + float(m[3])/3600)*15
+                query['params']['dec'] = (float(m[5]) + float(m[6])/60 + float(m[7])/3600)
+
+                if m[4] == '-':
+                    query['params']['dec'] *= -1
+
+                if m[9] is not None:
+                    query['params']['r'] = float(m[9])/3600
+
+                query['object'] = string
+                query['type'] = 'coordinates'
+                query['hint'] = 'HMS DMS coordinates'
+
+                if m[9] is not None:
+                    query['hint'] += ' with radius'
+
+            else:
+                query['object'] = string
+                query['type'] = 'unresolved'
+
+    # Should we resolve object name?..
+    if query['object'] and query['type'] == 'ztf' and not query['partial'] and 'r' in query['params']:
+        res = call_resolver(query['object'], 'ztf')
+        if res:
+            query['params']['ra'] = res[0]['i:ra']
+            query['params']['dec'] = res[0]['i:dec']
+
+    if query['object'] and query['type'] not in ['ztf', 'tracklet', 'coordinates', None]:
+        for reverse in [False, True]:
+            if 'ra' not in query['params'] and query['object'][0].isalpha():
+                # TNS
+                res = call_resolver(query['object'], 'tns', timeout=timeout, reverse=reverse)
+                if res:
+                    query['object'] = res[0]['d:fullname']
+                    query['type'] = 'tns'
+                    query['hint'] = 'TNS object / {}'.format(res[0]['d:internalname'])
+                    query['params']['ra'] = res[0]['d:ra']
+                    query['params']['dec'] = res[0]['d:declination']
+
+                    if len(res) > 1:
+                        # Make list of unique names not equal to the first one
+                        query['completions'] = list(
+                            np.unique(
+                                [_['d:fullname'] for _ in res if _['d:fullname'] != res[0]['d:fullname']]
+                            )
+                        )
+
+                    break
+
+        if 'ra' not in query['params'] and query['object'][0].isalpha():
+            # Simbad
+            res = call_resolver(query['object'], 'simbad', timeout=timeout)
+            if res:
+                query['object'] = res[0]['oname']
+                query['type'] = 'simbad'
+                query['hint'] = 'Simbad object'
+                query['params']['ra'] = res[0]['jradeg']
+                query['params']['dec'] = res[0]['jdedeg']
+
+        if 'ra' not in query['params']:
+                # SSO - final test
+                res = call_resolver(query['object'], 'ssodnet', timeout=timeout)
+                if res:
+                    query['object'] = res[0]['name']
+                    query['type'] = 'ssodnet'
+                    query['hint'] = 'SSO object / {}'.format(res[0]['type'])
+
+                    if len(res) > 1:
+                        query['completions'] = [_['name'] for _ in res]
+
+    # Guess the kind of query
+    if 'ra' in query['params'] and 'dec' in query['params']:
+        query['action'] = 'conesearch'
+
+    elif query['type'] == 'ztf':
+        query['action'] = 'objectid'
+
+    elif query['type'] == 'tracklet':
+        query['action'] = 'tracklet'
+
+    elif query['type'] == 'ssodnet':
+        query['action'] = 'sso'
+
+    elif 'class' in query['params']:
+        query['action'] = 'class'
+        query['hint'] = 'Class based search'
+
+    else:
+        query['action'] = 'unknown'
+
+    return query

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -26,14 +26,12 @@ def call_resolver(data, kind, timeout=None, reverse=False, **kwargs):
 
     if kind == 'tns':
         # Normalize AT name to have whitespace before year
-        m = re.match(r'^(AT|SN)\s*([12]\w+)$', data, re.IGNORECASE)
+        m = re.match(r'^(AT|SN)\s*([12]\w+)$', str(data), re.IGNORECASE)
         if m:
             data = m[1].upper() + ' ' + m[2]
     elif kind == 'ssodnet':
         data = str(data)
-        # Try to capitalize proper names if they start with lower letter
-        if len(data) and data[0].isalpha() and data[0].islower():
-            data = data.capitalize()
+
     try:
         if kind == 'ztf':
             r = requests.post(

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1954,10 +1954,12 @@ def zoom_cutouts(relayout_data, figure_states):
                 figure_state['layout']['yaxis']['autorange'] = True
             else:
                 figure_state['layout']['xaxis']['range'] = [
-                    unique_data['xaxis.range[0]'], unique_data['xaxis.range[1]']]
+                    unique_data.get('xaxis.range[0]'), unique_data.get('xaxis.range[1]')
+                ]
                 figure_state['layout']['xaxis']['autorange'] = False
                 figure_state['layout']['yaxis']['range'] = [
-                    unique_data['yaxis.range[0]'], unique_data['yaxis.range[1]']]
+                    unique_data.get('yaxis.range[0]'), unique_data.get('yaxis.range[1]')
+                ]
                 figure_state['layout']['yaxis']['autorange'] = False
         return [unique_data] * len(relayout_data), figure_states
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1208,6 +1208,7 @@ def draw_lightcurve_preview(name) -> dict:
                     'type': 'data',
                     'array': err[idx],
                     'visible': True,
+                    'width': 0,
                     'color': color,
                     'opacity': 0.5
                 },

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -110,7 +110,7 @@ layout_lightcurve = dict(
 
 layout_lightcurve_preview = dict(
     automargin=True,
-    margin=dict(l=50, r=30, b=0, t=0),
+    margin=dict(l=50, r=0, b=0, t=0),
     hovermode="closest",
     hoverlabel={
         'align': "left"

--- a/apps/query_cluster.py
+++ b/apps/query_cluster.py
@@ -20,14 +20,13 @@ import dash_mantine_components as dmc
 from dash_iconify import DashIconify
 
 from app import app
-from app import APIURL
 from apps.mining.utils import upload_file_hdfs, submit_spark_job
 from apps.mining.utils import estimate_size_gb_ztf, estimate_size_gb_elasticc
+from apps.utils import request_api
 
 import numpy as np
 import pandas as pd
 from datetime import datetime, timedelta, date
-import requests
 import yaml
 import textwrap
 
@@ -365,16 +364,17 @@ def estimate_alert_number_ztf(date_range_picker, class_select):
 
     for i in range(delta.days + 1):
         tmp = (dstart + timedelta(i)).strftime('%Y%m%d')
-        r = requests.post(
-            '{}/api/v1/statistics'.format(APIURL),
+        r = request_api(
+            '/api/v1/statistics',
             json={
                 'date': tmp,
                 'columns': columns,
                 'output-format': 'json'
-            }
+            },
+            get_json=True
         )
-        if r.json() != []:
-            payload = r.json()[0]
+        if r != []:
+            payload = r[0]
             dic['basic:sci'] += int(payload['basic:sci'])
             for column_name in column_names:
                 if column_name in payload.keys():

--- a/apps/statistics.py
+++ b/apps/statistics.py
@@ -16,13 +16,11 @@ from dash import html, dcc, Input, Output
 import dash_bootstrap_components as dbc
 
 from app import app
-from app import APIURL
 from apps.utils import loading
+from apps.utils import request_api
 
 import numpy as np
 import pandas as pd
-
-import requests
 
 dcc.Location(id='url', refresh=False)
 
@@ -123,8 +121,8 @@ def store_stat_query(name):
     """
     cols = 'basic:raw,basic:sci,basic:fields,basic:exposures,class:Unknown'
 
-    r = requests.post(
-        '{}/api/v1/statistics'.format(APIURL),
+    r = request_api(
+        '/api/v1/statistics',
         json={
             'date': '',
             'output-format': 'json',
@@ -132,7 +130,7 @@ def store_stat_query(name):
         }
     )
 
-    pdf = pd.read_json(r.content)
+    pdf = pd.read_json(r)
     pdf = pdf.set_index('key:key', drop=False)
 
     return pdf.to_json()
@@ -324,8 +322,8 @@ def daily_stats():
 def generate_night_list():
     """ Generate the list of available nights (last night first)
     """
-    r = requests.post(
-        '{}/api/v1/statistics'.format(APIURL),
+    r = request_api(
+        '/api/v1/statistics',
         json={
             'date': '',
             'output-format': 'json',
@@ -334,7 +332,7 @@ def generate_night_list():
     )
 
     # Format output in a DataFrame
-    pdf = pd.read_json(r.content)
+    pdf = pd.read_json(r)
 
     labels = list(pdf['key:key'].apply(lambda x: x[4:8] + '-' + x[8:10] + '-' + x[10:12]))
 
@@ -356,14 +354,14 @@ def generate_night_list():
 def generate_col_list():
     """ Generate the list of available columns
     """
-    r = requests.post(
-        '{}/api/v1/statistics'.format(APIURL),
+    r = request_api(
+        '/api/v1/statistics',
         json={
             'output-format': 'json',
             'schema': True
         }
     )
-    pdf = pd.read_json(r.content)
+    pdf = pd.read_json(r)
     schema_list = list(pdf['schema'])
 
     labels = [
@@ -397,8 +395,8 @@ def get_data_one_night(night):
     """
     cols = 'basic:raw,basic:sci,basic:fields,basic:exposures'
 
-    r = requests.post(
-        '{}/api/v1/statistics'.format(APIURL),
+    r = request_api(
+        '/api/v1/statistics',
         json={
             'date': night,
             'output-format': 'json',
@@ -407,7 +405,7 @@ def get_data_one_night(night):
     )
 
     # Format output in a DataFrame
-    pdf = pd.read_json(r.content)
+    pdf = pd.read_json(r)
 
     return pdf
 

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -38,7 +38,6 @@ from apps.sso.cards import card_sso_left
 
 from apps.cards import card_lightcurve_summary
 from apps.cards import card_id
-from apps.cards import create_external_links, create_external_links_brokers
 
 from apps.plotting import draw_sso_lightcurve, draw_sso_astrometry, draw_sso_residual
 from apps.plotting import draw_tracklet_lightcurve, draw_tracklet_radec
@@ -64,17 +63,6 @@ def tab1_content(pdf):
     """ Summary tab
     """
 
-    distnr = pdf['i:distnr'].values[0]
-    if is_source_behind(distnr):
-        extra_div = dbc.Alert(
-            "It looks like there is a source behind, at {:.1f} arcsec. You might want to check the DC magnitude, and get DR photometry to see its long-term behaviour.".format(distnr),
-            dismissable=True,
-            is_open=True,
-            color="light"
-        )
-    else:
-        extra_div = html.Div()
-
     tab1_content_ = html.Div([
         dmc.Space(h=10),
         dbc.Row(
@@ -95,10 +83,7 @@ def tab1_content(pdf):
         dbc.Row(
             [
                 dbc.Col(
-                    [
-                        extra_div,
-                        card_lightcurve_summary()
-                    ],
+                    card_lightcurve_summary(),
                     md=8
                 ),
                 dbc.Col(
@@ -474,30 +459,6 @@ def is_tracklet(pdfs):
         return True
 
     return False
-
-@app.callback(
-    Output('external_links', 'children'),
-    Input('object-data', 'children')
-)
-def create_external_links_(object_data):
-    """ Create links to external website. Used in the mobile app.
-    """
-    pdf = pd.read_json(object_data)
-    ra0 = pdf['i:ra'].values[0]
-    dec0 = pdf['i:dec'].values[0]
-    buttons = create_external_links(ra0, dec0)
-    return buttons
-
-@app.callback(
-    Output('external_links_brokers', 'children'),
-    Input('object-data', 'children')
-)
-def create_external_links_brokers_(object_data):
-    """ Create links to external website. Used in the mobile app.
-    """
-    pdf = pd.read_json(object_data)
-    buttons = create_external_links_brokers(pdf['i:objectId'].values[0])
-    return buttons
 
 @app.callback(
     [

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -24,7 +24,6 @@ from dash_iconify import DashIconify
 
 import pandas as pd
 import numpy as np
-import requests
 
 import rocks
 
@@ -51,11 +50,10 @@ from apps.utils import generate_qr
 from apps.utils import class_colors
 from apps.utils import retrieve_oid_from_metaname
 from apps.utils import loading
+from apps.utils import request_api
 from fink_utils.photometry.utils import is_source_behind
 
 from fink_utils.xmatch.simbad import get_simbad_labels
-
-from app import APIURL
 
 dcc.Location(id='url', refresh=False)
 
@@ -484,8 +482,8 @@ def store_query(name):
     else:
         oid = name[1:]
 
-    r = requests.post(
-        '{}/api/v1/objects'.format(APIURL),
+    r = request_api(
+        '/api/v1/objects',
         json={
             'objectId': oid,
             'withupperlim': True,
@@ -494,7 +492,7 @@ def store_query(name):
     )
 
     pdf = pd.read_json(
-        r.content,
+        r,
         dtype={'i:ssnamenr':str} # Force reading this field as string
     )
 
@@ -507,14 +505,14 @@ def store_query(name):
     payload = pdfs['i:ssnamenr'].values[0]
     is_sso = np.alltrue([i == payload for i in pdfs['i:ssnamenr'].values])
     if str(payload) != 'null' and is_sso:
-        r = requests.post(
-            '{}/api/v1/sso'.format(APIURL),
+        r = request_api(
+            '/api/v1/sso',
             json={
                 'n_or_d': payload,
             }
         )
 
-        pdfsso = pd.read_json(r.content)
+        pdfsso = pd.read_json(r)
 
         if pdfsso.empty:
             # This can happen for SSO candidate with a ssnamenr
@@ -531,14 +529,14 @@ def store_query(name):
     payload = pdfs['d:tracklet'].values[0]
 
     if str(payload).startswith('TRCK'):
-        r = requests.post(
-            '{}/api/v1/tracklet'.format(APIURL),
+        r = request_api(
+            '/api/v1/tracklet',
             json={
                 'id': payload,
             }
         )
 
-        pdftracklet = pd.read_json(r.content)
+        pdftracklet = pd.read_json(r)
     else:
         pdftracklet = pd.DataFrame()
 
@@ -603,13 +601,13 @@ def make_qrcode(path):
 
 def layout(name):
     # even if there is one object ID, this returns  several alerts
-    r = requests.post(
-        '{}/api/v1/objects'.format(APIURL),
+    r = request_api(
+        '/api/v1/objects',
         json={
             'objectId': name[1:],
         }
     )
-    pdf = pd.read_json(r.content)
+    pdf = pd.read_json(r)
 
     if pdf.empty:
         layout_ = html.Div(

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -775,7 +775,11 @@ def request_api(endpoint, json=None, get_json=False, method='POST'):
         if len(func_name) == 2 and func_name[0][0] == '.':
             func = getattr(apps.api.api, func_name[0][1:])
 
-            res = func(json)
+            if method == 'GET':
+                # No args?..
+                res = func()
+            else:
+                res = func(json)
             if isinstance(res, Response):
                 if res.direct_passthrough:
                     res.make_sequence()
@@ -796,8 +800,11 @@ def request_api(endpoint, json=None, get_json=False, method='POST'):
                 '{}{}'.format(APIURL, endpoint),
                 json=json
             )
-        else:
-            print("Method {} not implemented".format(method))
+        elif method == 'GET':
+                # No args?..
+            r = requests.get(
+                '{}{}'.format(APIURL, endpoint)
+            )
 
         if get_json:
             return r.json()

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -44,7 +44,8 @@ from fink_utils.sso.utils import get_miriade_data, query_miriade
 from fink_utils.photometry.conversion import dc_mag
 from fink_utils.xmatch.simbad import get_simbad_labels
 
-from app import APIURL, nlimit
+from app import APIURL, LOCALAPI, nlimit, server
+import apps.api
 
 simbad_types = get_simbad_labels('old_and_new')
 simbad_types = sorted(simbad_types, key=lambda s: s.lower())
@@ -748,16 +749,60 @@ def generate_qr(data):
 def retrieve_oid_from_metaname(name):
     """ Search for the corresponding ZTF objectId given a metaname
     """
-    r = requests.post(
-        '{}/api/v1/metadata'.format(APIURL),
+    r = request_api(
+        '/api/v1/metadata',
         json={
             'internal_name_encoded': name,
-        }
+        },
+        get_json=True
     )
 
-    if r.json() != []:
-        return r.json()[0]['key:key']
+    if r != []:
+        return r[0]['key:key']
     return None
+
+# Access local or remove API endpoint
+from app import server
+import apps.api
+from flask import Response
+from json import loads as json_loads
+
+def request_api(endpoint, json=None, get_json=False, method='POST'):
+    if LOCALAPI:
+        # Use local API
+        urls = server.url_map.bind('')
+        func_name = urls.match(endpoint, method)
+        if len(func_name) == 2 and func_name[0][0] == '.':
+            func = getattr(apps.api.api, func_name[0][1:])
+
+            res = func(json)
+            if isinstance(res, Response):
+                if res.direct_passthrough:
+                    res.make_sequence()
+                result = res.get_data()
+            else:
+                result = res
+
+            if get_json:
+                return json_loads(result)
+            else:
+                return result
+        else:
+            return None
+    else:
+        # Use remote API
+        if method == 'POST':
+            r = requests.post(
+                '{}{}'.format(APIURL, endpoint),
+                json=json
+            )
+        else:
+            print("Method {} not implemented".format(method))
+
+        if get_json:
+            return r.json()
+        else:
+            return r.content
 
 # TODO: split these UI snippets into separate file?..
 import dash_mantine_components as dmc

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -178,49 +178,6 @@ def markdownify_objectid(objectid):
     )
     return objectid_markdown
 
-def validate_query(query, query_type):
-    """ Validate a query. Need to be rewritten in a better way.
-    """
-    empty_query_type = (query_type is None) or (query_type == '')
-
-    if empty_query_type:
-        # This can only happen in queries formed from URL parameters
-        header = "Empty query type"
-        text = "You need to specify a query_type in your request (e.g. ?query_type=Conesearch&ra=value&dec=value&radius=value)"
-        return {'flag': False, 'header': header, 'text': text}
-
-    empty_query = (query is None) or (query == '')
-
-    # no queries
-    if empty_query and ((query_type == 'objectId') or (query_type == 'Conesearch') or (query_type == 'Date Search')):
-        header = "Empty query"
-        text = "You need to choose a query type and fill the search bar"
-        return {'flag': False, 'header': header, 'text': text}
-
-    # bad objectId
-    bad_objectid = (query_type == 'objectId') and not (query.startswith('ZTF'))
-    if bad_objectid:
-        header = "Bad ZTF object ID"
-        text = "ZTF object ID must start with `ZTF`"
-        return {'flag': False, 'header': header, 'text': text}
-
-    # bad conesearch
-    bad_conesearch = (query_type == 'Conesearch') and not ((len(query.split(',')) == 3) or (len(query.split(',')) == 5))
-    if bad_conesearch:
-        header = "Bad Conesearch formula"
-        text = "Conesearch must contain comma-separated RA, Dec, radius or RA, Dec, radius, startdate, window. See Help for more information."
-        return {'flag': False, 'header': header, 'text': text}
-
-    # bad search date
-    if query_type == 'Date Search':
-        try:
-            _ = isoify_time(query)
-        except (ValueError, TypeError) as e:
-            header = 'Bad start time'
-            return {'flag': False, 'header': header, 'text': str(e)}
-
-    return {'flag': True, 'header': 'Good query', 'text': 'Well done'}
-
 def extract_row(key: str, clientresult) -> dict:
     """ Extract one row from the client result, and return result as dict
     """
@@ -644,88 +601,6 @@ def extract_parameter_value_from_url(param_dic, key, default):
     else:
         val = default
     return val
-
-def extract_query_url(search: str):
-    """ try to infer the query from an URL
-
-    Parameters
-    ----------
-    search: str
-        String returned by `dcc.Location.search` property.
-        Typically starts with ?
-
-    Returns
-    ----------
-    query: str
-        The query formed by the args in the URL
-    query_type: str
-        The type of query (objectID, SSO, Conesearch, etc.)
-    dropdown_option: str
-        Parameter value used in `Date` or `Class` search.
-    """
-    # remove trailing ?
-    search = search[1:]
-
-    # split parameters
-    parameters = search.split('&')
-
-    # Make a dictionary with the parameter keys and values
-    param_dic = {s.split('=')[0]: s.split('=')[1] for s in parameters}
-
-    # if the user forgot to specify the query type
-    if 'query_type' not in param_dic:
-        return return_empty_query()
-
-    query_type = param_dic['query_type']
-
-    if query_type == 'objectId':
-        query = extract_parameter_value_from_url(param_dic, 'objectId', None)
-        dropdown_option = None
-    elif query_type == 'Conesearch':
-        ra = extract_parameter_value_from_url(param_dic, 'ra', '')
-        dec = extract_parameter_value_from_url(param_dic, 'dec', '')
-        radius = extract_parameter_value_from_url(param_dic, 'radius', '')
-        startdate = extract_parameter_value_from_url(
-            param_dic, 'startdate_conesearch', ''
-        )
-        window = extract_parameter_value_from_url(
-            param_dic, 'window_days_conesearch', ''
-        )
-
-        query = '{}, {}, {}'.format(ra, dec, radius)
-
-        if startdate != '' and window != '':
-            query += ', {}, {}'.format(startdate.replace('%20', ' '), window)
-
-        dropdown_option = None
-
-    elif query_type == 'Date%20Search':
-        startdate = extract_parameter_value_from_url(param_dic, 'startdate', '')
-        window = extract_parameter_value_from_url(param_dic, 'window', '')
-
-        query = '{}'.format(startdate.replace('%20', ' '))
-        dropdown_option = window
-
-    elif query_type == 'Class%20Search':
-        # This one is weird. The Class search has 4 parameters: class, n,
-        # startdate, stopdate.
-        # But from the webpage, the user can only select the class. The other
-        # parameters are fixed (n=100, startdate=2019, stopdate=now).
-        # Of course using the API, one can do whatever, but using the
-        # webpage (or URL query), one can only change the class... to be fixed
-        class_ = extract_parameter_value_from_url(param_dic, 'class', '')
-
-        query = class_.replace('%20', ' ')
-
-        dropdown_option = class_.replace('%20', ' ')
-
-    elif query_type == 'SSO':
-        n_or_d = extract_parameter_value_from_url(param_dic, 'n_or_d', '')
-
-        query = n_or_d.replace('%20', ' ')
-        dropdown_option = None
-
-    return query, query_type.replace('%20', ' '), dropdown_option
 
 def is_float(s: str) -> bool:
     """ Check if s can be transformed as a float

--- a/assets/home.css
+++ b/assets/home.css
@@ -49,19 +49,6 @@ html, body {
   clip-path: none;
 }
 
-.nozoom {
-  padding: 2px;
-  transition: transform .2s; /* Animation */
-  margin: 0 auto;
-}
-
-.nozoom:hover {
-  transform: scale(1.0); /* (150% zoom - Note: if the zoom is too large, it will go outside of the viewport) */
-  -ms-transform: scale(1.0); /* IE 9 */
-  -webkit-transform: scale(1.0); /* Safari 3-8 */
-  clip-path: none;
-}
-
 .home {
   overflow: auto;
   position:absolute;
@@ -71,20 +58,6 @@ html, body {
   left:0;
   bottom: 0;
   right: 0;
-}
-
-.finknav {
-    width: 100%;
-    height: 50px;
-    text-align: center;
-}
-
-.Absolute-Center {
-  height: 80%;
-  position: absolute;
-  margin: auto;
-  top: 0; left: 0; bottom: 0; right: 0;
-  vertical-align: middle;
 }
 
 .inputbar:focus {
@@ -97,86 +70,6 @@ html, body {
   border-radius: 25px;
   border: 2px solid black;
   padding: 0px;
-}
-
-.rcorners3 {
-  border-radius: 25px;
-  border: 0px solid grey;
-  padding: 0px;
-  /* other CSS styles */
-
-  /* round the corners */
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 25px;
-
-
-  /* make it glow! */
-  -webkit-box-shadow: 0px 0px 4px #F5622E;
-  -moz-box-shadow: 0px 0px 2px #F5622E;
-  box-shadow: 0px 0px 4px #F5622E;
-}
-
-.rcorners4 {
-  border-radius: 25px;
-  border: 0px solid grey;
-  padding: 0px;
-  outline:none;
-  /* other CSS styles */
-
-  /* round the corners */
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 25px;
-
-
-  /* make it glow! */
-  -webkit-box-shadow: 0px 0px 2px #15284F;
-  -moz-box-shadow: 0px 0px 2px #15284F;
-  box-shadow: 0px 0px 4px #15284F;
-}
-
-.buttonbar {
-    border: 0px black solid;
-    background: #ffffff00;
-    color: grey;
-}
-
-input[type="search"] {
-  border: 1px solid gray;
-  padding: .2em .4em;
-  padding-left: 25px;
-  border-radius: .2em;
-}
-
-input[type="search"].dark {
-  background: #222;
-  color: #fff;
-}
-
-input[type="search"].light {
-  background: #fff;
-  color: #222;
-}
-
-input[type="search"]::-webkit-search-cancel-button {
-  -webkit-appearance: none;
-  height: 1em;
-  width: 1em;
-  border-radius: 50em;
-  background: url(https://pro.fontawesome.com/releases/v5.10.0/svgs/light/times.svg) no-repeat 50% 50%;
-  background-size: contain;
-  opacity: 0.5;
-  pointer-events: all;
-}
-
-input[type="search"]:focus::-webkit-search-cancel-button {
-  opacity: 0.5;
-  pointer-events: all;
-}
-
-input[type="search"].dark::-webkit-search-cancel-button {
-  filter: invert(1);
 }
 
 img[alt=logoexp] { width: 200px; horizontal-align: middle; display: block; margin: auto;}

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -33,6 +33,13 @@ h2 {
 }
 
 /* Quasi-generic backgrounds, meant to be used in wrapper divs to override parent colors of the whole page */
+.bg-opaque-100 {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(var(--bgColorTriplet), 1.0)
+}
+
 .bg-opaque-90 {
   width: 100%;
   height: 100%;

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -56,21 +56,6 @@ h2 {
   background-color: rgba(var(--bgColorTriplet), 0.3)
 }
 
-/* Quickview modal */
-#modal_quickview .modal-content {
-  /* background: rgba(255, 255, 255, .9); */
-}
-
-#modal_quickview .modal-body {
-  /* background: #000; */
-  /* background-image: linear-gradient(rgba(0,0,0,0.3), rgba(255,255,255,0.3)), url(/assets/background.png); */
-}
-
-#modal_quickview .card {
-  /* background: #000; */
-  /* background-image: linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0.9)), url(/assets/background.png); */
-}
-
 #navbar {
   background-image: linear-gradient(rgba(255,255,255,0.3), rgba(255,255,255,0.3)), url(/assets/background.png);
   background-size: cover;
@@ -79,23 +64,16 @@ h2 {
 /* Main search bar */
 #search_bar {
   border: 0.5px grey solid;
-  background: rgba(255, 255, 255, .75);
+  background: rgba(255, 255, 255, 1.0);
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 #search_bar_input {
-  border: 0px black solid;
-  background: rgba(255, 255, 255, 0.0);
-  color: grey;
 }
 
-/* Help modal */
-#open {
-  border: 0px black solid;
-  background: rgba(255, 255, 255, 0.0);
-  color: grey;
-}
-
-#modal {
+#search_bar_suggestions .list-group-item {
+  background: rgba(248, 248, 248, 1);
 }
 
 /* Cards */

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -77,10 +77,14 @@ h2 {
 }
 
 #search_bar_input {
+  margin-left: 25px;
+  padding: 0;
 }
 
 #search_bar_suggestions .list-group-item {
   background: rgba(248, 248, 248, 1);
+  border-radius: 0 0 25px 25px;
+  border-bottom: 2px solid black;
 }
 
 /* Cards */

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -77,7 +77,7 @@ h2 {
 }
 
 #search_bar_input {
-  margin-left: 25px;
+  /* margin-left: 25px; */
   padding: 0;
 }
 

--- a/index.py
+++ b/index.py
@@ -544,46 +544,13 @@ def display_table_results(table):
     )
     switch_tracklet_description = "Toggle the switch to list each Tracklet only once (fast moving objects). Only the latest alert will be displayed."
 
-    return [
+    results = [
         dbc.Row(
             [
                 dbc.Col(
                     dropdown,
                     lg=5, md=6
                 ),
-                dbc.Col(
-                    dbc.Row(
-                        [
-                            dbc.Col(
-                                modal_skymap(),
-                                md='auto'
-                            ),
-                            dbc.Col(
-                                help_popover(
-                                    dcc.Markdown(msg_info),
-                                    id='help_msg_info',
-                                    trigger=dmc.ActionIcon(
-                                        DashIconify(icon="mdi:help"),
-                                        id='help_msg_info',
-                                        color='gray',
-                                        variant="default",
-                                        radius='xl',
-                                        size='lg',
-                                    ),
-                                ),
-                                md='auto'
-                            ),
-                        ],
-                        align='center', justify='end',
-                    ),
-                    md='auto',
-                )
-            ],
-            align='center', justify='between',
-            className='pt-1 pb-1 ps-2 pe-2'
-        ),
-        dbc.Row(
-            [
                 dbc.Col(
                     dmc.Tooltip(
                         children=switch,
@@ -621,10 +588,17 @@ def display_table_results(table):
                     md='auto'
                 ),
             ],
-            align='center', justify='start',
-            className='pt-1 pb-1 ps-2 pe-2',
+            align='end', justify='start',
+            className='mb-2',
         ),
         table
+    ]
+
+    return [
+        html.Div(
+            results,
+            className='results-inner bg-opaque-100 rounded mb-4 p-2 border shadow',
+        )
     ]
 
 @app.callback(
@@ -792,34 +766,6 @@ clientside_callback(
     [State("modal_skymap", "is_open")],
     prevent_initial_call=True,
 )
-
-# @app.callback(
-#     Output("modal_skymap", "is_open"),
-#     [
-#         Input("open_modal_skymap", "n_clicks"),
-#         Input("close_modal_skymap", "n_clicks")
-#     ],
-#     [State("modal_skymap", "is_open")],
-# )
-# def toggle_modal_preview(n1, n2, is_open):
-#     if n1 or n2:
-#         return not is_open
-#     return is_open
-
-def construct_results_layout(table, msg):
-    """ Construct the tabs containing explorer query results
-    """
-    results_ = html.Div(
-        className='bg-opaque-100 mb-2 shadow-sm border rounded-3',
-        children=[
-            html.P(
-                msg,
-                className='p-3 m-0'
-            ),
-        ] + display_table_results(table)
-    )
-
-    return results_
 
 def populate_result_table(data, columns):
     """ Define options of the results table, and add data and columns
@@ -1139,28 +1085,55 @@ def results(n_submit, n_clicks, searchurl, value, show_table):
             ]
 
             table = populate_result_table(data, columns)
-            results = construct_results_layout(table, msg)
+            results_ = display_table_results(table)
         else:
-            results = construct_results_list(pdf, msg)
+            results_ = display_cards_results(pdf)
+
+        results = [
+            # Common header for the results
+            dbc.Row(
+                [
+                    dbc.Col(
+                        msg,
+                        md='auto'
+                    ),
+                    dbc.Col(
+                        dbc.Row(
+                            [
+                                dbc.Col(
+                                    modal_skymap(),
+                                    xs='auto'
+                                ),
+                                dbc.Col(
+                                    help_popover(
+                                        dcc.Markdown(msg_info),
+                                        id='help_msg_info',
+                                        trigger=dmc.ActionIcon(
+                                            DashIconify(icon="mdi:help"),
+                                            id='help_msg_info',
+                                            color='gray',
+                                            variant="default",
+                                            radius='xl',
+                                            size='lg',
+                                        ),
+                                    ),
+                                    xs='auto'
+                                ),
+                            ],
+                            justify='end'
+                        ),
+                        md='auto'
+                    )
+                ],
+                align='end', justify='between',
+                className='m-2'
+            ),
+        ] + results_
 
         return results, False, no_update
 
-def construct_results_list(pdf, msg, page_size=10):
+def display_cards_results(pdf, page_size=10):
     results_ = [
-        dbc.Row(
-            [
-                dbc.Col(
-                    msg,
-                    md='auto'
-                ),
-                dbc.Col(
-                    modal_skymap(),
-                    md='auto'
-                ),
-            ],
-            align='end', justify='between',
-            className='m-2 ms-4 me-4'
-        ),
         # Data storage
         dcc.Store(
             id='results_store',
@@ -1595,7 +1568,7 @@ def display_page(pathname, searchurl):
                 ], fluid="lg"
             ),
             dbc.Container(id='results', fluid="xxl")
-        ],
+        ]
     )
     if pathname == '/about':
         return about.layout

--- a/index.py
+++ b/index.py
@@ -186,12 +186,17 @@ fink_search_bar = [
             [
                 html.Span('Quick fields:', className='text-secondary'),
             ] + [
-                html.A(
-                    __[0],
-                    title=__[1],
-                    id={'type': 'search_bar_quick_field', 'index': _},
-                    n_clicks=0,
-                    className='ms-2 link text-decoration-none'
+                html.Span(
+                    [
+                        html.A(
+                            __[0],
+                            title=__[1],
+                            id={'type': 'search_bar_quick_field', 'index': _},
+                            n_clicks=0,
+                            className='ms-2 link text-decoration-none'
+                        ),
+                        " "
+                    ]
                 ) for _,__ in enumerate(quick_fields)
             ],
             className="ps-2 pe-2 mb-0 mt-1"
@@ -1558,7 +1563,8 @@ def display_page(pathname):
                                     html.Img(
                                         src="/assets/Fink_PrimaryLogo_WEB.png",
                                         height='100%',
-                                        width='40%'
+                                        width='40%',
+                                        style={'min-width': '250px'},
                                     )
                                 ), style={'textAlign': 'center'}, className="mt-3",
                             ),

--- a/index.py
+++ b/index.py
@@ -1411,9 +1411,10 @@ def on_load_lightcurve(lc_id):
             figure=fig,
             config={'displayModeBar': False},
             style={
-                'max-width': '100%',
+                'width': '100%',
                 'height': '15pc'
             },
+            responsive=True
         )
 
     return no_update

--- a/index.py
+++ b/index.py
@@ -1562,7 +1562,7 @@ def display_page(pathname):
                                     )
                                 ), style={'textAlign': 'center'}, className="mt-3",
                             ),
-                            query="(max-height: 400px) or (max-width: 500px)",
+                            query="(max-height: 400px) or (max-width: 300px)",
                             styles={'display': 'none'},
                         ), is_open=True, id='logo',
                     ),

--- a/index.py
+++ b/index.py
@@ -203,7 +203,8 @@ fink_search_bar = [
         ),
 
 ] + [html.Div(
-    className='p-0 m-0 border shadow-sm rounded-3',
+    # className='p-0 m-0 border shadow-sm rounded-3',
+    className='p-0 m-0 rcorners2 shadow-sm',
     id="search_bar",
     # className='rcorners2',
     children=[

--- a/index.py
+++ b/index.py
@@ -77,86 +77,81 @@ fink_classes = [
 ]
 
 message_help = """
-##### Object ID
+You may search for different kinds of data depending on what you enter. Below you will find the description of syntax rules and some examples.
 
-Enter a valid object ID to access its data, e.g. try:
+The search is defined by the set of search terms (object names or coordinates) and options (e.g. search radius, number of returned entries, etc). The latters may be entered either manually or by using the `Quick fields` above the search bar. Supported formats for the options are both `name=value` and `name:value`, where `name` is case-insensitive, and `value` may use quotes to represent multi-word sentences. For some of the options, interactive drop-down menu will be shown with possible values.
 
-* ZTF21abfmbix, ZTF21aaxtctv, ZTF21abfaohe, ZTF20aanxcpf, ZTF17aaaabte, ZTF18aafpcwm, ZTF21abujbqa, ZTF21abuipwb, ZTF18acuajcr
+The search bar has a button (on the left) to show you the list of your latest search queries so that you may re-use them, and a switch (on the right, right above the search field) to choose the format of results - either card-based (default, shows the previews of object latest cutout and light curve), or tabular (allows to see all the fields of objects).
 
-##### Conesearch
+##### Search for specific ZTF objects
 
-Perform a conesearch around a position on the sky given by (RA, Dec, radius).
-The initializer for RA/Dec is very flexible and supports inputs provided in a number of convenient formats.
-The following ways of initializing a conesearch are all equivalent (radius in arcsecond):
+To search for specific object, just use its name, or just a part of it. In the latter case, all objects with the names starting with this pattern will be returned.
 
-* 193.822, 2.89732, 5
-* 193d49m18.267s, 2d53m50.35s, 5
-* 12h55m17.218s, +02d53m50.35s, 5
-* 12 55 17.218, +02 53 50.35, 5
-* 12:55:17.218, 02:53:50.35, 5
+Supported name patterns are as follows:
+- `ZTFyyccccccc` for ZTF objects, i.e. ZTF followed with 2 digits for the year, and 7 characters after that
+- `TRCK_YYYYMMDD_HHMMSS_NN` for tracklets detected at specific moment of time
 
-Maximum radius length is 18,000 arcseconds (5 degrees). Note that in case of
-several objects matching, the results will be sorted according to the angular
-separation in degree between the input (ra, dec) and the objects found.
+Examples:
+- `ZTF21abfmbix` - search for exact ZTF object
+- `ZTF21abfmb` - search for partially matched ZTF object name
+- `TRCK_20231213_133612_00` - search for all objects associated with specific tracklet
+- `TRCK_20231213` - search for all tracklet events from the night of Dec 13, 2023
 
-In addition, you can specify a starting date (UTC) and a window (in days) to refine your search.
-Example, to refine your search starting at 2021-06-25 05:59:37.000 for 7 days:
+##### Cone search
 
-* 193.822, 2.89732, 5, 2021-06-25 05:59:37.000, 7
-* 193.822, 2.89732, 5, 2459391.7497338, 7
+If you specify the position and search radius (using `r` option), all objects inside the given cone will be returned. Position may be specified by either coordinates, in either decimal or sexagesimal form, as exact ZTF object name, or as an object name resolvable through TNS or Simbad.
 
-We encourage you to use the `startdate` and `window`, as your query will run much faster.
+The coordinates may be specified as:
+- Pair of degrees
+- `HH MM SS.S [+-]?DD MM SS.S`
+- `HH:MM:SS.S [+-]?DD:MM:SS.S`
+- `HHhMMhSS.Ss [+-]?DDhMMhSS.Ss`
+- optionally, you may use one more number as a radius, in either arcseconds, minutes (suffixed with `m`) or degrees (`d`). If specified, you do not need to provide the corresponding keyword (`r`) separately
 
-##### Date search
+If the radius is not specified, but the coordinates or resolvable object names are given, the default search radius is 10 arcseconds.
 
-Choose a starting date and a time window to see all processed alerts in this period.
-Dates are in UTC, and the time window in minutes.
-Among several, you can choose YYYY-MM-DD hh:mm:ss, Julian Date, or Modified Julian Date. Example of valid search:
+Examples:
+- `10 20 30` - search within 30 arcseconds around
+- `10 22 31 40 50 55.5` - search within 10 arcseconds around `RA=10:22:31` `Dec=+40:50:55.5`
+- `Vega r=10m` - search within 600 arcseconds (10 arcminutes) from Vega
+- `ZTF21abfmbix r=20` - search within 20 arcseconds around the position of ZTF21abfmbix
+- `AT2021cow` or `AT 2021cow` - search within 10 arcseconds around the position of AT2021cow
 
-* 2021-07-01 05:59:37.000
-* 2459396.7497337963
-* 59396.2497337963
+##### Solar System objects
 
-##### Class
+To search for all ZTF objects associated with specific SSO, you may either directly specify `sso` keyword, which should be equal to contents of `i:ssnamenr` field of ZTF packets, or just enter the number or name of the SSO object that the system will try to resolve.
 
-Choose a class of interest using the drop-down menu to see the 100 latest alerts processed by Fink.
+So you may e.g. search for:
+- Asteroids by proper name
+  - `Vesta`
+- Asteroids by number
+  - Asteroids (Main Belt): `8467`, `1922`
+  - Asteroids (Hungarians): `18582`, `77799`
+  - Asteroids (Jupiter Trojans): `4501, `1583`
+  - Asteroids (Mars Crossers): `302530`
+- Asteroids by designation
+  - `2010JO69`, `2017AD19`, `2012XK111`
+- Comets by number
+  - `10P, `249P`, `124P`
+- Comets by designation
+  - `C/2020V2`, `C/2020R2`
 
-##### Solar System Objects (SSO)
+##### Latest objects
 
-Search for Solar System Objects in the Fink database.
-The numbers or designations are taken from the MPC archive.
-When searching for a particular asteroid or comet, it is best to use the IAU number,
-as in 8467 for asteroid "8467 Benoitcarry". You can also try for numbered comet (e.g. 10P),
-or interstellar object (none so far...). If the number does not yet exist, you can search for designation.
-Here are some examples of valid queries:
+To see the latest objects just specify the amount of them you want to get using keyword `last`.
 
-* Asteroids by number (default)
-  * Asteroids (Main Belt): 8467, 1922
-  * Asteroids (Hungarians): 18582, 77799
-  * Asteroids (Jupiter Trojans): 4501, 1583
-  * Asteroids (Mars Crossers): 302530
-* Asteroids by designation (if number does not exist yet)
-  * 2010JO69, 2017AD19, 2012XK111
-* Comets by number (default)
-  * 10P, 249P, 124P
-* Comets by designation (if number does no exist yet)
-  * C/2020V2, C/2020R2
+##### Class-based search
 
-Note for designation, you can also use space (2010 JO69 or C/2020 V2).
+To see the list of latest objects of specific class (as listed in `v:classification` alert field), just specify the `class` keyword. By default it will return 100 latest ones, but you may also directly specify `last` keywords to alter it.
 
+You may also specify the time interval to refine the search, using the self-explanatory keywords `before` and `after`. The limits may be specified with either time string, JD or MJD values. You may either set both limiting values, or just one of them. The results will be sorted in descending order by time, and limited to specified number of entries.
 
-##### Tracklet data
+Examples:
+- `last=100` or `class=allclasses` - return 100 latest objects of any class
+- `class=Unknown` - return 100 latest objects with class `Unknown`
+- `last=10 class="Early SN Ia candidate"` - return 10 latest arly SN Ia candidates
+- `class="Early SN Ia candidate" before="2023-12-01" after="2023-11-15 04:00:00"` - objects of the same class between 4am on Nov 15, 2023 and Dec 1, 2023
 
-Search for Tracklet Objects in the Fink database. Tracklets are fast
-moving objects, typically orbiting around the Earth. They are most likely
-produced by satellite glints or space debris.
-
-You have the choice to specify the date in the format `YYYY-MM-DD hh:mm:ss` or
-any short versions such as `YYY-MM-DD` or `YYYY-MM-DD hh`. E.g. try:
-
-- 2020-08-10
-- 2021-10-22 09:19
-- 2020-07-16 04:58:48
 """
 
 msg_info = """
@@ -242,6 +237,7 @@ fink_search_bar = [
                                 variant="transparent",
                                 radius='xl',
                                 size='lg',
+                                title='Search history'
                             )
                         ),
                         dmc.MenuDropdown(

--- a/index.py
+++ b/index.py
@@ -597,6 +597,7 @@ def display_table_results(table):
     """
     r = request_api(
         '/api/v1/columns',
+        method='GET'
         )
     pdf = pd.read_json(r)
 

--- a/index.py
+++ b/index.py
@@ -199,7 +199,7 @@ fink_search_bar = [
                     ]
                 ) for _,__ in enumerate(quick_fields)
             ],
-            className="ps-2 pe-2 mb-0 mt-1"
+            className="ps-4 pe-2 mb-0 mt-1"
         ),
 
 ] + [html.Div(
@@ -338,19 +338,33 @@ def update_suggestions(n_intervals, n_submit, n_clicks, value):
     content = []
 
     if query['completions']:
+        completions = []
+
+        for i,item in enumerate(query['completions']):
+            if isinstance(item, list) or isinstance(item, tuple):
+                # We expect it to be (name, ext)
+                name = item[0]
+                ext = item[1]
+            else:
+                name = item
+                ext = item
+
+            completions.append(
+                html.A(
+                    ext,
+                    id={'type': 'search_bar_completion', 'index': i},
+                    title=name,
+                    n_clicks=0,
+                    className='ms-2 link text-decoration-none'
+                )
+            )
+
         content += [
             html.Div(
                 [
                     html.Span('Did you mean:', className='text-secondary'),
-                ] + [
-                    html.A(
-                        __,
-                        id={'type': 'search_bar_completion', 'index': _},
-                        n_clicks=0,
-                        className='ms-2 link text-decoration-none'
-                    ) for _,__ in enumerate(query['completions'])
-                ],
-                className="border-bottom p-1 mb-1 mt-1"
+                ] + completions,
+                className="border-bottom p-1 mb-1 mt-1 small"
             )
         ]
 
@@ -383,7 +397,7 @@ def update_suggestions(n_intervals, n_submit, n_clicks, value):
 @app.callback(
     Output('search_bar_input', 'value'),
     Input({'type': 'search_bar_completion', 'index': ALL}, 'n_clicks'),
-    State({'type': 'search_bar_completion', 'index': ALL}, 'children'),
+    State({'type': 'search_bar_completion', 'index': ALL}, 'title'),
     prevent_initial_call=True
 )
 def on_completion(n_clicks, values):
@@ -1134,11 +1148,11 @@ def results(n_submit, n_clicks, searchurl, value):
 
     elif query['action'] == 'sso':
         # Solar System Objects
-        msg = "Solar System object search with ID {}".format(query['object'])
+        msg = "Solar System object search with ssnamenr {}".format(query['params']['sso'])
         r = requests.post(
             '{}/api/v1/sso'.format(APIURL),
             json={
-                'n_or_d': query['object'].replace(' ', '')
+                'n_or_d': query['params']['sso']
             }
         )
 

--- a/index.py
+++ b/index.py
@@ -1226,7 +1226,7 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
         )
 
     elif query['action'] == 'random':
-        n_random = int(query['params'].get('random', 100))
+        n_random = int(query['params'].get('random', 10))
 
         msg = "Random {} objects".format(n_random)
 
@@ -1270,6 +1270,10 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
 
     # Format output in a DataFrame
     pdf = pd.read_json(r.content)
+
+    if query['action'] == 'random':
+        # Keep only latest alert from all objects
+        pdf = pdf.loc[pdf.groupby('i:objectId')['i:jd'].idxmax()]
 
     msg = "{} - {} found".format(msg, 'nothing' if pdf.empty else str(len(pdf.index)) + ' objects')
 

--- a/index.py
+++ b/index.py
@@ -159,7 +159,9 @@ any short versions such as `YYY-MM-DD` or `YYYY-MM-DD hh`. E.g. try:
 """
 
 msg_info = """
-By default, the table shows:
+The `Card view` shows the cutout from science image, some basic alert info, and its light curve. Its header also displays the badges for alert classification and the distances from several reference catalogs, as listed in the alert.
+
+By default, the `Table view` shows the following fields:
 
 - i:objectId: Unique identifier for this object
 - i:ra: Right Ascension of candidate; J2000 (deg)
@@ -171,11 +173,7 @@ By default, the table shows:
 
 You can also add more columns using the dropdown button above the result table. Full documentation of all available fields can be found at {}/api/v1/columns.
 
-Moreover, you can hit the button `Preview`. This will show you more information
-about the first 10 alerts (science cutout, and basic information). Note you can
-swipe between alerts (or use arrows on a laptop).
-
-Finally, the button `Sky Map` will open a popup with embedded Aladin sky map showing the positions of the search results on the sky.
+The button `Sky Map` will open a popup with embedded Aladin sky map showing the positions of the search results on the sky.
 """.format(APIURL)
 
 # Smart search field
@@ -262,6 +260,7 @@ fink_search_bar = [
                     variant="transparent",
                     radius='xl',
                     size='lg',
+                    title='Clear the input',
                 ),
                 # Submit
                 dbc.Spinner(
@@ -274,6 +273,7 @@ fink_search_bar = [
                         radius='xl',
                         size='lg',
                         loaderProps={'variant': 'dots', 'color': 'orange'},
+                        title='Search'
                     ), size='sm', color='warning'
                 ),
                 # Help popup
@@ -290,6 +290,7 @@ fink_search_bar = [
                         radius='xl',
                         size='lg',
                         # className="d-none d-sm-flex"
+                        title='Show some help',
                     ),
                 ),
             ]

--- a/index.py
+++ b/index.py
@@ -239,9 +239,13 @@ fink_search_bar = [
                     component='input',
                     trigger=[
                         'class:', 'class=',
+                        'last:', 'last=',
+                        'r:', 'r=',
                     ],
                     options={
                         'class:':fink_classes, 'class=':fink_classes,
+                        'last:':['10', '100', '1000'], 'last=':['10', '100', '1000'],
+                        'r:':['10', '60', '10m', '30m'], 'r=':['10', '60', '10m', '30m'],
                     },
                     maxOptions=0,
                     className="inputbar form-control border-0",
@@ -357,7 +361,11 @@ def update_suggestions(n_intervals, n_submit, n_clicks, value):
 
     if query['action'] == 'unknown':
         content = [
-            html.Em('Query not recognized', className='m-0')
+            html.Div(
+                html.Em(
+                    'Query not recognized',
+                    className='m-0')
+            )
         ]
     else:
         content = []

--- a/index.py
+++ b/index.py
@@ -171,10 +171,12 @@ swipe between alerts (or use arrows on a laptop).
 
 # Smart search field
 quick_fields = [
-    ['class', 'Alert class'],
+    ['class', 'Alert class\nSelect one of Fink supported classes from the menu'],
     ['last', 'Number of latest alerts to show'],
-    ['r', 'Radius for cone search'],
-    ['after', 'Lower timit on alert time'],
+    ['r', 'Radius for cone search\nIn arcseconds by default, use `r=1m` or `r=2d` for arcminutes or degrees, correspondingly'],
+    # ['before', 'Upper timit on alert time\nISO time, MJD or JD'],
+    ['after', 'Lower timit on alert time\nISO time, MJD or JD'],
+    ['window', 'Time window length\nDays']
 ]
 
 fink_search_bar = [
@@ -190,7 +192,7 @@ fink_search_bar = [
                     className='ms-2 link text-decoration-none'
                 ) for _,__ in enumerate(quick_fields)
             ],
-            className="p-1 mb-1 mt-1"
+            className="ps-2 pe-2 mb-0 mt-1"
         ),
 
 ] + [html.Div(
@@ -1139,15 +1141,24 @@ def results(n_submit, n_clicks, value):
 
         msg = "Cone search with center at {:.4f} {:.3f} and radius {:.1f} arcsec".format(ra, dec, sr)
 
+        payload = {
+            'ra': ra,
+            'dec': dec,
+            'radius': sr,
+        }
+
+        if 'after' in query['params']:
+            startdate = isoify_time(query['params']['after'])
+            window = float(query['params'].get('window', 1.0))
+
+            msg += ' within {} days after {}'.format(window, startdate)
+
+            payload['startdate_conesearch'] = startdate
+            payload['window_days_conesearch'] = window
+
         r = requests.post(
             '{}/api/v1/explorer'.format(APIURL),
-            json={
-                'ra': ra,
-                'dec': dec,
-                'radius': sr
-                # 'startdate_conesearch': startdate,
-                # 'window_days_conesearch': window
-            }
+            json=payload
         )
 
         colnames_to_display = {

--- a/index.py
+++ b/index.py
@@ -1409,6 +1409,19 @@ def on_paginate(page, data, page_size):
 
     return results
 
+# Scroll to top on paginate
+clientside_callback(
+    """
+    function scroll_top(value) {
+        document.querySelector('#search_bar').scrollIntoView({behavior: "smooth"})
+        return dash_clientside.no_update;
+    }
+    """,
+    Output('results_pagination', 'page'), # Fake output!!!
+    Input('results_pagination', 'page'),
+    prevent_initial_call=True,
+)
+
 @app.callback(
     Output({'type': 'search_results_lightcurve', 'objectId': MATCH, 'index': MATCH}, 'children'),
     Input({'type': 'search_results_lightcurve', 'objectId': MATCH, 'index': MATCH}, 'id')

--- a/index.py
+++ b/index.py
@@ -251,8 +251,19 @@ fink_search_bar = [
                     className="inputbar form-control border-0",
                     quoteWhitespaces=True,
                     autoFocus=True,
+                    ignoreCase=True,
                 ),
-
+                # Clear
+                dmc.ActionIcon(
+                    DashIconify(icon="mdi:clear-bold"),
+                    n_clicks=0,
+                    id="search_bar_clear",
+                    color='gray',
+                    variant="transparent",
+                    radius='xl',
+                    size='lg',
+                ),
+                # Submit
                 dbc.Spinner(
                     dmc.ActionIcon(
                         DashIconify(icon="tabler:search", width=20),
@@ -265,7 +276,7 @@ fink_search_bar = [
                         loaderProps={'variant': 'dots', 'color': 'orange'},
                     ), size='sm', color='warning'
                 ),
-                # modal
+                # Help popup
                 help_popover(
                     [
                         dcc.Markdown(message_help)
@@ -473,6 +484,18 @@ def on_quickfield(n_clicks, values, value):
         return value + ' ' + values[ctx.triggered_id['index']] + '='
 
     return no_update
+
+# Clear inpit field
+clientside_callback(
+    """
+    function on_clear(n_clicks) {
+        return '';
+    }
+    """,
+    Output('search_bar_input', 'value', allow_duplicate=True),
+    Input('search_bar_clear', 'n_clicks'),
+    prevent_initial_call=True
+)
 
 def display_table_results(table):
     """ Display explorer results in the form of a table with a dropdown

--- a/index.py
+++ b/index.py
@@ -226,12 +226,35 @@ fink_search_bar = [
 
 ] + [html.Div(
     # className='p-0 m-0 border shadow-sm rounded-3',
-    className='p-0 m-0 rcorners2 shadow',
+    className='pt-0 pb-0 ps-1 pe-1 m-0 rcorners2 shadow',
     id="search_bar",
     # className='rcorners2',
     children=[
         dbc.InputGroup(
             [
+                # History
+                dmc.Menu(
+                    [
+                        dmc.MenuTarget(
+                            dmc.ActionIcon(
+                                DashIconify(icon="bi:clock-history"),
+                                color='gray',
+                                variant="transparent",
+                                radius='xl',
+                                size='lg',
+                            )
+                        ),
+                        dmc.MenuDropdown(
+                            [
+                                dmc.MenuLabel("Search history is empty"),
+                            ],
+                            className='shadow',
+                            id='search_history_menu'
+                        )
+                    ],
+                    zIndex=1000000,
+                ),
+                # Main input
                 AutocompleteInput(
                     id='search_bar_input',
                     placeholder='Search, and you will find',
@@ -345,37 +368,22 @@ clientside_callback(
 
 # Search history
 @app.callback(
-    Output('search_history', 'children'),
+    Output('search_history_menu', 'children'),
     Input('search_history_store', 'timestamp'),
-    State('search_history_store', 'data'),
+    Input('search_history_store', 'data'),
 )
-def display_search_history(timestamp, history):
-    # Render history
-    content = []
-
+def update_search_history_menu(timestamp, history):
     if history:
-        for i,item in enumerate(history):
-            content.append(
-                html.A(
-                    item,
-                    id={'type': 'search_bar_completion', 'index': 1000 + i, 'text': item},
-                    n_clicks=0,
-                    className='ms-2 link text-decoration-none'
-                )
-            )
+        return [
+            dmc.MenuLabel("Search history"),
+        ] + [
+            dmc.MenuItem(
+                item,
+                id={'type': 'search_bar_completion', 'index': 1000 + i, 'text': item},
+            ) for i,item in enumerate(history)
+        ]
     else:
         return no_update
-
-    return [
-        html.Ul(
-            [
-                html.Li('Search history')
-            ] + [
-                html.Li(_) for _ in content
-            ],
-            className='list-unstyled text-secondary'
-        )
-    ]
 
 # Update suggestions on (debounced) input
 @app.callback(
@@ -487,7 +495,7 @@ def on_completion(n_clicks):
     ctx = dash.callback_context
 
     if ctx.triggered[0]['value']:
-        return ctx.triggered_id['text']
+        return ctx.triggered_id['text'] + ' '
 
     return no_update
 

--- a/index.py
+++ b/index.py
@@ -176,6 +176,7 @@ quick_fields = [
     ['r', 'Radius for cone search\nIn arcseconds by default, use `r=1m` or `r=2d` for arcminutes or degrees, correspondingly'],
     # ['before', 'Upper timit on alert time\nISO time, MJD or JD'],
     ['after', 'Lower timit on alert time\nISO time, MJD or JD'],
+    ['before', 'Upper timit on alert time\nISO time, MJD or JD'],
     ['window', 'Time window length\nDays']
 ]
 
@@ -1179,12 +1180,28 @@ def results(n_submit, n_clicks, value):
 
         msg = "Last {} objects with class '{}'".format(n_last, alert_class)
 
+        payload = {
+            'class': alert_class,
+            'n': n_last
+        }
+
+        if 'after' in query['params']:
+            startdate = isoify_time(query['params']['after'])
+
+            msg += ' after {}'.format(startdate)
+
+            payload['startdate'] = startdate
+
+        if 'before' in query['params']:
+            stopdate = isoify_time(query['params']['before'])
+
+            msg += ' before {}'.format(stopdate)
+
+            payload['stopdate'] = stopdate
+
         r = requests.post(
             '{}/api/v1/latests'.format(APIURL),
-            json={
-                'class': alert_class,
-                'n': n_last
-            }
+            json=payload
         )
 
     else:

--- a/index.py
+++ b/index.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import dash
-from dash import html, dcc, Input, Output, State, dash_table, no_update
+from dash import html, dcc, Input, Output, State, dash_table, no_update, clientside_callback
 from dash.exceptions import PreventUpdate
 
 import dash_bootstrap_components as dbc
@@ -171,18 +171,19 @@ modal = html.Div(
     ]
 )
 
-@app.callback(
+clientside_callback(
+    """
+    function toggle_modal(n1, is_open) {
+        if (n1)
+            return !is_open;
+        else
+            return dash_clientside.no_update;
+    }
+    """,
     Output("modal", "is_open"),
     [Input("open", "n_clicks")],
     [State("modal", "is_open")],
 )
-def toggle_modal(n1, is_open):
-    """ Callback for the modal (open/close)
-    """
-    if n1:
-        return not is_open
-    return is_open
-
 
 fink_search_bar = dbc.InputGroup(
     [
@@ -1105,25 +1106,21 @@ def text_noresults(query, query_type, dropdown_option, searchurl):
         )
     return text, header
 
-def create_home_link(label):
-    return dmc.Text(
-        label,
-        size="xl",
-        color="gray",
-    )
-
-@app.callback(
+clientside_callback(
+    """
+    function drawer_switch(n_clicks, pathname) {
+        const triggered = dash_clientside.callback_context.triggered.map(t => t.prop_id);
+        if (triggered == 'drawer-button.n_clicks')
+            return true;
+        else
+            return false;
+    }
+    """,
     Output("drawer", "opened"),
     Input("drawer-button", "n_clicks"),
     Input('url', 'pathname'),
     prevent_initial_call=True,
 )
-def drawer_switch(n_clicks, pathname):
-    ctx = dash.callback_context
-    if ctx.triggered[0]['prop_id'].split('.')[0] == 'drawer-button':
-        return True
-    else:
-        return False
 
 navbar = dmc.Header(
     id='navbar',

--- a/index.py
+++ b/index.py
@@ -1730,9 +1730,10 @@ app.layout = html.Div([
     Output('page-content', 'children'),
     [
         Input('url', 'pathname'),
+        Input('url', 'search'),
     ]
 )
-def display_page(pathname):
+def display_page(pathname, searchurl):
     layout = html.Div(
         [
             dbc.Container(

--- a/index.py
+++ b/index.py
@@ -248,7 +248,7 @@ fink_search_bar = [
                             [
                                 dmc.MenuLabel("Search history is empty"),
                             ],
-                            className='shadow',
+                            className='shadow rounded',
                             id='search_history_menu'
                         )
                     ],
@@ -380,7 +380,7 @@ def update_search_history_menu(timestamp, history):
             dmc.MenuItem(
                 item,
                 id={'type': 'search_bar_completion', 'index': 1000 + i, 'text': item},
-            ) for i,item in enumerate(history)
+            ) for i,item in enumerate(history[::-1])
         ]
     else:
         return no_update

--- a/index.py
+++ b/index.py
@@ -598,7 +598,7 @@ def display_table_results(table):
     r = request_api(
         '/api/v1/columns',
         method='GET'
-        )
+    )
     pdf = pd.read_json(r)
 
     fink_fields = ['d:' + i for i in pdf.loc['Fink science module outputs (d:)']['fields'].keys()]

--- a/index.py
+++ b/index.py
@@ -60,6 +60,7 @@ tns_types = sorted(tns_types, key=lambda s: s.lower())
 
 fink_classes = [
     'All classes',
+    'Anomaly',
     'Unknown',
     # Fink derived classes
     'Early SN Ia candidate',
@@ -1184,6 +1185,35 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
 
         r = requests.post(
             '{}/api/v1/explorer'.format(APIURL),
+            json=payload
+        )
+
+    elif query['action'] == 'anomaly':
+        # Anomaly search
+        n_last = int(query['params'].get('last', 100))
+
+        msg = "Last {} anomalies".format(n_last)
+
+        payload = {
+            'n': n_last
+        }
+
+        if 'after' in query['params']:
+            startdate = isoify_time(query['params']['after'])
+
+            msg += ' after {}'.format(startdate)
+
+            payload['start_date'] = startdate
+
+        if 'before' in query['params']:
+            stopdate = isoify_time(query['params']['before'])
+
+            msg += ' before {}'.format(stopdate)
+
+            payload['stop_date'] = stopdate
+
+        r = requests.post(
+            '{}/api/v1/anomaly'.format(APIURL),
             json=payload
         )
 

--- a/index.py
+++ b/index.py
@@ -173,88 +173,86 @@ about the first 10 alerts (science cutout, and basic information). Note you can
 swipe between alerts (or use arrows on a laptop).
 """.format(APIURL)
 
-fink_search_bar = dbc.Row(
-    dbc.Col(
-        className='p-0 m-0 border border-dark rounded-3',
-        id="search_bar",
-        # className='rcorners2',
-        children=[
-            dbc.InputGroup(
-                [
-                    AutocompleteInput(
-                        id='search_bar_input',
-                        placeholder='Search, and you will find',
-                        component='input',
-                        trigger=[
-                            'class:', 'class=',
-                        ],
-                        options={
-                            'class:':fink_classes, 'class=':fink_classes,
-                        },
-                        maxOptions=0,
-                        className="inputbar form-control border-0",
-                        quoteWhitespaces=True,
-                        regex='^([a-zA-Z0-9_\-()]+|"[a-zA-Z0-9_\- ]*|\'[a-zA-Z0-9_\- ]*)$',
-                        autoFocus=True,
-                    ),
-
-                    dbc.Spinner(
-                        dmc.ActionIcon(
-                            DashIconify(icon="tabler:search", width=20),
-                            n_clicks=0,
-                            id="search_bar_submit",
-                            color='gray',
-                            variant="transparent",
-                            radius='xl',
-                            size='lg',
-                            loaderProps={'variant': 'dots', 'color': 'orange'},
-                            # Hide on screen sizes smaller than sm
-                            className="d-none d-sm-flex"
-                        ), size='sm',
-                    ),
-                    # modal
-                    help_popover(
-                        [
-                            dcc.Markdown(message_help)
-                        ],
-                        'help_search',
-                        trigger=dmc.ActionIcon(
-                            DashIconify(icon="mdi:help"),
-                            id='help_search',
-                            color='gray',
-                            variant="transparent",
-                            radius='xl',
-                            size='lg',
-                            className="d-none d-sm-flex"
-                        ),
-                    ),
-                ]
-            ),
-            # Search suggestions
-            dbc.Collapse(
-                dbc.ListGroup(
-                    id='search_bar_suggestions',
+fink_search_bar = html.Div(
+    className='p-0 m-0 border shadow-sm rounded-3',
+    id="search_bar",
+    # className='rcorners2',
+    children=[
+        dbc.InputGroup(
+            [
+                AutocompleteInput(
+                    id='search_bar_input',
+                    placeholder='Search, and you will find',
+                    component='input',
+                    trigger=[
+                        'class:', 'class=',
+                    ],
+                    options={
+                        'class:':fink_classes, 'class=':fink_classes,
+                    },
+                    maxOptions=0,
+                    className="inputbar form-control border-0",
+                    quoteWhitespaces=True,
+                    regex='^([a-zA-Z0-9_\-()]+|"[a-zA-Z0-9_\- ]*|\'[a-zA-Z0-9_\- ]*)$',
+                    autoFocus=True,
                 ),
-                id='search_bar_suggestions_collapser',
-                is_open=False,
+
+                dbc.Spinner(
+                    dmc.ActionIcon(
+                        DashIconify(icon="tabler:search", width=20),
+                        n_clicks=0,
+                        id="search_bar_submit",
+                        color='gray',
+                        variant="transparent",
+                        radius='xl',
+                        size='lg',
+                        loaderProps={'variant': 'dots', 'color': 'orange'},
+                        # Hide on screen sizes smaller than sm
+                        # className="d-none d-sm-flex"
+                    ), size='sm', color='warning'
+                ),
+                # modal
+                help_popover(
+                    [
+                        dcc.Markdown(message_help)
+                    ],
+                    'help_search',
+                    trigger=dmc.ActionIcon(
+                        DashIconify(icon="mdi:help"),
+                        id='help_search',
+                        color='gray',
+                        variant="transparent",
+                        radius='xl',
+                        size='lg',
+                        # className="d-none d-sm-flex"
+                    ),
+                ),
+            ]
+        ),
+        # Search suggestions
+        dbc.Collapse(
+            dbc.ListGroup(
+                id='search_bar_suggestions',
             ),
-            # Debounce timer
-            dcc.Interval(
-                id="search_bar_timer",
-                interval=2000,
-                max_intervals=1,
-                disabled=True
-            )
-        ],
-    )
+            id='search_bar_suggestions_collapser',
+            is_open=False,
+        ),
+        # Debounce timer
+        dcc.Interval(
+            id="search_bar_timer",
+            interval=2000,
+            max_intervals=1,
+            disabled=True
+        )
+    ],
 )
 
 # Time-based debounce from https://joetatusko.com/2023/07/11/time-based-debouncing-with-plotly-dash/
 clientside_callback(
     """
-    function start_suggestion_debounce_timer(value, n_submit, n_intervals) {
+    function start_suggestion_debounce_timer(value, n_submit, n_clicks, n_intervals) {
         const triggered = dash_clientside.callback_context.triggered.map(t => t.prop_id);
-        if (triggered == 'search_bar_input.n_submit')
+        if (triggered == 'search_bar_input.n_submit' || triggered == 'search_bar_submit.n_clicks')
             return [dash_clientside.no_update, true];
 
         if (n_intervals > 0)
@@ -269,6 +267,7 @@ clientside_callback(
     ],
     Input('search_bar_input', 'value'),
     Input('search_bar_input', 'n_submit'),
+    Input('search_bar_submit', 'n_clicks'),
     State('search_bar_timer', 'n_intervals'),
     prevent_initial_call=True,
 )
@@ -532,7 +531,7 @@ def modal_quickview():
                     dbc.ModalFooter(
                         dbc.Button(
                             "Close", id="close_modal_quickview", className="ml-auto", n_clicks=0
-                        ), style={'display': 'None'}
+                        ), className="d-block d-lg-none"
                     ),
                 ],
                 id="modal_quickview",
@@ -641,11 +640,48 @@ def display_table_results(table):
             [
                 dbc.Col(
                     dropdown,
-                    md=4
+                    lg=5, md=6
                 ),
                 dbc.Col(
+                    dbc.Row(
+                        [
+                            dbc.Col(
+                                modal_quickview(),
+                                md='auto'
+                            ),
+                            dbc.Col(
+                                modal_skymap(),
+                                md='auto'
+                            ),
+                            dbc.Col(
+                                help_popover(
+                                    dcc.Markdown(msg_info),
+                                    id='help_msg_info',
+                                    trigger=dmc.ActionIcon(
+                                        DashIconify(icon="mdi:help"),
+                                        id='help_msg_info',
+                                        color='gray',
+                                        variant="outline",
+                                        radius='xl',
+                                        size='lg',
+                                    ),
+                                ),
+                                md='auto'
+                            ),
+                        ],
+                        align='center', justify='end',
+                    ),
+                    md='auto',
+                )
+            ],
+            align='center', justify='between',
+            className='pt-1 pb-1 ps-2 pe-2'
+        ),
+        dbc.Row(
+            [
+                dbc.Col(
                     dmc.Tooltip(
-                    children=switch,
+                        children=switch,
                         width=220,
                         multiline=True,
                         withArrow=True,
@@ -653,7 +689,7 @@ def display_table_results(table):
                         transitionDuration=200,
                         label=switch_description
                     ),
-                    md=2,
+                    md='auto',
                 ),
                 dbc.Col(
                     dmc.Tooltip(
@@ -665,7 +701,7 @@ def display_table_results(table):
                         transitionDuration=200,
                         label=switch_sso_description
                     ),
-                    md=2
+                    md='auto'
                 ),
                 dbc.Col(
                     dmc.Tooltip(
@@ -677,15 +713,11 @@ def display_table_results(table):
                         transitionDuration=200,
                         label=switch_tracklet_description
                     ),
-                    md=2
+                    md='auto'
                 ),
-                dbc.Col(
-                    modal_quickview(),
-                    md=2
-                )
             ],
-            align='center',
-            className='pt-2 pb-1'
+            align='center', justify='start',
+            className='pt-1 pb-1 ps-2 pe-2',
         ),
         table
     ]
@@ -695,10 +727,10 @@ def display_table_results(table):
     [
         Input("result_table", "data"),
         Input("result_table", "columns"),
-        Input('tabs', 'active_tab')
+        Input("modal_skymap", "is_open"),
     ],
 )
-def display_skymap(data, columns, activetab):
+def display_skymap(data, columns, is_open):
     """ Display explorer result on a sky map (Aladin lite). Limited to 1000 sources total.
 
     TODO: image is not displayed correctly the first time
@@ -715,10 +747,15 @@ def display_skymap(data, columns, activetab):
     """
     ctx = dash.callback_context
     button_id = ctx.triggered[0]["prop_id"].split(".")[0]
-    if len(data) > 1000:
-        msg = '<b>We cannot display {} objects on the sky map (limit at 1000). Please refine your query.</b><br>'.format(len(data))
-        return """var container = document.getElementById('aladin-lite-div-skymap');var txt = '{}'; container.innerHTML = txt;""".format(msg)
-    if len(data) > 0 and (activetab == 't2'):
+
+    if not is_open:
+        return no_update
+
+    if len(data) > 0:
+        if len(data) > 1000:
+            # Silently limit the size of list we display
+            data = data[:1000]
+
         pdf = pd.DataFrame(data)
 
         # Coordinate of the first alert
@@ -781,44 +818,80 @@ def display_skymap(data, columns, activetab):
     else:
         return ""
 
-def display_skymap():
-    """ Display the sky map in the explorer tab results (Aladin lite)
+def modal_skymap():
+    button = dmc.Button(
+        "Sky Map",
+        id="open_modal_skymap",
+        n_clicks=0,
+        leftIcon=[DashIconify(icon="bi:stars")],
+        color="gray",
+        fullWidth=True,
+        variant='outline',
+        radius='xl'
+    )
 
-    It uses `visdcc` to execute javascript directly.
-
-    Returns
-    ---------
-    out: list of objects
-    """
-    return [
-        dbc.Container(
-            html.Div(
+    modal = html.Div(
+        [
+            button,
+            dbc.Modal(
                 [
-                    visdcc.Run_js(id='aladin-lite-div-skymap'),
-                    dcc.Markdown('_Hit the Aladin Lite fullscreen button if the image is not displayed (we are working on it...)_'),
-                ], style={
-                    'width': '100%',
-                    'height': '25pc'
-                }
-            )
-        )
-    ]
+                    loading(
+                        dbc.ModalBody(
+                            html.Div(
+                                [
+                                    visdcc.Run_js(id='aladin-lite-div-skymap'),
+                                    # dcc.Markdown('_Hit the Aladin Lite fullscreen button if the image is not displayed (we are working on it...)_'),
+                                ], style={
+                                    'width': '100%',
+                                    'height': '100%',
+                                }
+                            ),
+                            className="ps-4 pe-4",
+                            style={'height': '30pc'},
+                        )
+                    ),
+                    dbc.ModalFooter(
+                        dbc.Button(
+                            "Close", id="close_modal_skymap", className="ml-auto", n_clicks=0
+                        ),
+                    ),
+                ],
+                id="modal_skymap",
+                is_open=False,
+                size="lg",
+                # fullscreen="lg-down",
+            ),
+        ]
+    )
+
+    return modal
+
+@app.callback(
+    Output("modal_skymap", "is_open"),
+    [
+        Input("open_modal_skymap", "n_clicks"),
+        Input("close_modal_skymap", "n_clicks")
+    ],
+    [State("modal_skymap", "is_open")],
+)
+def toggle_modal_preview(n1, n2, is_open):
+    if n1 or n2:
+        return not is_open
+    return is_open
 
 def construct_results_layout(table, msg):
     """ Construct the tabs containing explorer query results
     """
-    results_ = [
-        dbc.Alert(msg, color='light'),
-        dbc.Tabs(
-            [
-                dbc.Tab(print_msg_info(), label='Info', tab_id='t0', label_style = {"color": "#000"}),
-                dbc.Tab(display_table_results(table), label="Table", tab_id='t1', label_style = {"color": "#000"}),
-                dbc.Tab(display_skymap(), label="Sky map", tab_id='t2', label_style = {"color": "#000"}),
-            ],
-            id="tabs",
-            active_tab="t1",
-        )
-    ]
+    results_ = html.Div(
+        className='bg-opaque-100 mb-2 shadow-sm border rounded-3',
+        children=[
+            html.P(
+                msg,
+                className='p-3 m-0'
+            ),
+        ] + display_table_results(table)
+    )
+
     return results_
 
 def populate_result_table(data, columns):
@@ -837,11 +910,11 @@ def populate_result_table(data, columns):
         sort_action="native",
         filter_action="native",
         markdown_options=markdown_options,
-        fixed_columns={'headers': True, 'data': 1},
+        # fixed_columns={'headers': True, 'data': 1},
         style_data={
             'backgroundColor': 'rgb(248, 248, 248, 1.0)',
         },
-        style_table={'maxWidth': '100%'},
+        style_table={'maxWidth': '100%', 'overflowX': 'scroll'},
         style_cell={
             'padding': '5px',
             'textAlign': 'right',
@@ -929,6 +1002,7 @@ def update_table(field_dropdown, groupby1, groupby2, groupby3, data, columns):
     [
         Output('results', 'children'),
         Output('logo', 'is_open'),
+        Output('search_bar_submit', 'children', allow_duplicate=True),
     ],
     [
         Input('search_bar_input', 'n_submit'),
@@ -946,7 +1020,7 @@ def results(n_submit, n_clicks, value):
 
     if not value:
         # TODO: show back the logo?..
-        return None, no_update
+        return None, no_update, no_update
 
     # TODO: catch parameters sent from URL
 
@@ -963,10 +1037,14 @@ def results(n_submit, n_clicks, value):
     query = parse_query(value)
 
     if not query:
-        return None, no_update
+        return None, no_update, no_update
 
     if query['action'] == 'unknown':
-        return dbc.Alert('Cannot parse the query: {}'.format(query), color='danger', dismissable=True), no_update
+        return dbc.Alert(
+            'Cannot parse the query: {}'.format(value),
+            color='danger',
+            className='shadow-sm'
+        ), no_update, no_update
 
     elif query['action'] == 'objectid':
         # Search objects by objectId
@@ -1046,20 +1124,24 @@ def results(n_submit, n_clicks, value):
         )
 
     else:
-        return dbc.Alert('Unhandled query: {}'.format(query), color='danger', dismissable=True), no_update
+        return dbc.Alert(
+            'Unhandled query: {}'.format(query),
+            color='danger',
+            className='shadow-sm'
+        ), no_update, no_update
 
     # Format output in a DataFrame
     pdf = pd.read_json(r.content)
 
-    msg = [msg, html.Br(), "{} found".format('Nothing' if pdf.empty else str(len(pdf.index)) + ' objects')]
+    msg = "{} - {} found".format(msg, 'nothing' if pdf.empty else str(len(pdf.index)) + ' objects')
 
     if pdf.empty:
         # text, header = text_noresults(query, query_type, dropdown_option, searchurl)
         return dbc.Alert(
             msg,
             color="warning",
-            dismissable=True
-        ), no_update
+            className='shadow-sm'
+        ), no_update, no_update
     else:
         # Make clickable objectId
         pdf['i:objectId'] = pdf['i:objectId'].apply(markdownify_objectid)
@@ -1083,7 +1165,7 @@ def results(n_submit, n_clicks, value):
         ]
 
     table = populate_result_table(data, columns)
-    return construct_results_layout(table, msg), False
+    return construct_results_layout(table, msg), False, no_update
 
 clientside_callback(
     """
@@ -1386,13 +1468,13 @@ def display_page(pathname):
                     ),
                     dbc.Row(
                         dbc.Col(
-                            dbc.Row(fink_search_bar),
+                            fink_search_bar,
                             md={'size':8, 'offset':2}
                         ), className="mt-3 mb-3"
                     ),
                 ], fluid="lg"
             ),
-            loading(dbc.Container(id='results', fluid="xxl"))
+            dbc.Container(id='results', fluid="xxl")
         ],
     )
     if pathname == '/about':

--- a/index.py
+++ b/index.py
@@ -1552,14 +1552,18 @@ def display_page(pathname):
                 [
                     # Logo shown by default
                     dbc.Collapse(
-                        dbc.Row(
-                            dbc.Col(
-                                html.Img(
-                                    src="/assets/Fink_PrimaryLogo_WEB.png",
-                                    height='100%',
-                                    width='40%'
-                                )
-                            ), style={'textAlign': 'center'}, className="mt-3",
+                        dmc.MediaQuery(
+                            dbc.Row(
+                                dbc.Col(
+                                    html.Img(
+                                        src="/assets/Fink_PrimaryLogo_WEB.png",
+                                        height='100%',
+                                        width='40%'
+                                    )
+                                ), style={'textAlign': 'center'}, className="mt-3",
+                            ),
+                            query="(max-height: 400px) or (max-width: 500px)",
+                            styles={'display': 'none'},
                         ), is_open=True, id='logo',
                     ),
                     dbc.Row(

--- a/index.py
+++ b/index.py
@@ -183,6 +183,7 @@ fink_search_bar = dbc.Row(
                 [
                     AutocompleteInput(
                         id='search_bar_input',
+                        placeholder='Search, and you will find',
                         component='input',
                         trigger=[
                             'class:', 'class=',
@@ -933,6 +934,7 @@ def update_table(field_dropdown, groupby1, groupby2, groupby3, data, columns):
         Input('search_bar_submit', 'n_clicks'),
     ],
     State('search_bar_input', 'value'),
+    prevent_initial_call=True
 )
 def results(n_submit, n_clicks, value):
     """ Parse the search string and query the database
@@ -1021,11 +1023,13 @@ def results(n_submit, n_clicks, value):
         if not alert_class or alert_class == 'All classes':
             alert_class = 'allclasses'
 
+        n_last = int(query['params'].get('last', 100))
+
         r = requests.post(
             '{}/api/v1/latests'.format(APIURL),
             json={
                 'class': alert_class,
-                'n': '100'
+                'n': n_last
             }
         )
 

--- a/index.py
+++ b/index.py
@@ -360,7 +360,7 @@ def update_suggestions(n_intervals, n_submit, n_clicks, value):
     if n_intervals != 1:
         return no_update, no_update, no_update
 
-    if not value:
+    if not value.strip():
         return None, no_update, False
 
     query = parse_query(value, timeout=5)
@@ -496,6 +496,20 @@ clientside_callback(
     Output('search_bar_input', 'value', allow_duplicate=True),
     Input('search_bar_clear', 'n_clicks'),
     prevent_initial_call=True
+)
+
+# Disable clear button for empty input field
+clientside_callback(
+    """
+    function on_input(value) {
+        if (value)
+            return false;
+        else
+            return true;
+    }
+    """,
+    Output('search_bar_clear', 'disabled'),
+    Input('search_bar_input', 'value')
 )
 
 def display_table_results(table):
@@ -931,7 +945,7 @@ def results(n_submit, n_clicks, searchurl, value, show_table):
     if not n_submit and not n_clicks and not searchurl:
         raise PreventUpdate
 
-    if not value and not searchurl:
+    if not value.strip() and not searchurl:
         # TODO: show back the logo?..
         return None, no_update, no_update
 

--- a/index.py
+++ b/index.py
@@ -41,13 +41,13 @@ from apps.utils import convert_jd
 from apps.utils import retrieve_oid_from_metaname
 from apps.utils import loading, help_popover
 from apps.utils import class_colors
+from apps.utils import request_api
 from apps.plotting import draw_cutouts_quickview, draw_lightcurve_preview
 from apps.cards import card_search_result
 from apps.parse import parse_query
 
 from fink_utils.photometry.utils import is_source_behind
 
-import requests
 import pandas as pd
 import numpy as np
 from astropy.time import Time, TimeDelta
@@ -595,10 +595,10 @@ def display_table_results(table):
           2. Table of results
         The dropdown is shown only if the table is non-empty.
     """
-    r = requests.get(
-        '{}/api/v1/columns'.format(APIURL),
+    r = request_api(
+        '/api/v1/columns',
         )
-    pdf = pd.read_json(r.content)
+    pdf = pd.read_json(r)
 
     fink_fields = ['d:' + i for i in pdf.loc['Fink science module outputs (d:)']['fields'].keys()]
     ztf_fields = ['i:' + i for i in pdf.loc['ZTF original fields (i:)']['fields'].keys()]
@@ -1052,8 +1052,8 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
     elif query['action'] == 'objectid':
         # Search objects by objectId
         msg = "ObjectId search with {} name {}".format('partial' if query['partial'] else 'exact', query['object'])
-        r = requests.post(
-            '{}/api/v1/explorer'.format(APIURL),
+        r = request_api(
+            '/api/v1/explorer',
             json={
                 'objectId': query['object'],
             }
@@ -1062,8 +1062,8 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
     elif query['action'] == 'sso':
         # Solar System Objects
         msg = "Solar System object search with ssnamenr {}".format(query['params']['sso'])
-        r = requests.post(
-            '{}/api/v1/sso'.format(APIURL),
+        r = request_api(
+            '/api/v1/sso',
             json={
                 'n_or_d': query['params']['sso']
             }
@@ -1076,8 +1076,8 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
             'id': query['object']
         }
 
-        r = requests.post(
-            '{}/api/v1/tracklet'.format(APIURL),
+        r = request_api(
+            '/api/v1/tracklet',
             json=payload
         )
 
@@ -1117,8 +1117,8 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
 
             payload['window'] = window
 
-        r = requests.post(
-            '{}/api/v1/explorer'.format(APIURL),
+        r = request_api(
+            '/api/v1/explorer',
             json=payload
         )
 
@@ -1159,8 +1159,8 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
 
             payload['stopdate'] = stopdate
 
-        r = requests.post(
-            '{}/api/v1/latests'.format(APIURL),
+        r = request_api(
+            '/api/v1/latests',
             json=payload
         )
 
@@ -1191,8 +1191,8 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
 
             payload['window'] = window
 
-        r = requests.post(
-            '{}/api/v1/explorer'.format(APIURL),
+        r = request_api(
+            '/api/v1/explorer',
             json=payload
         )
 
@@ -1220,8 +1220,8 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
 
             payload['stop_date'] = stopdate
 
-        r = requests.post(
-            '{}/api/v1/anomaly'.format(APIURL),
+        r = request_api(
+            '/api/v1/anomaly',
             json=payload
         )
 
@@ -1248,8 +1248,8 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
 
             payload['seed'] = seed
 
-        r = requests.post(
-            '{}/api/v1/random'.format(APIURL),
+        r = request_api(
+            '/api/v1/random',
             json=payload
         )
 
@@ -1269,7 +1269,7 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
     history = history[-10:] # Limit it to 10 latest entries
 
     # Format output in a DataFrame
-    pdf = pd.read_json(r.content)
+    pdf = pd.read_json(r)
 
     if query['action'] == 'random':
         # Keep only latest alert from all objects

--- a/index.py
+++ b/index.py
@@ -164,6 +164,13 @@ Examples:
 - `last=10 class="Early SN Ia candidate"` - return 10 latest arly SN Ia candidates
 - `class="Early SN Ia candidate" before="2023-12-01" after="2023-11-15 04:00:00"` - objects of the same class between 4am on Nov 15, 2023 and Dec 1, 2023
 
+##### Random objects
+
+To get random subset of objects just specify the amount of them you want to get using keyword `random`. You may also refine it by adding the class using `class` keyword.
+
+Examples:
+- `random=10 class=Unknown` - return 10 random objects of class `Unknown`
+
 """
 
 msg_info = """
@@ -192,7 +199,8 @@ quick_fields = [
     # ['before', 'Upper timit on alert time\nISO time, MJD or JD'],
     ['after', 'Lower timit on alert time\nISO time, MJD or JD'],
     ['before', 'Upper timit on alert time\nISO time, MJD or JD'],
-    ['window', 'Time window length\nDays']
+    ['window', 'Time window length\nDays'],
+    ['random', 'Number of random objects to show'],
 ]
 
 fink_search_bar = [
@@ -1214,6 +1222,34 @@ def results(n_submit, n_clicks, searchurl, value, history, show_table):
 
         r = requests.post(
             '{}/api/v1/anomaly'.format(APIURL),
+            json=payload
+        )
+
+    elif query['action'] == 'random':
+        n_random = int(query['params'].get('random', 100))
+
+        msg = "Random {} objects".format(n_random)
+
+        payload = {
+            'n': n_random
+        }
+
+        if 'class' in query['params']:
+            alert_class = query['params']['class']
+
+            msg += ' with class {}'.format(alert_class)
+
+            payload['class'] = alert_class
+
+        if 'seed' in query['params']:
+            seed = query['params']['seed']
+
+            msg += ' seed {}'.format(seed)
+
+            payload['seed'] = seed
+
+        r = requests.post(
+            '{}/api/v1/random'.format(APIURL),
             json=payload
         )
 

--- a/index.py
+++ b/index.py
@@ -1153,7 +1153,7 @@ def results(n_submit, n_clicks, searchurl, value):
         ra = float(query['params'].get('ra'))
         dec = float(query['params'].get('dec'))
         # Default is 10 arcsec, max is 5 degrees
-        sr = max(float(query['params'].get('r', 10)), 18000)
+        sr = min(float(query['params'].get('r', 10)), 18000)
 
         msg = "Cone search with center at {:.4f} {:.3f} and radius {:.1f} arcsec".format(ra, dec, sr)
 

--- a/index.py
+++ b/index.py
@@ -281,6 +281,7 @@ fink_search_bar = [
                     quoteWhitespaces=True,
                     autoFocus=True,
                     ignoreCase=True,
+                    triggerInsideWord=False,
                 ),
                 # Clear
                 dmc.ActionIcon(

--- a/tests/api_conesearch_test.py
+++ b/tests/api_conesearch_test.py
@@ -24,7 +24,7 @@ import sys
 
 APIURL = sys.argv[1]
 
-def conesearch(ra='193.8217409', dec='2.8973184', radius='5', startdate_conesearch=None, window_days_conesearch=None, output_format='json'):
+def conesearch(ra='193.8217409', dec='2.8973184', radius='5', startdate=None, window=None, output_format='json'):
     """ Perform a conesearch in the Science Portal using the Fink REST API
     """
     payload = {
@@ -34,11 +34,11 @@ def conesearch(ra='193.8217409', dec='2.8973184', radius='5', startdate_conesear
         'output-format': output_format
     }
 
-    if startdate_conesearch is not None:
+    if startdate is not None:
         payload.update(
             {
-                'startdate_conesearch': startdate_conesearch,
-                'window_days_conesearch': window_days_conesearch
+                'startdate': startdate,
+                'window': window
             }
         )
 
@@ -97,8 +97,8 @@ def test_conesearch_with_dates() -> None:
         ra='175.3242473',
         dec='36.5429392',
         radius='5',
-        startdate_conesearch='2021-11-03 10:00:00',
-        window_days_conesearch='1'
+        startdate='2021-11-03 10:00:00',
+        window='1'
     )
 
     # at this date, a new object appeared
@@ -106,8 +106,8 @@ def test_conesearch_with_dates() -> None:
         ra='175.3242473',
         dec='36.5429392',
         radius='5',
-        startdate_conesearch='2021-11-05 10:00:00',
-        window_days_conesearch='1'
+        startdate='2021-11-05 10:00:00',
+        window='1'
     )
 
     assert pdf1.empty


### PR DESCRIPTION
Redesign of the search page to use "smart search" like in Google or ADS. Like the latter, offer the palette of search terms above the input field. 

Possible queries are like:
- `10 20 300` - cone search at ra=10 dec=20 with 300 arcsec radius
- `Vega r=10` - cone search within 10 arcsec around Vega
- `10 20 300 after="2023-01-01" window=1` - cone search within 300 arcsec from Vega in 24 hours after given moment
- `ZTF22abzanvj` - exact search for objectId
- `ZTF23abshpmf r=100` - cone search within 100 arcsec around the alert
- `ZTF22abzan` - partial match search for objectIds starting with given pattern
- `TRCK_20231212` - partial match search for tracklets (effectively, all tracklets from a given date)
- `class=Unknown` - last 100 alerts of a given class
- `class=Unknown last=10` - last 10 alerts of a given class
- `class=Unknown before="2023-01-01 01:12:23"` - last 100 alerts before given moment
- `class=Anomaly last=10` - last 10 anomalies
- `after="2022-12-29 13:36:52" before="2023-12-29 13:46:52"` - date range search with exact specification of start and stop times

~~Everything is somehow working, except for SSO - this one is waiting for backend API improvements as discussed with Julien.~~ 
GET api (does anyone actually use it?..) is changed to reflect underlying query parser, so the urls that work now look like:

- `/?action=conesearch&ra=10&dec=20&r=300`
- `/?action=class&class=Unknown&last=10`

Requires installation of two additional packages from pip - `regex` (used for partial matches) and `dash-autocomplete-input` (used for dropdown menu for class search).
Also requires updating `dash-mantine-components` to latest version from pip.
 
~~Documentation (mostly the help popup inside the search bar itself) is not yet updated.~~