### PR TITLE
Data release photometry for lightcurve panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@
 import dash
 import dash_bootstrap_components as dbc
 from dash.long_callback import DiskcacheLongCallbackManager
+from dash import DiskcacheManager
 
 # import jpype
 
@@ -24,6 +25,7 @@ import diskcache
 
 cache = diskcache.Cache("./cache")
 long_callback_manager = DiskcacheLongCallbackManager(cache)
+background_callback_manager = DiskcacheManager(cache)
 
 args = yaml.load(open('config.yml'), yaml.Loader)
 
@@ -56,7 +58,8 @@ app = factory(
         "name": "viewport",
         "content": "width=device-width, initial-scale=1"
     }],
-    long_callback_manager=long_callback_manager
+    long_callback_manager=long_callback_manager,
+    background_callback_manager=background_callback_manager,
 )
 
 

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -41,7 +41,7 @@ In addition, the _Difference magnitude_ view shows:
 - upper triangles with errors (&#9650;), representing alert measurements that do not satisfy Fink quality cuts, but are nevetheless contained in the history of valid alerts and used by classifiers.
 - lower triangles (&#9661;), representing 5-sigma magnitude limit in difference image based on PSF-fit photometry contained in the history of valid alerts.
 
-If the **Color** switch is turned on, the view also shows the panel with `g - r` color, estimated by combining nearby (closer than 0.3 days) measurements in two filters.
+If the `Color` switch is turned on, the view also shows the panel with `g - r` color, estimated by combining nearby (closer than 0.3 days) measurements in two filters.
 
 ##### DC magnitude
 DC magnitude is computed by combining the nearest reference image catalog magnitude (`magnr`),
@@ -59,7 +59,7 @@ to ensure the source is close enough to be considered an association
 
 The view also shows, with dashed horizontal lines, the levels corresponding to the magnitudes of the nearest reference image catalog entry (`magnr`) used in computing DC magnitudes.
 
-This view may be augmented with the photometric points from [ZTF Data Releases](https://www.ztf.caltech.edu/ztf-public-releases.html) by clicking **Get DR photometry** button. The points will be shown with semi-transparent dots (&#8226;).
+This view may be augmented with the photometric points from [ZTF Data Releases](https://www.ztf.caltech.edu/ztf-public-releases.html) by clicking `Get DR photometry` button. The points will be shown with semi-transparent dots (&#8226;).
 
 ##### DC flux
 DC flux (in Jansky) is constructed from DC magnitude by using the following:

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -101,7 +101,31 @@ def card_lightcurve_summary():
                     )
                 )
             ),
-            help_popover(lc_help, 'help_lc'),
+            dmc.Group(
+                [
+                    dmc.Button(
+                        "Request data release photometry",
+                        id='lightcurve_request_release',
+                        variant="outline",
+                        color='gray',
+                        radius='xl', size='xs',
+                        compact=False,
+                    ),
+                    help_popover(
+                        lc_help,
+                        'help_lc',
+                        trigger=dmc.ActionIcon(
+                            DashIconify(icon="mdi:help"),
+                            id='help_lc',
+                            color='gray',
+                            variant="outline",
+                            radius='xl',
+                            size='md',
+                        )
+                    ),
+                ],
+                position='center',
+            )
         ], radius='xl', p='md', shadow='xl', withBorder=True
     )
     return card

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -41,6 +41,8 @@ In addition, the _Difference magnitude_ view shows:
 - upper triangles with errors (&#9650;), representing alert measurements that do not satisfy Fink quality cuts, but are nevetheless contained in the history of valid alerts and used by classifiers.
 - lower triangles (&#9661;), representing 5-sigma magnitude limit in difference image based on PSF-fit photometry contained in the history of valid alerts.
 
+If the **Color** switch is turned on, the view also shows the panel with `g - r` color, estimated by combining nearby (closer than 0.3 days) measurements in two filters.
+
 ##### DC magnitude
 DC magnitude is computed by combining the nearest reference image catalog magnitude (`magnr`),
 differential magnitude (`magpsf`), and `isdiffpos` (positive or negative difference image detection) as follows:
@@ -106,6 +108,14 @@ def card_lightcurve_summary():
             ),
             dmc.Group(
                 [
+                    dmc.Switch(
+                        "Color",
+                        id='lightcurve_show_color',
+                        color='gray',
+                        radius='xl',
+                        size='sm',
+                        persistence=True
+                    ),
                     dmc.Button(
                         "Get DR photometry",
                         id='lightcurve_request_release',
@@ -129,7 +139,7 @@ def card_lightcurve_summary():
                         )
                     ),
                 ],
-                position='center',
+                position='center', align='center'
             )
         ], radius='xl', p='md', shadow='xl', withBorder=True
     )

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1038,6 +1038,16 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
             figure['layout']['yaxis']['domain'] = [0.35, 1.0]
             figure['layout']['xaxis']['anchor'] = 'free'
 
