### PR TITLE
Cross-zoom for the Supernova tab

### DIFF
--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1700,10 +1700,11 @@ def draw_t2(object_data) -> dict:
     Output('colors', 'figure'),
     [
         Input('object-data', 'data'),
+        Input('lightcurve_scores', 'relayoutData')
     ],
     prevent_initial_call=True
 )
-def draw_color(object_data) -> dict:
+def draw_color(object_data, relayout_data) -> dict:
     """ Draw color evolution
 
     Returns
@@ -1711,6 +1712,8 @@ def draw_color(object_data) -> dict:
     figure: dict
     """
     pdf = pd.read_json(object_data)
+
+    layout_session = update_xaxis_for_zoom(relayout_data, layout_colors)
 
     # type conversion
     dates = convert_jd(pdf['i:jd'])
@@ -1748,7 +1751,7 @@ def draw_color(object_data) -> dict:
                 }
             },
         ],
-        "layout": layout_colors
+        "layout": layout_session
     }
     return figure
 
@@ -1756,10 +1759,11 @@ def draw_color(object_data) -> dict:
     Output('colors_rate', 'figure'),
     [
         Input('object-data', 'data'),
+        Input('lightcurve_scores', 'relayoutData')
     ],
     prevent_initial_call=True
 )
-def draw_color_rate(object_data) -> dict:
+def draw_color_rate(object_data, relayout_data) -> dict:
     """ Draw color rate
 
     Returns
@@ -1769,6 +1773,8 @@ def draw_color_rate(object_data) -> dict:
     TODO: memoise me
     """
     pdf = pd.read_json(object_data)
+
+    layout_session = update_xaxis_for_zoom(relayout_data, layout_colors_rate)
 
     # type conversion
     dates = convert_jd(pdf['i:jd'])
@@ -1862,7 +1868,7 @@ def draw_color_rate(object_data) -> dict:
                 }
             },
         ],
-        "layout": layout_colors_rate
+        "layout": layout_session
     }
     return figure
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -40,6 +40,7 @@ from fink_utils.photometry.utils import is_source_behind
 from apps.utils import sine_fit
 from apps.utils import class_colors
 from apps.utils import request_api
+from apps.utils import update_xaxis_for_zoom
 from apps.statistics import dic_names
 
 from fink_utils.sso.spins import func_hg, func_hg12, func_hg1g2, func_hg1g2_with_spin
@@ -1498,11 +1499,7 @@ def draw_scores(object_data, relayout_data) -> dict:
 
     TODO: memoise me
     """
-    layout_scores_session = copy.deepcopy(layout_scores)
-    layout_scores_session["xaxis"]["range"] = [
-        relayout_data["xaxis.range[0]"],
-        relayout_data["xaxis.range[1]"]
-    ]
+    layout_session = update_xaxis_for_zoom(relayout_data, layout_scores)
 
     pdf = pd.read_json(object_data)
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1485,10 +1485,11 @@ def draw_lightcurve_preview(name) -> dict:
     Output('scores', 'figure'),
     [
         Input('object-data', 'data'),
+        Input('lightcurve_scores', 'relayoutData')
     ],
     prevent_initial_call=True
 )
-def draw_scores(object_data) -> dict:
+def draw_scores(object_data, relayout_data) -> dict:
     """ Draw scores from SNN module
 
     Returns
@@ -1497,6 +1498,12 @@ def draw_scores(object_data) -> dict:
 
     TODO: memoise me
     """
+    layout_scores_session = copy.deepcopy(layout_scores)
+    layout_scores_session["xaxis"]["range"] = [
+        relayout_data["xaxis.range[0]"],
+        relayout_data["xaxis.range[1]"]
+    ]
+
     pdf = pd.read_json(object_data)
 
     # type conversion
@@ -1574,7 +1581,7 @@ def draw_scores(object_data) -> dict:
                     'symbol': 'diamond'}
             }
         ],
-        "layout": layout_scores
+        "layout": layout_scores_session
     }
     return figure
 

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1578,7 +1578,7 @@ def draw_scores(object_data, relayout_data) -> dict:
                     'symbol': 'diamond'}
             }
         ],
-        "layout": layout_scores_session
+        "layout": layout_session
     }
     return figure
 

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -805,3 +805,29 @@ def help_popover(text, id, trigger=None, className=None):
             ),
         ], className=className
     )
+
+def update_xaxis_for_zoom(relayout_data, layout):
+    """ Update the xaxis bounds in layout based on relayout data fromm a graph
+
+    Parameters
+    ----------
+    relayout_data: dict
+        Graph attribute containing e.g. axes bounds
+    layout: dict
+        Layout for a Graph object
+
+    Returns
+    ----------
+    layout: dict
+        Updated (copy) layout with new xaxis bounds
+    """
+    if 'xaxis.range[0]' in relayout_data:
+        layout_session = copy.deepcopy(layout)
+        layout_session["xaxis"]["range"] = [
+            relayout_data["xaxis.range[0]"],
+            relayout_data["xaxis.range[1]"]
+        ]
+    else:
+         layout_session = layout
+
+    return layout

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -17,6 +17,7 @@ import numpy as np
 import pandas as pd
 import gzip
 import io
+import copy
 import requests
 import base64
 import yaml

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -819,7 +819,7 @@ def update_xaxis_for_zoom(relayout_data, layout):
 
     Returns
     ----------
-    layout: dict
+    layout_session: dict
         Updated (copy) layout with new xaxis bounds
     """
     if 'xaxis.range[0]' in relayout_data:
@@ -831,4 +831,4 @@ def update_xaxis_for_zoom(relayout_data, layout):
     else:
          layout_session = layout
 
-    return layout
+    return layout_session


### PR DESCRIPTION
Closes #560 

For the Supernova profile, we now synchronize any x-axis zoom on the lightcurve with the ML score, color, and rate graphs (zoom & de-zoom). Note that the reverse does not work here (i.e. zooming on the color graph does not apply zoom on the lightcurve), although it can be added if need be (but one-way is enough?).