### PR TITLE
Do not compute ecliptic coordinates for SSO

### DIFF
--- a/apps/summary.py
+++ b/apps/summary.py
@@ -635,7 +635,7 @@ def store_query(name):
             if name:
                 pdfsso["i:ssnamenr"] = name
 
-            pdfsso = get_miriade_data(pdfsso)
+            pdfsso = get_miriade_data(pdfsso, withecl=False)
     else:
         pdfsso = pd.DataFrame()
 


### PR DESCRIPTION
Closes #617 

Note: this is still computed at the API level (`apps/api/utils.py`)