+            figure['layout']['shapes'].append(
+                {
+                    'type': 'line',
+                    'yref': 'paper', 'y0':0.325, 'y1': 0.325,
+                    'xref': 'paper', 'x0': 0, 'x1': 1,
+                    'line': {'color': 'gray', 'width': 4},
+                    'opacity': 0.1,
+                }
+            )
+
     return figure
 
 @app.callback(

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1001,6 +1001,7 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
         if pdf_ is not None:
             pdf_gr = extract_color(pdf_)
             dates_gr = pdf_gr['i:jd'].apply(lambda x: convert_jd(float(x), to='iso'))
+            color = '#3C8DFF'
 
             figure['data'].append(
                 {
@@ -1012,7 +1013,7 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
                         'visible': True,
                         'width': 0,
                         'opacity': 0.5,
-                        'color': 'black'
+                        'color': color
                     },
                     'mode': 'markers',
                     'name': 'g - r',
@@ -1020,7 +1021,7 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
                     'hovertemplate': hovertemplate_gr,
                     'legendgroup': 'g-r',
                     'marker': {
-                        'color': 'black',
+                        'color': color,
                         'symbol': 'o',
                     },
                     'showlegend': True,

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -788,7 +788,7 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
                 apparent_flux(*args) for args in zip(
                     mag.astype(float).values,
                     err.astype(float).values,
-                    pdf['i:magnr'].astype(float).values if is_dc_corrected else 99.0,
+                    pdf['i:magnr'].astype(float).values if is_dc_corrected else [99.0]*len(pdf.index),
                     pdf['i:sigmagnr'].astype(float).values,
                     pdf['i:isdiffpos'].values
                 )
@@ -1042,7 +1042,7 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
                 {
                     'type': 'line',
                     'yref': 'paper', 'y0':0.325, 'y1': 0.325,
-                    'xref': 'paper', 'x0': 0, 'x1': 1,
+                    'xref': 'paper', 'x0': -0.1, 'x1': 1.05,
                     'line': {'color': 'gray', 'width': 4},
                     'opacity': 0.1,
                 }

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -906,19 +906,21 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
         elif switch == "DC magnitude":
             if is_dc_corrected:
                 # Overplot the levels of nearby source magnitudes
-                ref = np.mean(pdf['i:magnr'][pdf['i:fid'] == fid])
+                idx = pdf['i:fid'] == fid
+                if np.sum(idx):
+                    ref = np.mean(pdf['i:magnr'][idx])
 
-                figure['layout']['shapes'].append(
-                    {
-                        'type': 'line',
-                        'yref': 'y',
-                        'y0': ref, 'y1': ref,   # adding a horizontal line
-                        'xref': 'paper', 'x0': 0, 'x1': 1,
-                        'line': {'color': color, 'dash': 'dash', 'width': 1},
-                        'legendgroup': '{} band'.format(fname),
-                        'opacity': 0.3,
-                    }
-                )
+                    figure['layout']['shapes'].append(
+                        {
+                            'type': 'line',
+                            'yref': 'y',
+                            'y0': ref, 'y1': ref,   # adding a horizontal line
+                            'xref': 'paper', 'x0': 0, 'x1': 1,
+                            'line': {'color': color, 'dash': 'dash', 'width': 1},
+                            'legendgroup': '{} band'.format(fname),
+                            'opacity': 0.3,
+                        }
+                    )
 
             # Data release photometry
             if not pdf_release.empty:

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -35,6 +35,7 @@ from dash.exceptions import PreventUpdate
 
 from apps.utils import convert_jd, readstamp, _data_stretch, convolve
 from fink_utils.photometry.conversion import apparent_flux, dc_mag
+from fink_utils.photometry.utils import is_source_behind
 from apps.utils import sine_fit
 from apps.utils import class_colors
 from apps.statistics import dic_names
@@ -690,9 +691,10 @@ def plot_classbar(object_data):
         Input('url', 'pathname'),
         Input('object-data', 'children'),
         Input('object-upper', 'children'),
-        Input('object-uppervalid', 'children')
+        Input('object-uppervalid', 'children'),
+        Input('object-release', 'children')
     ])
-def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, object_uppervalid) -> dict:
+def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, object_uppervalid, object_release) -> dict:
     """ Draw object lightcurve with errorbars
 
     Parameters
@@ -709,37 +711,65 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
     ----------
     figure: dict
     """
