### PR TITLE
Stricter checks on alert columns

### DIFF
--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -913,6 +913,22 @@ def columns_arguments():
         }, ignore_index=True
     )
 
+    ztf_candidate = ztf_candidate._append(
+        {
+            "name": "fink_broker_version",
+            "type": "string",
+            "doc": "Fink broker (fink-broker) version used to process the data"
+        }, ignore_index=True
+    )
+
+    ztf_candidate = ztf_candidate._append(
+        {
+            "name": "fink_science_version",
+            "type": "string",
+            "doc": "Science modules (fink-science) version used to process the data"
+        }, ignore_index=True
+    )
+
     ztf_cutouts = pd.DataFrame.from_dict(
         [
             {

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -968,6 +968,8 @@ def columns_arguments():
             {'name': 'mangrove_2MASS_name', 'type': 'string', 'doc': '2MASS source designation of closest source from Mangrove catalog; if exists within 1 arcmin.'},
             {'name': 'mangrove_lum_dist', 'type': 'string', 'doc': 'Luminosity distance of closest source from Mangrove catalog; if exists within 1 arcmin.'},
             {'name': 'mangrove_ang_dist', 'type': 'string', 'doc': 'Angular distance of closest source from Mangrove catalog; if exists within 1 arcmin.'},
+            {'name': 'spicy_id', 'type': 'string', 'doc': 'Unique source designation of closest source from SPICY catalog; if exists within 1.2 arcsec.'},
+            {'name': 'spicy_class', 'type': 'string', 'doc': 'Class name of closest source from SPICY catalog; if exists within 1.2 arcsec.'},
             {'name': 'mulens', 'type': 'double', 'doc': 'Probability score of an alert to be a microlensing event by [LIA](https://github.com/dgodinez77/LIA).'},
             {'name': 'rf_snia_vs_nonia', 'type': 'double', 'doc': 'Probability of an alert to be a SNe Ia using a Random Forest Classifier (binary classification). Higher is better.'},
             {'name': 'rf_kn_vs_nonkn', 'type': 'double', 'doc': 'Probability of an alert to be a Kilonova using a PCA & Random Forest Classifier (binary classification). Higher is better.'},

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -943,15 +943,35 @@ def columns_arguments():
             {'name': 'cdsxmatch', 'type': 'string', 'doc': 'Object type of the closest source from SIMBAD database; if exists within 1 arcsec. See https://fink-portal.org/api/v1/classes'},
             {'name': 'gcvs', 'type': 'string', 'doc': 'Object type of the closest source from GCVS catalog; if exists within 1 arcsec.'},
             {'name': 'vsx', 'type': 'string', 'doc': 'Object type of the closest source from VSX catalog; if exists within 1 arcsec.'},
+            {'name': 'DR3Name', 'type': 'string', 'doc': 'Unique source designation of closest source from Gaia catalog; if exists within 1 arcsec.'},
             {'name': 'Plx', 'type': 'double', 'doc': 'Absolute stellar parallax (in milli-arcsecond) of the closest source from Gaia catalog; if exists within 1 arcsec.'},
             {'name': 'e_Plx', 'type': 'double', 'doc': 'Standard error of the stellar parallax (in milli-arcsecond) of the closest source from Gaia catalog; if exists within 1 arcsec.'},
-            {'name': 'DR3Name', 'type': 'string', 'doc': 'Unique source designation of closest source from Gaia catalog; if exists within 1 arcsec.'},
+            {'name': 'x3hsp', 'type': 'string', 'doc': 'Counterpart (cross-match) to the 3HSP catalog if exists within 1 arcminute.'},
+            {'name': 'x4lac', 'type': 'string', 'doc': 'Counterpart (cross-match) to the 4LAC DR3 catalog if exists within 1 arcminute.'},
+            {'name': 'mangrove_HyperLEDA_name', 'type': 'string', 'doc': 'HyperLEDA source designation of closest source from Mangrove catalog; if exists within 1 arcmin.'},
+            {'name': 'mangrove_2MASS_name', 'type': 'string', 'doc': '2MASS source designation of closest source from Mangrove catalog; if exists within 1 arcmin.'},
+            {'name': 'mangrove_lum_dist', 'type': 'string', 'doc': 'Luminosity distance of closest source from Mangrove catalog; if exists within 1 arcmin.'},
+            {'name': 'mangrove_ang_dist', 'type': 'string', 'doc': 'Angular distance of closest source from Mangrove catalog; if exists within 1 arcmin.'},
             {'name': 'mulens', 'type': 'double', 'doc': 'Probability score of an alert to be a microlensing event by [LIA](https://github.com/dgodinez77/LIA).'},
             {'name': 'rf_snia_vs_nonia', 'type': 'double', 'doc': 'Probability of an alert to be a SNe Ia using a Random Forest Classifier (binary classification). Higher is better.'},
             {'name': 'rf_kn_vs_nonkn', 'type': 'double', 'doc': 'Probability of an alert to be a Kilonova using a PCA & Random Forest Classifier (binary classification). Higher is better.'},
             {'name': 'roid', 'type': 'int', 'doc': 'Determine if the alert is a potential Solar System object (experimental). 0: likely not SSO, 1: first appearance but likely not SSO, 2: candidate SSO, 3: found in MPC.'},
             {'name': 'snn_sn_vs_all', 'type': 'double', 'doc': 'The probability of an alert to be a SNe vs. anything else (variable stars and other categories in the training) using SuperNNova'},
             {'name': 'snn_snia_vs_nonia', 'type': 'double', 'doc': 'The probability of an alert to be a SN Ia vs. core-collapse SNe using SuperNNova'},
+            {'name': 'anomaly_score', 'type': 'double', 'doc': 'Probability of an alert to be anomalous (lower values mean more anomalous observations) based on lc_*'},
+            {'name': 'nalerthist', 'type': 'int', 'doc': 'Number of detections contained in each alert (current+history). Upper limits are not taken into account.'},
+            {'name': 'tracklet', 'type': 'string', 'doc': 'ID for fast moving objects, typically orbiting around the Earth. Of the format YYYY-MM-DD hh:mm:ss'},
+            {'name': 'lc_features_g', 'type': 'string', 'doc': 'Numerous light curve features for the g band (see https://github.com/astrolabsoftware/fink-science/tree/master/fink_science/ad_features). Stored as string of array.'},
+            {'name': 'lc_features_r', 'type': 'string', 'doc': 'Numerous light curve features for the r band (see https://github.com/astrolabsoftware/fink-science/tree/master/fink_science/ad_features). Stored as string of array.'},
+            {'name': 'jd_first_real_det', 'type': 'double', 'doc': 'First variation time at 5 sigma contained in the alert history'},
+            {'name': 'jdstarthist_dt', 'type': 'double', 'doc': 'Delta time between `jd_first_real_det` and the first variation time at 3 sigma (`jdstarthist`). If `jdstarthist_dt` > 30 days then the first variation time at 5 sigma is False (accurate for fast transient).'},
+            {'name': 'mag_rate', 'type': 'double', 'doc': 'Magnitude rate (mag/day)'},
+            {'name': 'sigma_rate', 'type': 'double', 'doc': 'Magnitude rate error estimation (mag/day)'},
+            {'name': 'lower_rate', 'type': 'double', 'doc': '5% percentile of the magnitude rate sampling used for the error computation (`sigma_rate`)'},
+            {'name': 'upper_rate', 'type': 'double', 'doc': '95% percentile of the magnitude rate sampling used for the error computation (`sigma_rate`)'},
+            {'name': 'delta_time', 'type': 'double', 'doc': 'Delta time between the the two measurement used for the magnitude rate `mag_rate`'},
+            {'name': 'from_upper', 'type': 'boolean', 'doc': 'If True, the magnitude rate `mag_rate` has been computed using the last upper limit and the current measurement.'},
+            {'name': 'tag', 'type': 'string', 'doc': 'Quality tag among `valid`, `badquality` (does not satisfy quality cuts), and `upper` (upper limit measurement). Only available if `withupperlim` is set to True.'}
         ]
     )
 
@@ -967,7 +987,7 @@ def columns_arguments():
             {'name': 'sigma(rate)', 'type': 'double', 'doc': 'Error of brightness change rate in mag/day (between last and previous measurement in this filter).'},
             {'name': 'lastdate', 'type': 'string', 'doc': 'Human readable datetime for the alert (from the i:jd field).'},
             {'name': 'firstdate', 'type': 'string', 'doc': 'Human readable datetime for the first detection of the object (from the i:jdstarthist field).'},
-            {'name': 'lapse', 'type': 'string', 'doc': 'Number of days between first and last detection.'},
+            {'name': 'lapse', 'type': 'double', 'doc': 'Number of days between first and last detection.'},
         ]
     )
 
