### PR TITLE
Faster SSOFT download

### DIFF
--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -1563,14 +1563,18 @@ def ssoft_table(payload=None):
         # return the schema of the table
         return jsonify({"args": ssoft_columns})
 
-    pdfs = return_ssoft_pdf(payload)
+    out = return_ssoft_pdf(payload)
 
     # Error propagation
-    if isinstance(pdfs, Response):
-        return pdfs
+    if isinstance(out, Response):
+        return out
 
-    output_format = payload.get("output-format", "json")
-    return send_data(pdfs, output_format)
+    if isinstance(out, pd.DataFrame):
+        output_format = payload.get("output-format", "json")
+        return send_data(out, output_format)
+
+    # return the binary
+    return out
 
 
 @api_bp.route("/api/v1/resolver", methods=["GET"])

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1405,6 +1405,9 @@ def return_ssoft_pdf(payload: dict) -> pd.DataFrame:
         ),
     )
 
+    if payload.get("output-format", "parquet") != "parquet":
+        return pd.read_parquet(io.BytesIO(r.content))
+
     if "sso_name" in payload:
         pdf = pd.read_parquet(io.BytesIO(r.content))
         mask = pdf["sso_name"] == pdf["sso_name"]

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -1405,18 +1405,21 @@ def return_ssoft_pdf(payload: dict) -> pd.DataFrame:
         ),
     )
 
-    pdf = pd.read_parquet(io.BytesIO(r.content))
-
     if "sso_name" in payload:
+        pdf = pd.read_parquet(io.BytesIO(r.content))
         mask = pdf["sso_name"] == pdf["sso_name"]
         pdf = pdf[mask]
         pdf = pdf[pdf["sso_name"].astype("str") == payload["sso_name"]]
+        return pdf
     elif "sso_number" in payload:
+        pdf = pd.read_parquet(io.BytesIO(r.content))
         mask = pdf["sso_number"] == pdf["sso_number"]
         pdf = pdf[mask]
         pdf = pdf[pdf["sso_number"].astype("int") == int(payload["sso_number"])]
+        return pdf
 
-    return pdf
+    # return blob
+    return io.BytesIO(r.content)
 
 
 def return_resolver_pdf(payload: dict) -> pd.DataFrame:


### PR DESCRIPTION
This PR brings speed up in downloading the SSOFT in parquet format

| output format | download time |
|-------------------|---------------------|
| csv | 21.28 seconds |
| json | 16.61 seconds |
| parquet (old) | 5.85 seconds |
| parquet (new) | 4.84 seconds |

`json` and `csv` are slow because the data needs to be decompressed, and formatted in pandas DataFrame before being sent to the user (that is: DO NOT USE THAT unless you really needs it). The parquet mode is now faster because I get rid of the pandas DataFrame step.