+    # Primary high-quality data points
     pdf_ = pd.read_json(object_data)
     cols = [
-        'i:jd', 'i:magpsf', 'i:sigmapsf', 'i:fid',
+        'i:jd', 'i:magpsf', 'i:sigmapsf', 'i:fid', 'i:distnr',
         'i:magnr', 'i:sigmagnr', 'i:magzpsci', 'i:isdiffpos', 'i:candid'
     ]
     pdf = pdf_.loc[:, cols]
 
+    # Upper limits
+    pdf_upper = pd.read_json(object_upper)
+
+    # Lower-quality data points
+    pdf_upperv = pd.read_json(object_uppervalid)
+
     # type conversion
     dates = pdf['i:jd'].apply(lambda x: convert_jd(float(x), to='iso'))
+    dates_upper = pdf_upper['i:jd'].apply(lambda x: convert_jd(float(x), to='iso'))
+    dates_upperv = pdf_upperv['i:jd'].apply(lambda x: convert_jd(float(x), to='iso'))
+
+    if object_release:
+        # Data release photometry
+        pdf_release = pd.read_json(object_release)
+        dates_release = pdf_release['mjd'].apply(lambda x: convert_jd(float(x)+2400000.5, to='iso'))
+    else:
+        pdf_release = pd.DataFrame()
+
+    # Exclude lower-quality points overlapping higher-quality ones
+    mask = np.in1d(pdf_upperv['i:jd'].values, pdf['i:jd'].values)
+    pdf_upperv,dates_upperv = [_[~mask] for _ in (pdf_upperv,dates_upperv)]
 
     # shortcuts
     mag = pdf['i:magpsf']
     err = pdf['i:sigmapsf']
+
+    # Should we correct DC magnitudes for the nearby source?..
+    is_dc_corrected = is_source_behind(pdf['i:distnr'].values[0])
 
     if switch == "Difference magnitude":
         layout_lightcurve['yaxis']['title'] = 'Difference magnitude'
         layout_lightcurve['yaxis']['autorange'] = 'reversed'
         scale = 1.0
     elif switch == "DC magnitude":
-        # inplace replacement
-        mag, err = np.transpose(
-            [
-                dc_mag(*args) for args in zip(
-                    mag.astype(float).values,
-                    err.astype(float).values,
-                    pdf['i:magnr'].astype(float).values,
-                    pdf['i:sigmagnr'].astype(float).values,
-                    pdf['i:isdiffpos'].values
-                )
-            ]
-        )
+        if is_dc_corrected:
+            # inplace replacement for DC corrected flux
+            mag, err = np.transpose(
+                [
+                    dc_mag(*args) for args in zip(
+                        mag.astype(float).values,
+                        err.astype(float).values,
+                        pdf['i:magnr'].astype(float).values,
+                        pdf['i:sigmagnr'].astype(float).values,
+                        pdf['i:isdiffpos'].values
+                    )
+                ]
+            )
+            # Keep only "good" measurements
+            idx = err < 1
+            pdf, dates, mag, err = [_[idx] for _ in [pdf, dates, mag, err]]
+
         layout_lightcurve['yaxis']['title'] = 'Apparent DC magnitude'
         layout_lightcurve['yaxis']['autorange'] = 'reversed'
         scale = 1.0
@@ -750,178 +780,182 @@ def draw_lightcurve(switch: int, pathname: str, object_data, object_upper, objec
                 apparent_flux(*args) for args in zip(
                     mag.astype(float).values,
                     err.astype(float).values,
-                    pdf['i:magnr'].astype(float).values,
+                    pdf['i:magnr'].astype(float).values if is_dc_corrected else 99.0,
                     pdf['i:sigmagnr'].astype(float).values,
                     pdf['i:isdiffpos'].values
                 )
             ]
         )
+
         layout_lightcurve['yaxis']['title'] = 'Apparent DC flux (milliJansky)'
         layout_lightcurve['yaxis']['autorange'] = True
         scale = 1e3
 
