### PR TITLE
Improve SSO resolver

### DIFF
--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -200,7 +200,7 @@ def layout():
                         [
                             dbc.Card(
                                 dbc.CardBody(
-                                    dcc.Markdown(api_doc_resolver)
+                                    dcc.Markdown(api_doc_resolver, dangerously_allow_html=True)
                                 )
                             ),
                         ], label="Name resolver", label_style = {"color": "#000"}

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -200,7 +200,7 @@ def layout():
                         [
                             dbc.Card(
                                 dbc.CardBody(
-                                    dcc.Markdown(api_doc_resolver, dangerously_allow_html=True)
+                                    dcc.Markdown(api_doc_resolver)
                                 )
                             ),
                         ], label="Name resolver", label_style = {"color": "#000"}

--- a/apps/api/doc.py
+++ b/apps/api/doc.py
@@ -1703,6 +1703,52 @@ sso = pd.read_json(io.BytesIO(r.content))
 30  31.916201  20.444067  ZTF23abuqdev  35.732460    0.172873     624188
 ```
 
+### Exact/inexact searches
+
+By default, the SSO resolver will perform an _inexact_ search, meaning it will return the exact search plus closest matches. The number of closest matches is controlled by the parameter `nmax`, with default `nmax=10`:
+
+```python
+r = requests.post(
+  'https://fink-portal.org/api/v1/resolver',
+  json={
+    'resolver': 'ssodnet',
+    'name': '33'
+  }
+)
+
+pdf = pd.read_json(io.BytesIO(r.content))
+
+   i:source  i:ssnamenr
+0  ssnamenr          33
+1    number          33
+2  ssnamenr         330
+3    number         330
+4    number         331
+5  ssnamenr         331
+6    number         332
+7  ssnamenr         332
+8    number         333
+9  ssnamenr         333
+```
+If you want to perform an _exact_ search, just put `nmax=1`:
+
+```python
+r = requests.post(
+  'https://fink-portal.org/api/v1/resolver',
+  json={
+    'resolver': 'ssodnet',
+    'name': '33',
+    'nmax': 1
+  }
+)
+
+pdf = pd.read_json(io.BytesIO(r.content))
+
+   i:source  i:ssnamenr
+0  ssnamenr          33
+1    number          33
+```
+
 ### ZTF to SSO
 
 I have a ZTF object name, is there a counterpart in the SsODNet quaero database, and what are all the known aliases to Fink?
@@ -1726,7 +1772,8 @@ if r.json() != []:
       'https://fink-portal.org/api/v1/resolver',
       json={
         'resolver': 'ssodnet',
-        'name': name
+        'name': name,
+        'nmax': 1
       }
     )
 

--- a/apps/api/doc.py
+++ b/apps/api/doc.py
@@ -1650,11 +1650,11 @@ r = requests.post(
 
 pdf = pd.read_json(io.BytesIO(r.content))
 
-   i:source i:ssnamenr
-0    number   2002MA06
-1    number    2002MA6
-2    number     624188
-3  ssnamenr     624188
+     i:name  i:number i:ssnamenr
+0  2002 MA6    624188    2002MA6
+1  2002 MA6    624188     624188
+2  2002 MA6    624188   2002MA06
+3  2002 MA6    624188     624188
 ```
 
 and then search for corresponding alerts for all `ssnamenr`:
@@ -1718,18 +1718,19 @@ r = requests.post(
 
 pdf = pd.read_json(io.BytesIO(r.content))
 
-   i:source  i:ssnamenr
-0  ssnamenr          33
-1    number          33
-2  ssnamenr         330
-3    number         330
-4    number         331
-5  ssnamenr         331
-6    number         332
-7  ssnamenr         332
-8    number         333
-9  ssnamenr         333
+          i:name  i:number  i:ssnamenr
+0     Polyhymnia        33          33
+1     Polyhymnia        33          33
+2      Adalberta       330         330
+3      Adalberta       330         330
+4       3300 T-1     17325       17325
+5       3300 T-2     69209       69209
+6       3300 T-3     79071       79071
+7      McGlasson      3300        3300
+8      McGlasson      3300        3300
+9  Chenjiansheng     33000       33000
 ```
+Note that there are duplicates, as data is indexed by `name`, `number`, and `ssnamenr`.
 If you want to perform an _exact_ search, just put `nmax=1`:
 
 ```python
@@ -1744,9 +1745,9 @@ r = requests.post(
 
 pdf = pd.read_json(io.BytesIO(r.content))
 
-   i:source  i:ssnamenr
-0  ssnamenr          33
-1    number          33
+       i:name  i:number  i:ssnamenr
+0  Polyhymnia        33          33
+1  Polyhymnia        33          33
 ```
 
 ### ZTF to SSO

--- a/apps/api/doc.py
+++ b/apps/api/doc.py
@@ -1660,7 +1660,7 @@ and then search for corresponding alerts:
 r = requests.post(
   'https://fink-portal.org/api/v1/sso',
   json={
-    'n_or_d': pdf['i:ssnamenr'].astype(str).values[0],
+    'n_or_d': pdf['i:ssnamenr'].values[0],
     'columns': 'i:objectId,i:ra,i:dec,i:magpsf,i:sigmapsf'
   }
 )

--- a/apps/api/doc.py
+++ b/apps/api/doc.py
@@ -1521,56 +1521,11 @@ r = requests.post(
 
 # Format output in a DataFrame
 pdf = pd.read_json(io.BytesIO(r.content))
+
+   d:declination  d:fullname d:internalname       d:ra d:type       key:time
+0      52.219894  SN 2023vwy     ATLAS23url  47.765951  SN Ia  1702926332847
+1      52.219894  SN 2023vwy   ZTF23abmwsrw  47.765951  SN Ia  1702926332847
 ```
-
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>d:declination</th>
-      <th>d:fullname</th>
-      <th>d:internalname</th>
-      <th>d:ra</th>
-      <th>d:type</th>
-      <th>key:time</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>52.219894</td>
-      <td>SN 2023vwy</td>
-      <td>ATLAS23url</td>
-      <td>47.765951</td>
-      <td>SN Ia</td>
-      <td>1701889538816</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>52.219894</td>
-      <td>SN 2023vwy</td>
-      <td>ZTF23abmwsrw</td>
-      <td>47.765951</td>
-      <td>SN Ia</td>
-      <td>1701889538816</td>
-    </tr>
-  </tbody>
-</table>
-</div>
 
 ### ZTF to TNS
 
@@ -1589,58 +1544,11 @@ r = requests.post(
 
 # Format output in a DataFrame
 pdf = pd.read_json(io.BytesIO(r.content))
+
+   d:declination  d:fullname d:internalname       d:ra d:type       key:time
+0      52.219904  AT 2023vwy   ZTF23abmwsrw  47.765935    nan  1698788550829
+1      52.219894  SN 2023vwy   ZTF23abmwsrw  47.765951  SN Ia  1702926332847
 ```
-
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>d:declination</th>
-      <th>d:fullname</th>
-      <th>d:internalname</th>
-      <th>d:ra</th>
-      <th>d:type</th>
-      <th>key:time</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>52.219904</td>
-      <td>AT 2023vwy</td>
-      <td>ZTF23abmwsrw</td>
-      <td>47.765935</td>
-      <td>nan</td>
-      <td>1698788550829</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>52.219894</td>
-      <td>SN 2023vwy</td>
-      <td>ZTF23abmwsrw</td>
-      <td>47.765951</td>
-      <td>SN Ia</td>
-      <td>1701889538816</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-
 
 ### SIMBAD to ZTF
 
@@ -1677,6 +1585,8 @@ else:
     print('No objects found')
 ```
 
+Leading in this example to:
+
     Object found!
     [{'name': 'Si=Simbad, all IDs (via url)', 'oid': 1579005, 'oname': 'Mrk 2', 'otype': 'GiG', 'jpos': '01:54:53.80 +36:55:04.6', 'jradeg': 28.7241958, 'jdedeg': 36.9179556, 'refPos': '2006AJ....131.1163S', 'z': None, 'MType': 'SBa', 'nrefs': 138}]
 
@@ -1697,71 +1607,16 @@ r = requests.post(
   }
 )
 pdf = pd.read_json(io.BytesIO(r.content))
+
+  d:cdsxmatch      i:dec    i:objectId       i:ra
+0    GinGroup  36.917909  ZTF18aabfjoi  28.724092
+1    GinGroup  36.917912  ZTF18aabfjoi  28.724130
+2    GinGroup  36.917924  ZTF18aabfjoi  28.724110
+3    GinGroup  36.917913  ZTF18aabfjoi  28.724100
+4    GinGroup  36.917892  ZTF18aabfjoi  28.724094
 ```
 
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>d:cdsxmatch</th>
-      <th>i:dec</th>
-      <th>i:objectId</th>
-      <th>i:ra</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>GinGroup</td>
-      <td>36.917909</td>
-      <td>ZTF18aabfjoi</td>
-      <td>28.724092</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>GinGroup</td>
-      <td>36.917912</td>
-      <td>ZTF18aabfjoi</td>
-      <td>28.724130</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <td>GinGroup</td>
-      <td>36.917924</td>
-      <td>ZTF18aabfjoi</td>
-      <td>28.724110</td>
-    </tr>
-    <tr>
-      <th>3</th>
-      <td>GinGroup</td>
-      <td>36.917913</td>
-      <td>ZTF18aabfjoi</td>
-      <td>28.724100</td>
-    </tr>
-    <tr>
-      <th>4</th>
-      <td>GinGroup</td>
-      <td>36.917892</td>
-      <td>ZTF18aabfjoi</td>
-      <td>28.724094</td>
-    </tr>
-  </tbody>
-</table>
-</div>
+5 different alerts from the same object (`ZTF18aabfjoi`).
 
 ### SSO to ZTF
 

--- a/apps/api/doc.py
+++ b/apps/api/doc.py
@@ -1644,42 +1644,63 @@ r = requests.post(
   'https://fink-portal.org/api/v1/resolver',
   json={
     'resolver': 'ssodnet',
-    'name': 'Benoitcarry'
+    'name': '624188'
   }
 )
 
 pdf = pd.read_json(io.BytesIO(r.content))
 
-  i:source  i:ssnamenr
-0     name        8467
+   i:source i:ssnamenr
+0    number   2002MA06
+1    number    2002MA6
+2    number     624188
+3  ssnamenr     624188
 ```
 
-and then search for corresponding alerts:
+and then search for corresponding alerts for all `ssnamenr`:
 
 ```python
 r = requests.post(
   'https://fink-portal.org/api/v1/sso',
   json={
-    'n_or_d': pdf['i:ssnamenr'].values[0],
-    'columns': 'i:objectId,i:ra,i:dec,i:magpsf,i:sigmapsf'
+    'n_or_d': ','.join(pdf['i:ssnamenr'].values),
+    'columns': 'i:objectId,i:ra,i:dec,i:magpsf,i:sigmapsf,i:ssnamenr'
   }
 )
 sso = pd.read_json(io.BytesIO(r.content))
 
-         i:dec   i:magpsf    i:objectId        i:ra  i:sigmapsf
-0    36.161248  18.611034  ZTF19acobkas   77.294453    0.083834
-1    36.331305  18.620789  ZTF19acpqeds   76.876430    0.094948
-2    36.486187  18.402218  ZTF19acrdtum   76.405307    0.122535
-3    36.488667  18.515806  ZTF19acreebv   76.397151    0.105453
-4    36.537212  17.863874  ZTF19acrptft   76.226673    0.059307
-..         ...        ...           ...         ...         ...
-139 -27.313561  19.024980  ZTF23abmhbto  305.778251    0.149182
-140 -26.954849  19.046757  ZTF23abnctrh  306.352687    0.151236
-141 -26.676200  19.217007  ZTF23abnpgnk  306.832111    0.161494
-142 -25.915354  19.193588  ZTF23abovwcw  308.263112    0.148075
-143 -25.721885  19.228273  ZTF23abpkzcn  308.651113    0.122658
-
-[144 rows x 5 columns]
+        i:dec   i:magpsf    i:objectId       i:ra  i:sigmapsf i:ssnamenr
+0   38.761579  19.651100  ZTF19acrplsa  84.760898    0.201959   2002MA06
+1   35.097359  19.678823  ZTF19adagirr  74.131671    0.154512   2002MA06
+2   32.709072  20.320038  ZTF23aazubcu  38.761726    0.181345    2002MA6
+3   36.039245  20.226397  ZTF23abcakzn  42.951283    0.208451    2002MA6
+4   37.399041  20.620817  ZTF23abecthp  44.314170    0.181139    2002MA6
+5   37.412476  19.931238  ZTF23abeeoen  44.324915    0.122155    2002MA6
+6   38.092562  19.839323  ZTF23abfvtyr  44.875277    0.110749    2002MA6
+7   38.102591  20.627150  ZTF23abfxptv  44.881451    0.182423    2002MA6
+8   39.028132  19.811459  ZTF23abhahgo  45.412434    0.116035    2002MA6
+9   40.087669  19.518000  ZTF23abidfxt  45.472807    0.134570     624188
+10  40.253863  20.037786  ZTF23abilvaz  45.374426    0.172761     624188
+11  40.263377  19.517801  ZTF23abiotst  45.365776    0.116226     624188
+12  40.717564  19.452196  ZTF23abkempy  44.508594    0.087599     624188
+13  40.718352  19.871597  ZTF23abkfquu  44.504111    0.144978     624188
+14  40.760788  19.485823  ZTF23abkwjee  44.211183    0.093203     624188
+15  40.777337  19.365993  ZTF23ablsjlg  43.858879    0.078582     624188
+16  40.777324  19.830032  ZTF23ablthyz  43.850151    0.109873     624188
+17  40.046433  19.359879  ZTF23abogmeh  40.809196    0.127990     624188
+18  39.832539  19.788800  ZTF23aboqpks  40.349063    0.139298     624188
+19  39.153497  19.270357  ZTF23abpqqiz  39.155381    0.140963     624188
+20  39.134613  19.803095  ZTF23abpsedk  39.124796    0.165054     624188
+21  38.846470  19.866776  ZTF23abqbtrv  38.709943    0.139531     624188
+22  38.826889  19.179682  ZTF23abqdzil  38.680996    0.095241     624188
+23  38.508815  19.166033  ZTF23abqphse  38.268334    0.072787     624188
+24  33.059517  19.892330  ZTF23absmjqg  35.439591    0.186579     624188
+25  32.477462  19.840815  ZTF23abtpaxv  35.544006    0.173815     624188
+26  32.294998  19.863436  ZTF23abtxgba  35.595829    0.105220     624188
+27  32.292988  19.976093  ZTF23abtxjux  35.596339    0.081324     624188
+28  32.094647  20.584602  ZTF23abuivpe  35.662240    0.160992     624188
+29  31.925860  20.086443  ZTF23abuppio  35.728953    0.138072     624188
+30  31.916201  20.444067  ZTF23abuqdev  35.732460    0.172873     624188
 ```
 
 ### ZTF to SSO

--- a/apps/api/doc.py
+++ b/apps/api/doc.py
@@ -1587,10 +1587,26 @@ else:
 
 Leading in this example to:
 
-    Object found!
-    [{'name': 'Si=Simbad, all IDs (via url)', 'oid': 1579005, 'oname': 'Mrk 2', 'otype': 'GiG', 'jpos': '01:54:53.80 +36:55:04.6', 'jradeg': 28.7241958, 'jdedeg': 36.9179556, 'refPos': '2006AJ....131.1163S', 'z': None, 'MType': 'SBa', 'nrefs': 138}]
+```
+Object found!
+[
+  {
+    'name': 'Si=Simbad, all IDs (via url)',
+    'oid': 1579005,
+    'oname': 'Mrk 2',
+    'otype': 'GiG',
+    'jpos': '01:54:53.80 +36:55:04.6',
+    'jradeg': 28.7241958,
+    'jdedeg': 36.9179556,
+    'refPos': '2006AJ....131.1163S',
+    'z': None,
+    'MType': 'SBa',
+    'nrefs': 138
+  }
+]
 
-    Object(s) in ZTF: ['ZTF18aabfjoi']
+Object(s) in ZTF: ['ZTF18aabfjoi']
+```
 
 ### ZTF to SIMBAD
 
@@ -1638,7 +1654,7 @@ pdf = pd.read_json(io.BytesIO(r.content))
 0     name        8467
 ```
 
-and then search for correspondind alerts:
+and then search for corresponding alerts:
 
 ```python
 r = requests.post(
@@ -1700,12 +1716,14 @@ if r.json() != []:
 
 Leading to:
 
-    Asteroid counterpart found with designation 624188
+```
+Asteroid counterpart found with designation 624188
 
-    In the Fink database, 624188 also corresponds to:
-      i:source i:ssnamenr
-    0    number   2002MA06
-    1    number    2002MA6
-    2    number     624188
-    3  ssnamenr     624188
+In the Fink database, 624188 also corresponds to:
+  i:source i:ssnamenr
+0    number   2002MA06
+1    number    2002MA6
+2    number     624188
+3  ssnamenr     624188
+```
 """

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1466,9 +1466,9 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
                 client.close()
                 pdfs = pd.DataFrame.from_dict(results, orient='index')
 
-                # Remove internal deduplication markers
+                # Remove internal prefix & deduplication markers
                 pdfs = pdfs.reset_index().rename(columns={'index': 'SSO ID'})
-                pdfs['SSO ID'] = pdfs['SSO ID'].apply(lambda x: x.split('_')[0])
+                pdfs['SSO ID'] = pdfs['SSO ID'].apply(lambda x: x.split('_')[1])
 
         else:
             # MPC -> ssnamenr

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1449,7 +1449,7 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
             pdfs = pd.DataFrame.from_dict(results, orient='index')
 
             # ssnmanenr -> MPC name & number
-            if not pdfs.empty():
+            if not pdfs.empty:
                 client = connect_to_hbase_table('ztf.sso_resolver')
                 ssnamenrs = np.unique(pdfs['i:ssnamenr'].values)
                 results = {}

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1471,16 +1471,19 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
                 pdfs['SSO ID'] = pdfs['SSO ID'].apply(lambda x: x.split('_')[0])
 
         else:
-            # MPC -> ssnamenr -> ZTF alerts
-            client = connect_to_hbase_table('ztf.sso_resolver')
-
-            # Hardcode the limit to 20 max
-            # This should be enough for autocompletion tasks
-            client.setLimit(20)
-
+            # MPC -> ssnamenr
             # keys follow the pattern <prefix>_<name>_<deduplication>
             # where the <prefix> is a five-letter string
-            to_evaluate = "key:key:_{}:substring".format(name)
+            client = connect_to_hbase_table('ztf.sso_resolver')
+
+            if nmax == 1:
+                # enclose the name exactly
+                to_evaluate = "key:key:_{}_:substring".format(name)
+            elif nmax > 1:
+                # This enables e.g. autocompletion tasks
+                client.setLimit(nmax)
+                to_evaluate = "key:key:_{}:substring".format(name)
+
             results = client.scan(
                 "",
                 to_evaluate,

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1473,7 +1473,14 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
         else:
             # MPC -> ssnamenr -> ZTF alerts
             client = connect_to_hbase_table('ztf.sso_resolver')
-            to_evaluate = "key:key:{}_".format(name)
+
+            # Hardcode the limit to 20 max
+            # This should be enough for autocompletion tasks
+            client.setLimit(20)
+
+            # keys follow the pattern <prefix>_<name>_<deduplication>
+            # where the <prefix> is a five-letter string
+            to_evaluate = "key:key:_{}:substring".format(name)
             results = client.scan(
                 "",
                 to_evaluate,

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1418,7 +1418,7 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
             results = client.scan(
                 "",
                 to_evaluate,
-                "i:objectId,d:cdsxmatch,i:ra,i:dec",
+                "i:objectId,d:cdsxmatch,i:ra,i:dec,i:candid,i:jd",
                 0, False, False
             )
             client.close()

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -505,7 +505,7 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
     else:
         # single object search
         # Note the trailing _ to avoid mixing e.g. 91 and 915 in the same query
-        names = ["key:key:{}_".format(payload['n_or_d'].replace(' ', ''))]
+        names = ["key:key:{}_".format(str(payload['n_or_d']).replace(' ', ''))]
 
     # Get data from the main table
     client = connect_to_hbase_table('ztf.ssnamenr')

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -496,16 +496,18 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
     else:
         truncated = True
 
-    if ',' in payload['n_or_d']:
+    n_or_d = str(payload['n_or_d'])
+
+    if ',' in n_or_d:
         # multi-objects search
-        splitids = payload['n_or_d'].replace(' ', '').split(',')
+        splitids = n_or_d.replace(' ', '').split(',')
 
         # Note the trailing _ to avoid mixing e.g. 91 and 915 in the same query
         names = ['key:key:{}_'.format(i.strip()) for i in splitids]
     else:
         # single object search
         # Note the trailing _ to avoid mixing e.g. 91 and 915 in the same query
-        names = ["key:key:{}_".format(str(payload['n_or_d']).replace(' ', ''))]
+        names = ["key:key:{}_".format(n_or_d.replace(' ', ''))]
 
     # Get data from the main table
     client = connect_to_hbase_table('ztf.ssnamenr')

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1456,7 +1456,7 @@ def return_resolver_pdf(payload: dict) -> pd.DataFrame:
                 for ssnamenr in ssnamenrs:
                     result = client.scan(
                         "",
-                        "i:ssnamenr:{}".format(ssnamenr),
+                        "i:ssnamenr:{}:exact".format(ssnamenr),
                         "i:source,i:ssnamenr",
                         0, False, False
                     )

--- a/tests/api_resolver_test.py
+++ b/tests/api_resolver_test.py
@@ -183,7 +183,7 @@ def test_reverse_ssodnet_resolver() -> None:
     assert len(pdf) == 3, len(pdf)
 
     assert 'Julienpeloton' in pdf['i:name'].values, pdf
-    assert '33803' in pdf['i:number'].values, pdf
+    assert 33803 in pdf['i:number'].values, pdf
 
 
 if __name__ == "__main__":

--- a/tests/api_resolver_test.py
+++ b/tests/api_resolver_test.py
@@ -158,23 +158,15 @@ def test_ssodnet_resolver() -> None:
     ---------
     >>> test_ssodnet_resolver()
     """
-    pdf = resolver(resolver='ssodnet', name='33803')
+    pdf = resolver(resolver='ssodnet', name='624188')
 
     # Not empty
     assert not pdf.empty
 
     # One object found
-    assert len(pdf) == 10
+    assert len(pdf) == 4, pdf
 
-    assert 'Julienpeloton' in pdf['name'].values, pdf['name'].values
-
-    cols = [
-        'type', 'system', 'class', 'updated',
-        'ephemeris', 'physical-ephemeris',
-        'aliases', 'links', 'id', 'name', 'parent'
-    ]
-    for col in cols:
-        assert col in pdf.columns, [col, pdf.columns]
+    assert '2002MA06' in pdf['i:ssnamenr'].values, pdf
 
 def test_reverse_ssodnet_resolver() -> None:
     """
@@ -188,9 +180,10 @@ def test_reverse_ssodnet_resolver() -> None:
     assert not pdf.empty
 
     # One object found
-    assert len(pdf) == 1, len(pdf)
+    assert len(pdf) == 3, len(pdf)
 
-    assert pdf['i:ssnamenr'].values[0] == 33803, pdf['i:ssnamenr'].values
+    assert 'Julienpeloton' in pdf['SSO ID'].values, pdf
+    assert '33803' in pdf['SSO ID'].values, pdf
 
 
 if __name__ == "__main__":

--- a/tests/api_resolver_test.py
+++ b/tests/api_resolver_test.py
@@ -182,8 +182,8 @@ def test_reverse_ssodnet_resolver() -> None:
     # One object found
     assert len(pdf) == 3, len(pdf)
 
-    assert 'Julienpeloton' in pdf['SSO ID'].values, pdf
-    assert '33803' in pdf['SSO ID'].values, pdf
+    assert 'Julienpeloton' in pdf['i:name'].values, pdf
+    assert '33803' in pdf['i:number'].values, pdf
 
 
 if __name__ == "__main__":

--- a/tests/api_ssocand_test.py
+++ b/tests/api_ssocand_test.py
@@ -103,7 +103,7 @@ def test_lightcurves_traj() -> None:
     ---------
     >>> test_lightcurves_traj()
     """
-    pdf = ssocandsearch(kind='lightcurves', trajectory_id='FF2023aaaaaaj')
+    pdf = ssocandsearch(kind='lightcurves', trajectory_id='FF20230725aaaacgw')
 
     assert 'd:ssoCandId' in pdf.columns
 


### PR DESCRIPTION
A new HBase table has been added (https://github.com/astrolabsoftware/fink-broker/pull/774) to enable resolving SSO names more easily. The resolver behaviour for `ssodnet` has been modified (syntax remains the same). You'll find below some typical use cases.

### SSO to ZTF

I have a SSO name or number, are there ZTF objects corresponding?
You first need to resolve the corresponding ZTF `ssnamenr`:

```python
r = requests.post(
  'https://fink-portal.org/api/v1/resolver',
  json={
    'resolver': 'ssodnet',
    'name': '624188'
  }
)

pdf = pd.read_json(io.BytesIO(r.content))

     i:name  i:number i:ssnamenr
0  2002 MA6    624188    2002MA6
1  2002 MA6    624188     624188
2  2002 MA6    624188   2002MA06
3  2002 MA6    624188     624188
```

and then search for corresponding alerts for all `ssnamenr`:

```python
r = requests.post(
  'https://fink-portal.org/api/v1/sso',
  json={
    'n_or_d': ','.join(pdf['i:ssnamenr'].values),
    'columns': 'i:objectId,i:ra,i:dec,i:magpsf,i:sigmapsf,i:ssnamenr'
  }
)
sso = pd.read_json(io.BytesIO(r.content))

        i:dec   i:magpsf    i:objectId       i:ra  i:sigmapsf i:ssnamenr
0   38.761579  19.651100  ZTF19acrplsa  84.760898    0.201959   2002MA06
1   35.097359  19.678823  ZTF19adagirr  74.131671    0.154512   2002MA06
2   32.709072  20.320038  ZTF23aazubcu  38.761726    0.181345    2002MA6
3   36.039245  20.226397  ZTF23abcakzn  42.951283    0.208451    2002MA6
4   37.399041  20.620817  ZTF23abecthp  44.314170    0.181139    2002MA6
5   37.412476  19.931238  ZTF23abeeoen  44.324915    0.122155    2002MA6
6   38.092562  19.839323  ZTF23abfvtyr  44.875277    0.110749    2002MA6
7   38.102591  20.627150  ZTF23abfxptv  44.881451    0.182423    2002MA6
8   39.028132  19.811459  ZTF23abhahgo  45.412434    0.116035    2002MA6
9   40.087669  19.518000  ZTF23abidfxt  45.472807    0.134570     624188
10  40.253863  20.037786  ZTF23abilvaz  45.374426    0.172761     624188
11  40.263377  19.517801  ZTF23abiotst  45.365776    0.116226     624188
12  40.717564  19.452196  ZTF23abkempy  44.508594    0.087599     624188
13  40.718352  19.871597  ZTF23abkfquu  44.504111    0.144978     624188
14  40.760788  19.485823  ZTF23abkwjee  44.211183    0.093203     624188
15  40.777337  19.365993  ZTF23ablsjlg  43.858879    0.078582     624188
16  40.777324  19.830032  ZTF23ablthyz  43.850151    0.109873     624188
17  40.046433  19.359879  ZTF23abogmeh  40.809196    0.127990     624188
18  39.832539  19.788800  ZTF23aboqpks  40.349063    0.139298     624188
19  39.153497  19.270357  ZTF23abpqqiz  39.155381    0.140963     624188
20  39.134613  19.803095  ZTF23abpsedk  39.124796    0.165054     624188
21  38.846470  19.866776  ZTF23abqbtrv  38.709943    0.139531     624188
22  38.826889  19.179682  ZTF23abqdzil  38.680996    0.095241     624188
23  38.508815  19.166033  ZTF23abqphse  38.268334    0.072787     624188
24  33.059517  19.892330  ZTF23absmjqg  35.439591    0.186579     624188
25  32.477462  19.840815  ZTF23abtpaxv  35.544006    0.173815     624188
26  32.294998  19.863436  ZTF23abtxgba  35.595829    0.105220     624188
27  32.292988  19.976093  ZTF23abtxjux  35.596339    0.081324     624188
28  32.094647  20.584602  ZTF23abuivpe  35.662240    0.160992     624188
29  31.925860  20.086443  ZTF23abuppio  35.728953    0.138072     624188
30  31.916201  20.444067  ZTF23abuqdev  35.732460    0.172873     624188
```

### Exact/inexact searches

By default, the SSO resolver will perform an _inexact_ search, meaning it will return the exact search plus closest matches. The number of closest matches is controlled by the parameter `nmax`, with default `nmax=10`:

```python
r = requests.post(
  'https://fink-portal.org/api/v1/resolver',
  json={
    'resolver': 'ssodnet',
    'name': '33'
  }
)

pdf = pd.read_json(io.BytesIO(r.content))

          i:name  i:number  i:ssnamenr
0     Polyhymnia        33          33
1     Polyhymnia        33          33
2      Adalberta       330         330
3      Adalberta       330         330
4       3300 T-1     17325       17325
5       3300 T-2     69209       69209
6       3300 T-3     79071       79071
7      McGlasson      3300        3300
8      McGlasson      3300        3300
9  Chenjiansheng     33000       33000
```
Note that there are duplicates, as data is indexed by `name`, `number`, and `ssnamenr`.
If you want to perform an _exact_ search, just put `nmax=1`:

```python
r = requests.post(
  'https://fink-portal.org/api/v1/resolver',
  json={
    'resolver': 'ssodnet',
    'name': '33',
    'nmax': 1
  }
)

pdf = pd.read_json(io.BytesIO(r.content))

       i:name  i:number  i:ssnamenr
0  Polyhymnia        33          33
1  Polyhymnia        33          33
```

### ZTF to SSO

I have a ZTF object name, is there a counterpart in the SsODNet quaero database, and what are all the known aliases to Fink?

```python
r = requests.post(
  'https://fink-portal.org/api/v1/resolver',
  json={
    'resolver': 'ssodnet',
    'reverse': True,
    'name': 'ZTF23abidfxt'
  }
)

if r.json() != []:
    name = r.json()[0]['i:ssnamenr']
    print('Asteroid counterpart found with designation {}'.format(name))
    print()

    r2 = requests.post(
      'https://fink-portal.org/api/v1/resolver',
      json={
        'resolver': 'ssodnet',
        'name': name,
        'nmax': 1
      }
    )

    pdf = pd.read_json(io.BytesIO(r2.content))
    print('In the Fink database, {} also corresponds to: '.format(name))
    print(pdf)
```

Leading to:

```
Asteroid counterpart found with designation 624188

In the Fink database, 624188 also corresponds to:
  i:source i:ssnamenr
0    number   2002MA06
1    number    2002MA6
2    number     624188
3  ssnamenr     624188
```