@@ -980,7 +1000,7 @@ def columns_arguments():
         'ZTF original fields (i:)': {i: {'type': j, 'doc': k} for i, j, k in zip(ztf_candidate.name, ztf_candidate.type, ztf_candidate.doc)},
         'ZTF original cutouts (b:)': {i: {'type': j, 'doc': k} for i, j, k in zip(ztf_cutouts.name, ztf_cutouts.type, ztf_cutouts.doc)},
         'Fink science module outputs (d:)': {i: {'type': j, 'doc': k} for i, j, k in zip(fink_science.name, fink_science.type, fink_science.doc)},
-        'Fink added values (v:)': {i: {'type': j, 'doc': k} for i, j, k in zip(fink_derived.name, fink_derived.type, fink_derived.doc)}
+        'Fink on-the-fly added values (v:)': {i: {'type': j, 'doc': k} for i, j, k in zip(fink_derived.name, fink_derived.type, fink_derived.doc)}
     }
 
     return jsonify({'fields': types})

--- a/tests/api_anomaly_test.py
+++ b/tests/api_anomaly_test.py
@@ -48,6 +48,8 @@ def anomalysearch(n=10, start_date=None, stop_date=None, output_format='json', c
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'json':
         # Format output in a DataFrame
         pdf = pd.read_json(io.BytesIO(r.content))

--- a/tests/api_bayestar_test.py
+++ b/tests/api_bayestar_test.py
@@ -43,6 +43,8 @@ def bayestartest(bayestar='bayestar.fits.gz', event_name='', credible_level=0.1,
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     pdf = pd.read_json(io.BytesIO(r.content))
 
     return pdf

--- a/tests/api_classsearch_test.py
+++ b/tests/api_classsearch_test.py
@@ -48,6 +48,8 @@ def classsearch(myclass='Early SN Ia candidate', n=10, startdate=None, stopdate=
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'json':
         # Format output in a DataFrame
         pdf = pd.read_json(io.BytesIO(r.content))

--- a/tests/api_columns_test.py
+++ b/tests/api_columns_test.py
@@ -1,0 +1,162 @@
+# Copyright 2024 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import requests
+import pandas as pd
+import numpy as np
+
+import io
+import sys
+
+APIURL = sys.argv[1]
+
+def get_fields_per_family():
+    """ Get fields exposed in /api/v1/columns
+    """
+    r = requests.get('{}/api/v1/columns'.format(APIURL))
+
+    assert r.status_code == 200, r.content
+
+    schema = r.json()
+
+    categories = schema['fields'].keys()
+
+    dic = {}
+    for i in ['i:', 'd:', 'b:', 'v:']:
+        for category in categories:
+            if i in category:
+                dic[i] = list(schema['fields'][category].keys())
+
+    return dic
+
+
+def check_recent_columns(columns, objectId):
+    """ Check the alert columns correspond to what is defined in /api/v1/columns
+    """
+    fields_per_family = get_fields_per_family()
+
+    for family in fields_per_family.keys():
+        definition = fields_per_family[family]
+        obtained = [i.split(family)[1] for i in columns if i.startswith(family) and ('t2_' not in i)]
+
+        outside_obtained = [i for i in definition if i not in obtained]
+        assert len(outside_obtained) == 0, ('Not in obtained fields', family, outside_obtained, objectId)
+
+        # `spicy_name` was introduced by mistake instead of `spicy_class` for 2024/02/01
+        outside_definition = [i for i in obtained if (i not in definition) and (i != 'spicy_name')]
+        assert len(outside_definition) == 0, ('Not in defined fields', family, outside_definition, objectId)
+
+def check_old_columns(columns, objectId):
+    """ Check the alert columns correspond to what is defined in /api/v1/columns
+    """
+    fields_per_family = get_fields_per_family()
+
+    for family in fields_per_family.keys():
+        definition = fields_per_family[family]
+        obtained = [i.split(family)[1] for i in columns if i.startswith(family) and ('t2_' not in i)]
+
+        # Only d: has changed
+        if family != 'd:':
+            outside_obtained = [i for i in definition if i not in obtained]
+            assert len(outside_obtained) == 0, ('Not in obtained fields', family, outside_obtained, objectId)
+
+            # `spicy_name` was introduced by mistake instead of `spicy_class` for 2024/02/01
+            outside_definition = [i for i in obtained if (i not in definition) and (i != 'spicy_name')]
+            assert len(outside_definition) == 0, ('Not in defined fields', family, outside_definition, objectId)
+        else:
+            recent_cols = [
+                'DR3Name', 'Plx', 'anomaly_score', 'delta_time',
+                'e_Plx', 'from_upper', 'gcvs', 'jd_first_real_det',
+                'jdstarthist_dt', 'lc_features_g', 'lc_features_r',
+                'lower_rate', 'mag_rate', 'mangrove_2MASS_name',
+                'mangrove_HyperLEDA_name', 'mangrove_ang_dist', 'mangrove_lum_dist',
+                'sigma_rate', 'spicy_class', 'spicy_id',
+                'upper_rate', 'vsx', 'x3hsp', 'x4lac'
+            ]
+
+            outside_obtained = [i for i in definition if i not in obtained]
+            outside_obtained_ = [i for i in outside_obtained if i not in recent_cols]
+            assert len(outside_obtained_) == 0, ('Not in obtained fields', family, outside_obtained_, objectId)
+
+            # `spicy_name` was introduced by mistake instead of `spicy_class` for 2024/02/01
+            outside_definition = [i for i in obtained if (i not in definition) and (i != 'spicy_name')]
+            assert len(outside_definition) == 0, ('Not in defined fields', family, outside_definition, objectId)
+
+def test_recent_object() -> None:
+    """ This is supposed to fail if apps/api/api.py@columns_arguments is not updated correctly
+
+    Examples
+    ---------
+    >>> test_recent_object()
+    """
+    r = requests.post(
+        '{}/api/v1/latests'.format(APIURL),
+        json={
+            'class': 'EB*',
+            'n': 1,
+            'columns': 'i:objectId'
+        }
+    )
+
+    assert r.status_code == 200, r.content
+
+    objectId = r.json()[0]['i:objectId']
+    r2 = requests.post(
+        '{}/api/v1/objects'.format(APIURL),
+        json={
+            'objectId': objectId,
+            'columns': '*',
+            'output-format': 'json',
+            'withupperlim': True,
+            'withcutouts': True
+        }
+    )
+
+    assert r2.status_code == 200, r.content
+
+    pdf = pd.read_json(io.BytesIO(r2.content))
+
+    check_recent_columns(pdf.columns, objectId)
+
+def test_old_object() -> None:
+    """
+    Examples
+    ---------
+    >>> test_old_object()
+    """
+    objectId = 'ZTF21abfmbix'
+    r2 = requests.post(
+        '{}/api/v1/objects'.format(APIURL),
+        json={
+            'objectId': objectId,
+            'columns': '*',
+            'output-format': 'json',
+            'withupperlim': True,
+            'withcutouts': True
+        }
+    )
+
+    assert r2.status_code == 200, r.content
+
+    pdf = pd.read_json(io.BytesIO(r2.content))
+
+    check_old_columns(pdf.columns, objectId)
+
+
+if __name__ == "__main__":
+    """ Execute the test suite """
+    import sys
+    import doctest
+
+    sys.exit(doctest.testmod()[0])

--- a/tests/api_columns_test.py
+++ b/tests/api_columns_test.py
@@ -123,7 +123,7 @@ def test_recent_object() -> None:
         }
     )
 
-    assert r2.status_code == 200, r.content
+    assert r2.status_code == 200, r2.content
 
     pdf = pd.read_json(io.BytesIO(r2.content))
 
@@ -136,7 +136,7 @@ def test_old_object() -> None:
     >>> test_old_object()
     """
     objectId = 'ZTF21abfmbix'
-    r2 = requests.post(
+    r = requests.post(
         '{}/api/v1/objects'.format(APIURL),
         json={
             'objectId': objectId,
@@ -147,9 +147,9 @@ def test_old_object() -> None:
         }
     )
 
-    assert r2.status_code == 200, r.content
+    assert r.status_code == 200, r.content
 
-    pdf = pd.read_json(io.BytesIO(r2.content))
+    pdf = pd.read_json(io.BytesIO(r.content))
 
     check_old_columns(pdf.columns, objectId)
 

--- a/tests/api_conesearch_test.py
+++ b/tests/api_conesearch_test.py
@@ -47,6 +47,8 @@ def conesearch(ra='193.8217409', dec='2.8973184', radius='5', startdate=None, wi
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'json':
         # Format output in a DataFrame
         pdf = pd.read_json(io.BytesIO(r.content))

--- a/tests/api_cutouts_test.py
+++ b/tests/api_cutouts_test.py
@@ -50,6 +50,8 @@ def cutouttest(objectId='ZTF21aaxtctv', kind='Science', stretch='sigmoid', color
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'PNG':
         # Format output in a DataFrame
         data = im.open(io.BytesIO(r.content))

--- a/tests/api_datesearch_test.py
+++ b/tests/api_datesearch_test.py
@@ -35,6 +35,8 @@ def datesearch(startdate='2021-07-01 05:59:37.000', window=1/24/60, output_forma
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'json':
         # Format output in a DataFrame
         pdf = pd.read_json(io.BytesIO(r.content))

--- a/tests/api_euclidsso_test.py
+++ b/tests/api_euclidsso_test.py
@@ -39,6 +39,8 @@ def push_euclid(fn='old_ssopipe.txt'):
         }
     )
 
+    assert r.status_code == 200, r.content
+
     return r.content
 
 def pull_euclid(pipeline='ssopipe', dates='20210101', columns='*', output_format='json'):
@@ -56,6 +58,8 @@ def pull_euclid(pipeline='ssopipe', dates='20210101', columns='*', output_format
         '{}/api/v1/eucliddata'.format(APIURL),
         json=payload
     )
+
+    assert r.status_code == 200, r.content
 
     if output_format == 'json':
         # Format output in a DataFrame

--- a/tests/api_performance_test.py
+++ b/tests/api_performance_test.py
@@ -45,6 +45,8 @@ def classsearch(myclass='Solar System MPC', n=100000, startdate='2022-03-03', st
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'json':
         # Format output in a DataFrame
         pdf = pd.read_json(io.BytesIO(r.content))

--- a/tests/api_random_object_test.py
+++ b/tests/api_random_object_test.py
@@ -41,6 +41,8 @@ def get_an_object(number=1, output_format='json', columns='*', object_class="", 
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'json':
         # Format output in a DataFrame
         pdf = pd.read_json(io.BytesIO(r.content))

--- a/tests/api_resolver_test.py
+++ b/tests/api_resolver_test.py
@@ -51,6 +51,8 @@ def resolver(resolver='', name='', nmax=None, reverse=None, output_format='json'
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'json':
         # Format output in a DataFrame
         pdf = pd.read_json(io.BytesIO(r.content))

--- a/tests/api_single_object_test.py
+++ b/tests/api_single_object_test.py
@@ -38,6 +38,8 @@ def get_an_object(oid='ZTF21abfmbix', output_format='json', columns='*', withupp
         }
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'json':
         # Format output in a DataFrame
         pdf = pd.read_json(io.BytesIO(r.content))

--- a/tests/api_sso_test.py
+++ b/tests/api_sso_test.py
@@ -36,6 +36,8 @@ def ssosearch(n_or_d='8467', withEphem=False, columns='*', output_format='json')
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'json':
         # Format output in a DataFrame
         pdf = pd.read_json(io.BytesIO(r.content))

--- a/tests/api_ssocand_test.py
+++ b/tests/api_ssocand_test.py
@@ -44,6 +44,8 @@ def ssocandsearch(kind='orbParams', trajectory_id=None, start_date=None, stop_da
         '{}/api/v1/ssocand'.format(APIURL),
         json=payload
     )
+    
+    assert r.status_code == 200, r.content
 
     if output_format == 'json':
         # Format output in a DataFrame

--- a/tests/api_ssoft_test.py
+++ b/tests/api_ssoft_test.py
@@ -70,6 +70,8 @@ def ssoftsearch(version=None, flavor=None, sso_number=None, sso_name=None, schem
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'json':
         # Format output in a DataFrame
         pdf = pd.read_json(io.BytesIO(r.content))

--- a/tests/api_stats_test.py
+++ b/tests/api_stats_test.py
@@ -35,6 +35,8 @@ def statstest(date='2021', columns='*', output_format='json'):
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'json':
         # Format output in a DataFrame
         pdf = pd.read_json(io.BytesIO(r.content))

--- a/tests/api_tracklet_test.py
+++ b/tests/api_tracklet_test.py
@@ -37,6 +37,8 @@ def trackletsearch(date='2021-08-10', columns='*', output_format='json'):
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     if output_format == 'json':
         # Format output in a DataFrame
         pdf = pd.read_json(io.BytesIO(r.content))

--- a/tests/api_xmatch_test.py
+++ b/tests/api_xmatch_test.py
@@ -36,6 +36,8 @@ def xmatchtest(catalog='mycatalog.csv', header='RA,Dec,ID,Time', radius=1.5, win
         json=payload
     )
 
+    assert r.status_code == 200, r.content
+
     pdf = pd.read_json(io.BytesIO(r.content))
 
     return pdf


### PR DESCRIPTION
Closes #578 

This PR updates the schema definition in `api/v1/columns`. This PR also adds new checks for alert columns:
- check that recent alerts have all columns defined in /api/v1/columns
- check new fields added compared to old alerts

This PR also updates existing tests by being more explicit if an API request fails.