-    hovertemplate = r"""
-    <b>%{yaxis.title.text}</b>: %{customdata[1]}%{y:.2f} &plusmn; %{error_y.array:.2f}<br>
-    <b>%{xaxis.title.text}</b>: %{x|%Y/%m/%d %H:%M:%S.%L}<br>
-    <b>mjd</b>: %{customdata[0]}
-    <extra></extra>
-    """
+    layout_lightcurve['shapes'] = []
+
     figure = {
-        'data': [
-            {
-                'x': dates[pdf['i:fid'] == 1],
-                'y': mag[pdf['i:fid'] == 1] * scale,
-                'error_y': {
-                    'type': 'data',
-                    'array': err[pdf['i:fid'] == 1] * scale,
-                    'visible': True,
-                    'color': COLORS_ZTF[0]
-                },
-                'mode': 'markers',
-                'name': 'g band',
-                'customdata': np.stack(
-                    (
-                        pdf['i:jd'].apply(lambda x: x - 2400000.5)[pdf['i:fid'] == 1],
-                        pdf['i:isdiffpos'].apply(lambda x: '(-) ' if x == 'f' else '')[pdf['i:fid'] == 1],
-                    ), axis=-1
-                ),
-                'hovertemplate': hovertemplate,
-                "legendgroup": "g band",
-                'legendrank': 110,
-                'marker': {
-                    'size': 12,
-                    'color': COLORS_ZTF[0],
-                    'symbol': 'o'}
-            },
-            {
-                'x': dates[pdf['i:fid'] == 2],
-                'y': mag[pdf['i:fid'] == 2] * scale,
-                'error_y': {
-                    'type': 'data',
-                    'array': err[pdf['i:fid'] == 2] * scale,
-                    'visible': True,
-                    'color': COLORS_ZTF[1]
-                },
-                'mode': 'markers',
-                'name': 'r band',
-                'legendrank': 120,
-                'customdata':  np.stack(
-                    (
-                        pdf['i:jd'].apply(lambda x: x - 2400000.5)[pdf['i:fid'] == 2],
-                        pdf['i:isdiffpos'].apply(lambda x: '(-) ' if x == 'f' else '')[pdf['i:fid'] == 2],
-                    ), axis=-1
-                ),
-                'hovertemplate': hovertemplate,
-                "legendgroup": "r band",
-                'marker': {
-                    'size': 12,
-                    'color': COLORS_ZTF[1],
-                    'symbol': 'o'}
-            }
-        ],
+        'data': [],
         "layout": layout_lightcurve
     }
 
-    if switch == "Difference magnitude":
-        pdf_upper = pd.read_json(object_upper)
-        # <b>candid</b>: %{customdata[0]}<br> not available in index tables...
-        hovertemplate_upper = r"""
-        <b>Upper limit</b>: %{y:.2f}<br>
+    for fid,fname,color in (
+            (1, "g", COLORS_ZTF[0]),
+            (2, "r", COLORS_ZTF[1])
+    ):
+        # High-quality measurements
+        hovertemplate = r"""
+        <b>%{yaxis.title.text}</b>: %{customdata[1]}%{y:.2f} &plusmn; %{error_y.array:.2f}<br>
         <b>%{xaxis.title.text}</b>: %{x|%Y/%m/%d %H:%M:%S.%L}<br>
