### PR TITLE
Clientside linked zoom (x axis only) for SN plots

### DIFF
--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1718,14 +1718,15 @@ def draw_color(object_data) -> dict:
     <extra></extra>
     """
     color = '#3C8DFF'
+    idx = pdf['i:fid'] == 1 # Show colors at g points only
     figure = {
         'data': [
             {
-                'x': dates,
-                'y': pdf['v:g-r'],
+                'x': dates[idx],
+                'y': pdf['v:g-r'][idx],
                 'error_y': {
                     'type': 'data',
-                    'array': pdf['v:sigma(g-r)'],
+                    'array': pdf['v:sigma(g-r)'][idx],
                     'visible': True,
                     'width': 0,
                     'color': color,
@@ -1780,11 +1781,11 @@ def draw_color_rate(object_data) -> dict:
     figure = {
         'data': [
             {
-                'x': dates,
-                'y': pdf['v:rate(g-r)'],
+                'x': dates[m1],
+                'y': pdf['v:rate(g-r)'][m1],
                 'error_y': {
                     'type': 'data',
-                    'array': pdf['v:sigma(rate(g-r))'],
+                    'array': pdf['v:sigma(rate(g-r))'][m1],
                     'visible': True,
                     'width': 0,
                     'color': '#3C8DFF',
@@ -1794,8 +1795,8 @@ def draw_color_rate(object_data) -> dict:
                 'name': 'rate g-r (mag/day)',
                 'customdata': list(
                     zip(
-                        ['rate(g - r)'] * len(pdf['i:jd']),
-                        pdf['i:jd'] - 2400000.5,
+                        ['rate(g - r)'] * len(pdf['i:jd'][m1]),
+                        pdf['i:jd'][m1] - 2400000.5,
                     )
                 ),
                 'hovertemplate': hovertemplate_rate,
@@ -1882,9 +1883,11 @@ function linked_zoom_xaxis() {
 
     for(i = 0; i < Nfigs; i++) {
         var figure_state = arguments[2*i + 1];
+        if (figure_state === undefined)
+            continue;
         figure_state = JSON.parse(JSON.stringify(figure_state));
 
-        if ('xaxis.autorange' in relayout) {
+        if ('xaxis.autorange' in relayout || 'autosize' in relayout) {
             figure_state['layout']['xaxis']['autorange'] = true;
             figure_state['layout']['yaxis']['autorange'] = true;
         } else if ('xaxis.range[0]' in relayout){

--- a/apps/supernovae/cards.py
+++ b/apps/supernovae/cards.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from dash import html, dcc, dash_table, Input, Output, State
+from dash import html, dcc, dash_table, Input, Output, State, callback_context
 import dash_mantine_components as dmc
 import dash_bootstrap_components as dbc
 
@@ -137,11 +137,14 @@ def card_sn_scores() -> html.Div:
     Output("card_sn_properties", "children"),
     [
         Input('lightcurve_scores', 'clickData'),
+        Input('scores', 'clickData'),
+        Input('colors', 'clickData'),
+        Input('colors_rate', 'clickData'),
         Input('object-data', 'data'),
     ],
     prevent_initial_call=True
 )
-def card_sn_properties(clickData, object_data):
+def card_sn_properties(clickData1, clickData2, clickData3, clickData4, object_data):
     """ Add an element containing SN alert data (right side of the page)
 
     The element is updated when the the user click on the point in the lightcurve
@@ -167,6 +170,19 @@ def card_sn_properties(clickData, object_data):
 
     pdf = pd.read_json(object_data)
     pdf = pdf.sort_values('i:jd', ascending=False)
+
+    # Which graph was clicked, if any?
+    triggered_id = callback_context.triggered[0]["prop_id"].split(".")[0]
+    if triggered_id == 'lightcurve_scores':
+        clickData = clickData1
+    elif triggered_id == 'scores':
+        clickData = clickData2
+    elif triggered_id == 'colors':
+        clickData = clickData3
+    elif triggered_id == 'colors_rate':
+        clickData = clickData4
+    else:
+        clickData = None
 
     if clickData is not None:
         time0 = clickData['points'][0]['x']


### PR DESCRIPTION
Fixes #560 , and is a client-side alternative to #564 
Does not take into account T2 plots (I never saw one, so don't know whether they are even relevant)