-        <b>mjd</b>: %{customdata}
+        <b>mjd</b>: %{customdata[0]}
         <extra></extra>
         """
-        if not pdf_upper.empty:
-            dates2 = pdf_upper['i:jd'].apply(lambda x: convert_jd(float(x), to='iso'))
-            figure['data'].append(
-                {
-                    'x': dates2[pdf_upper['i:fid'] == 1],
-                    'y': pdf_upper['i:diffmaglim'][pdf_upper['i:fid'] == 1],
-                    'mode': 'markers',
-                    'name': '',
-                    'customdata': pdf_upper['i:jd'].apply(lambda x: x - 2400000.5)[pdf_upper['i:fid'] == 1],
-                    'hovertemplate': hovertemplate_upper,
-                    "legendgroup": "g band upper",
-                    'legendrank': 111,
-                    'marker': {
-                        'color': COLORS_ZTF[0],
-                        'symbol': 'triangle-down-open'
-                    },
-                    # 'showlegend': False
-                }
-            )
-            figure['data'].append(
-                {
-                    'x': dates2[pdf_upper['i:fid'] == 2],
-                    'y': pdf_upper['i:diffmaglim'][pdf_upper['i:fid'] == 2],
-                    'mode': 'markers',
-                    'name': '',
-                    'customdata': pdf_upper['i:jd'].apply(lambda x: x - 2400000.5)[pdf_upper['i:fid'] == 2],
-                    'hovertemplate': hovertemplate_upper,
-                    "legendgroup": "r band upper",
-                    'legendrank': 121,
-                    'marker': {
-                        'color': COLORS_ZTF[1],
-                        'symbol': 'triangle-down-open'
-                    },
-                    # 'showlegend': False
-                }
-            )
-        pdf_upperv = pd.read_json(object_uppervalid)
-        # <b>candid</b>: %{customdata[0]}<br> not available in index tables...
-        hovertemplate_upperv = r"""
-        <b>%{yaxis.title.text} (low quality)</b>: %{y:.2f} &plusmn; %{error_y.array:.2f}<br>
-        <b>%{xaxis.title.text}</b>: %{x|%Y/%m/%d %H:%M:%S.%L}<br>
-        <b>mjd</b>: %{customdata}
-        <extra></extra>
-        """
-        if not pdf_upperv.empty:
-            dates2 = pdf_upperv['i:jd'].apply(lambda x: convert_jd(float(x), to='iso'))
-            mask = np.array([False if i in pdf['i:jd'].values else True for i in pdf_upperv['i:jd'].values])
-            dates2 = dates2[mask]
-            pdf_upperv = pdf_upperv[mask]
-            figure['data'].append(
-                {
-                    'x': dates2[pdf_upperv['i:fid'] == 1],
-                    'y': pdf_upperv['i:magpsf'][pdf_upperv['i:fid'] == 1],
-                    'error_y': {
-                        'type': 'data',
-                        'array': pdf_upperv['i:sigmapsf'][pdf_upperv['i:fid'] == 1],
-                        'visible': True,
-                        'color': COLORS_ZTF[0]
-                    },
-                    'mode': 'markers',
-                    'customdata': pdf_upperv['i:jd'].apply(lambda x: x - 2400000.5)[pdf_upperv['i:fid'] == 1],
-                    'hovertemplate': hovertemplate_upperv,
-                    "legendgroup": "g band",
-                    'marker': {
-                        'color': COLORS_ZTF[0],
-                        'symbol': 'triangle-up'
-                    },
-                    'showlegend': False
-                }
-            )
-            figure['data'].append(
-                {
-                    'x': dates2[pdf_upperv['i:fid'] == 2],
-                    'y': pdf_upperv['i:magpsf'][pdf_upperv['i:fid'] == 2],
-                    'error_y': {
-                        'type': 'data',
-                        'array': pdf_upperv['i:sigmapsf'][pdf_upperv['i:fid'] == 2],
-                        'visible': True,
-                        'color': COLORS_ZTF[1]
-                    },
-                    'mode': 'markers',
-                    'customdata': pdf_upperv['i:jd'].apply(lambda x: x - 2400000.5)[pdf_upperv['i:fid'] == 2],
-                    'hovertemplate': hovertemplate_upperv,
-                    "legendgroup": "r band",
-                    'marker': {
-                        'color': COLORS_ZTF[1],
-                        'symbol': 'triangle-up'
-                    },
-                    'showlegend': False
-                }
-            )
+        idx = pdf['i:fid'] == fid
+        figure['data'].append(
+            {
+                'x': dates[idx],
+                'y': mag[idx] * scale,
+                'error_y': {
+                    'type': 'data',
+                    'array': err[idx] * scale,
+                    'visible': True,
+                    'width': 0,
+                    'opacity': 0.5,
+                    'color': color
+                },
+                'mode': 'markers',
+                'name': '{} band'.format(fname),
+                'customdata': np.stack(
+                    (
+                        pdf['i:jd'].apply(lambda x: x - 2400000.5)[idx],
+                        pdf['i:isdiffpos'].apply(lambda x: '(-) ' if x == 'f' else '')[idx],
+                    ), axis=-1
+                ),
+                'hovertemplate': hovertemplate,
+                "legendgroup": "{} band".format(fname),
+                'legendrank': 100 + 10*fid,
+                'marker': {
+                    'size': 12,
+                    'color': color,
+                    'symbol': 'o'}
+            }
+        )
+
+        if switch == "Difference magnitude":
+            # Upper limits
+            if not pdf_upper.empty:
+                # <b>candid</b>: %{customdata[0]}<br> not available in index tables...
+                hovertemplate_upper = r"""
+                <b>Upper limit</b>: %{y:.2f}<br>
+                <b>%{xaxis.title.text}</b>: %{x|%Y/%m/%d %H:%M:%S.%L}<br>
+                <b>mjd</b>: %{customdata}
+                <extra></extra>
+                """
+                idx = pdf_upper['i:fid'] == fid
+                figure['data'].append(
+                    {
+                        'x': dates_upper[idx],
+                        'y': pdf_upper['i:diffmaglim'][idx],
+                        'mode': 'markers',
+                        'name': '',
+                        'customdata': pdf_upper['i:jd'].apply(lambda x: x - 2400000.5)[idx],
+                        'hovertemplate': hovertemplate_upper,
+                        "legendgroup": "{} band upper".format(fname),
+                        'legendrank': 101 + 10*fid,
+                        'marker': {
+                            'color': color,
+                            'symbol': 'triangle-down-open'
+                        },
+                        # 'showlegend': False
+                    }
+                )
+
+            # Lower-quality data points
+            if not pdf_upperv.empty:
+                # <b>candid</b>: %{customdata[0]}<br> not available in index tables...
+                hovertemplate_upperv = r"""
+                <b>%{yaxis.title.text} (low quality)</b>: %{y:.2f} &plusmn; %{error_y.array:.2f}<br>
+                <b>%{xaxis.title.text}</b>: %{x|%Y/%m/%d %H:%M:%S.%L}<br>
+                <b>mjd</b>: %{customdata}
+                <extra></extra>
+                """
+                idx = pdf_upperv['i:fid'] == fid
+                figure['data'].append(
+                    {
+                        'x': dates_upperv[idx],
+                        'y': pdf_upperv['i:magpsf'][idx],
+                        'error_y': {
+                            'type': 'data',
+                            'array': pdf_upperv['i:sigmapsf'][idx],
+                            'visible': True,
+                            'width': 0,
+                            'opacity': 0.5,
+                            'color': color
+                        },
+                        'mode': 'markers',
+                        'customdata': pdf_upperv['i:jd'].apply(lambda x: x - 2400000.5)[idx],
+                        'hovertemplate': hovertemplate_upperv,
+                        "legendgroup": "{} band".format(fname),
+                        'marker': {
+                            'color': color,
+                            'symbol': 'triangle-up'
+                        },
+                        'showlegend': False
+                    }
+                )
+
+        elif switch == "DC magnitude":
+            if is_dc_corrected:
+                # Overplot the levels of nearby source magnitudes
+                ref = np.mean(pdf['i:magnr'][pdf['i:fid'] == fid])
+
+                figure['layout']['shapes'].append(
+                    {
+                        'type': 'line',
+                        'yref': 'y',
+                        'y0': ref, 'y1': ref,   # adding a horizontal line
+                        'xref': 'paper', 'x0': 0, 'x1': 1,
+                        'line': {'color': color, 'dash': 'dash', 'width': 1},
+                        'legendgroup': '{} band'.format(fname),
+                        'opacity': 0.3,
+                    }
+                )
+
+            # Data release photometry
+            if not pdf_release.empty:
+                hovertemplate_release = r"""
+                <b>Data release magnitude</b>: %{y:.2f} &plusmn; %{error_y.array:.2f}<br>
+                <b>%{xaxis.title.text}</b>: %{x|%Y/%m/%d %H:%M:%S.%L}<br>
+                <b>mjd</b>: %{customdata}
+                <extra></extra>
+                """
+                idx = pdf_release['filtercode'] == 'z' + fname
+                figure['data'].append(
+                    {
+                        'x': dates_release[idx],
+                        'y': pdf_release['mag'][idx],
+                        'error_y': {
+                            'type': 'data',
+                            'array': pdf_release['magerr'][idx],
+                            'visible': True,
+                            'width': 0,
+                            'opacity': 0.5,
+                            'color': color
+                        },
+                        'mode': 'markers',
+                        'name': '',
+                        'customdata': pdf_release['mjd'][idx],
+                        'hovertemplate': hovertemplate_release,
+                        "legendgroup": "{} band release".format(fname),
+                        'legendrank': 102 + 10*fid,
+                        'marker': {
+                            'color': color,
+                            'symbol': '.'
+                        },
+                        'opacity': 0.5,
+                        # 'showlegend': False
+                    }
+                )
+
     return figure
 
 @app.callback(

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -587,6 +587,7 @@ def store_query(name):
     [
         Output('object-release', 'children'),
         Output('lightcurve_request_release', 'children'),
+        Output('switch-mag-flux', 'value'),
     ],
     Input('lightcurve_request_release', 'n_clicks'),
     State('object-data', 'children'),
@@ -618,14 +619,14 @@ def store_release_photometry(n_clicks, object_data):
         if not pdf_release.empty:
             pdf_release = pdf_release[['mjd', 'mag', 'magerr', 'filtercode']]
 
-            return pdf_release.to_json(), "DR photometry: {} points".format(len(pdf_release.index))
+            return pdf_release.to_json(), "DR photometry: {} points".format(len(pdf_release.index)), 'DC magnitude'
 
     except:
         import traceback
         traceback.print_exc()
         pass
 
-    return no_update, "No DR photometry"
+    return no_update, "No DR photometry", no_update
 
 @app.callback(
     Output('qrcode', 'children'),

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -67,7 +67,7 @@ def tab1_content(pdf):
     distnr = pdf['i:distnr'].values[0]
     if is_source_behind(distnr):
         extra_div = dbc.Alert(
-            "It looks like there is a source behind, at {:.1f} arcsec. You might want to check the DC magnitude instead.".format(distnr),
+            "It looks like there is a source behind, at {:.1f} arcsec. You might want to check the DC magnitude, and get DR photometry to see its long-term behaviour.".format(distnr),
             dismissable=True,
             is_open=True,
             color="light"
@@ -612,7 +612,7 @@ def store_release_photometry(n_clicks, object_data):
             'https://irsa.ipac.caltech.edu/cgi-bin/ZTF/nph_light_curves?POS=CIRCLE%20{}%20{}%20{}&BAD_CATFLAGS_MASK=32768&FORMAT=CSV'.format(
                 mean_ra,
                 mean_dec,
-                2/3600
+                2.0/3600
             )
         )
 

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import dash
-from dash import html, dcc, Input, Output, State
+from dash import html, dcc, Input, Output, State, no_update
 from dash.exceptions import PreventUpdate
 
 import dash_bootstrap_components as dbc
@@ -60,9 +60,21 @@ from app import APIURL
 
 dcc.Location(id='url', refresh=False)
 
-def tab1_content(pdf, extra_div):
+def tab1_content(pdf):
     """ Summary tab
     """
+
+    distnr = pdf['i:distnr'].values[0]
+    if is_source_behind(distnr):
+        extra_div = dbc.Alert(
+            "It looks like there is a source behind, at {:.1f} arcsec. You might want to check the DC magnitude instead.".format(distnr),
+            dismissable=True,
+            is_open=True,
+            color="light"
+        )
+    else:
+        extra_div = html.Div()
+
     tab1_content_ = html.Div([
         dmc.Space(h=10),
         dbc.Row(
@@ -80,10 +92,21 @@ def tab1_content(pdf, extra_div):
                 ),
             ], justify='around'
         ),
-        dbc.Row([
-            dbc.Col([extra_div, loading(card_lightcurve_summary())], md=8),
-            dbc.Col(card_id(pdf), md=4)
-        ], className='g-1'),
+        dbc.Row(
+            [
+                dbc.Col(
+                    [
+                        extra_div,
+                        loading(card_lightcurve_summary())
+                    ],
+                    md=8
+                ),
+                dbc.Col(
+                    card_id(pdf),
+                    md=4
+                )
+            ], className='g-1'
+        ),
     ])
 
     out = tab1_content_
@@ -408,30 +431,20 @@ def tab6_content(object_tracklet):
     return tab6_content_
 
 def tabs(pdf):
-    distnr = pdf['i:distnr'].values[0]
-    if is_source_behind(distnr):
-        extra_div = dbc.Alert(
-            "It looks like there is a source behind. You might want to check the DC magnitude instead.",
-            dismissable=True,
-            is_open=True,
-            color="light"
-        )
-    else:
-        extra_div = html.Div()
     tabs_ = dmc.Tabs(
         [
             dmc.TabsList(
                 [
                     dmc.Tab("Summary", value="Summary"),
-                    dmc.Tab("Supernovae", value="Supernovae"),
-                    dmc.Tab("Variable stars", value="Variable stars"),
-                    dmc.Tab("Microlensing", value="Microlensing"),
+                    dmc.Tab("Supernovae", value="Supernovae", disabled=len(pdf.index) == 1),
+                    dmc.Tab("Variable stars", value="Variable stars", disabled=len(pdf.index) == 1),
+                    dmc.Tab("Microlensing", value="Microlensing", disabled=len(pdf.index) == 1),
                     dmc.Tab("Solar System", value="Solar System", disabled=not is_sso(pdf)),
                     dmc.Tab("Tracklets", value="Tracklets", disabled=not is_tracklet(pdf)),
                     dmc.Tab("GRB", value="GRB", disabled=True)
                 ], position='right'
             ),
-            dmc.TabsPanel(tab1_content(pdf, extra_div), value="Summary"),
+            dmc.TabsPanel(tab1_content(pdf), value="Summary"),
             dmc.TabsPanel(tab2_content(), value="Supernovae"),
             dmc.TabsPanel(tab3_content(), value="Variable stars"),
             dmc.TabsPanel(tab4_content(), value="Microlensing"),
@@ -567,7 +580,40 @@ def store_query(name):
         pdftracklet = pd.read_json(r.content)
     else:
         pdftracklet = pd.DataFrame()
+
     return pdfs.to_json(), pdfsU.to_json(), pdfsUV.to_json(), pdfsso.to_json(), pdftracklet.to_json()
+
+@app.callback(
+    Output('object-release', 'children'),
+    Input('lightcurve_request_release', 'n_clicks'),
+    State('object-data', 'children'),
+    prevent_initial_call=True,
+    background=True,
+    running=[
+        (Output('lightcurve_request_release', 'disabled'), True, False),
+        (Output('lightcurve_request_release', 'loading'), True, False),
+        # (Output('lightcurve_request_release', 'children'), 'Requesting data release photometry...', 'Data release photometry requested'),
+    ],
+)
+def store_release_photometry(n_clicks, object_data):
+    if not n_clicks or not object_data:
+        return no_update
+
+    pdf = pd.read_json(object_data)
+
+    mean_ra = np.mean(pdf['i:ra'])
+    mean_dec = np.mean(pdf['i:dec'])
+
+    pdf_release = pd.read_csv(
+        'https://irsa.ipac.caltech.edu/cgi-bin/ZTF/nph_light_curves?POS=CIRCLE%20{}%20{}%20{}&BAD_CATFLAGS_MASK=32768&FORMAT=CSV'.format(
+            mean_ra,
+            mean_dec,
+            2/3600
+        )
+    )
+    pdf_release = pdf_release[['mjd', 'mag', 'magerr', 'filtercode']]
+
+    return pdf_release.to_json()
 
 @app.callback(
     Output('qrcode', 'children'),
@@ -640,6 +686,7 @@ def layout(name):
                 html.Div(id='object-uppervalid', style={'display': 'none'}),
                 html.Div(id='object-sso', style={'display': 'none'}),
                 html.Div(id='object-tracklet', style={'display': 'none'}),
+                html.Div(id='object-release', style={'display': 'none'}),
             ], className='bg-opaque-90'
         )
 

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -560,6 +560,50 @@ def extract_delta_color(pdf: pd.DataFrame, filter_: int):
 
     return vec, rate
 
+def extract_color(pdf: pd.DataFrame, tolerance: float = 0.3, colnames=None):
+    """ Extract g-r values for single object a pandas DataFrame
+
+    Parameters
+    ----------
+    pdf: pandas DataFrame
+        DataFrame containing alert parameters from an API call
+    tolerance: float
+        Maximal distance in days between data points to be associated
+    colnames: list
+        List of extra column names to keep in the output.
+
+    Returns
+    ----------
+    pdf_gr: pandas DataFrame
+        DataFrame containing the time and magnitudes of matched points,
+        along with g-r color and its error
+    """
+    if colnames is None:
+        colnames = ['i:jd', 'i:magpsf', 'i:sigmapsf']
+    else:
+        colnames = ['i:jd', 'i:magpsf', 'i:sigmapsf'] + colnames
+        colnames = list(np.unique(colnames))
+
+    pdf_g = pdf[pdf['i:fid'] == 1][colnames]
+    pdf_r = pdf[pdf['i:fid'] == 2][colnames]
+
+    # merge_asof expects sorted data
+    pdf_g = pdf_g.sort_values('i:jd')
+    pdf_r = pdf_r.sort_values('i:jd')
+
+    # As merge_asof does not keep the second jd column - let's make it manually
+    pdf_g['v:mjd'] = pdf_g['i:jd'] - 2400000.5
+    pdf_r['v:mjd'] = pdf_r['i:jd'] - 2400000.5
+
+    pdf_gr = pd.merge_asof(pdf_g, pdf_r, on='i:jd', suffixes=('_g', '_r'), direction='nearest', tolerance=0.3)
+    pdf_gr = pdf_gr[~pdf_gr.isna()['i:magpsf_r']] # Keep only matched rows
+
+    pdf_gr['v:g-r'] = pdf_gr['i:magpsf_g'] - pdf_gr['i:magpsf_r']
+    pdf_gr['v:sigma_g-r'] = np.hypot(pdf_gr['i:sigmapsf_g'], pdf_gr['i:sigmapsf_r'])
+    pdf_gr['v:delta_jd'] = pdf_gr['v:mjd_g'] - pdf_gr['v:mjd_r']
+
+    return pdf_gr
+
 def queryMPC(number, kind='asteroid'):
     """Query MPC for information about object 'designation'.
 


### PR DESCRIPTION
Adds an option to request and display the photometry from ZTF data releases (IRSA archive) in the DC magnitudes tab of lightcurve panel. Also, shows the levels of magnr in the same tab, to be able to quickly see how much alert points actually deviate from it. The lines are not toggleable, as Plotly does not support it yet (implemented through shapes, not traces). These line plotting, and DC mag conversion in general, happen only when the nearest object is close enough (1.5 arcsec by default), i.e. when the alert is shown. The resulting DC magnitudes are also filtered to hide the points with errors exceeding 1 mag (basically, not measured), in order to make the plot more resistant to bad quality points.
Finally, some cleanup and visual simplification (e.g. removal of errorbar caps, and making errorbars slightly transparent, to make plots with many points a mit less messy) of the lightcurve plotting.
<img width="673" alt="Screenshot 2023-12-22 at 4 02 19" src="https://github.com/astrolabsoftware/fink-science-portal/assets/6555548/88d13c84-493a-4d89-a0f2-bc77955b7d6e">
