### PR TITLE
Access stamps data when querying Solar System objects

### DIFF
--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -407,6 +407,11 @@ args_sso = [
         "description": "`Science`[default], `Template`, or `Difference`",
     },
     {
+        "name": "cutout-format",
+        "required": False,
+        "description": "Output format of the cutouts: 2D array (`array`[default]) or binary gzipped FITS (`raw`).",
+    },
+    {
         "name": "output-format",
         "required": False,
         "description": "Query output format among `json`[default], `csv`, `parquet`, `votable`",

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -1300,7 +1300,7 @@ def return_sso(payload=None):
         payload = request.json
 
     pdf = return_sso_pdf(payload)
-    
+
     # Error propagation
     if not isinstance(pdf, pd.DataFrame):
         return pdf

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -1310,6 +1310,10 @@ def return_sso(payload=None):
         payload = request.json
 
     pdf = return_sso_pdf(payload)
+    
+    # Error propagation
+    if isinstance(pdf, Response):
+        return pdf
 
     output_format = payload.get("output-format", "json")
     return send_data(pdf, output_format)

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -392,9 +392,24 @@ args_sso = [
         "description": f"Comma-separated data columns to transfer. Default is all columns. See {APIURL}/api/v1/columns for more information.",
     },
     {
+        "name": "withcutouts",
+        "required": False,
+        "description": "If True, retrieve also cutout data. See also `cutout-kind` and `cutout-format`.",
+    },
+    {
+        "name": "cutout-kind",
+        "required": False,
+        "description": "`Science`[default], `Template`, or `Difference`",
+    },
+    {
+        "name": "cutout-format",
+        "required": False,
+        "description": "Cutout format among `array`[default] or `FITS`",
+    },
+    {
         "name": "output-format",
         "required": False,
-        "description": "Output format among json[default], csv, parquet, votable",
+        "description": "Query output format among `json`[default], `csv`, `parquet`, `votable`",
     },
 ]
 

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -1312,7 +1312,7 @@ def return_sso(payload=None):
     pdf = return_sso_pdf(payload)
     
     # Error propagation
-    if isinstance(pdf, Response):
+    if not isinstance(pdf, pd.DataFrame):
         return pdf
 
     output_format = payload.get("output-format", "json")

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -407,11 +407,6 @@ args_sso = [
         "description": "`Science`[default], `Template`, or `Difference`",
     },
     {
-        "name": "cutout-format",
-        "required": False,
-        "description": "Output format of the cutouts: 2D array (`array`[default]) or binary gzipped FITS (`raw`).",
-    },
-    {
         "name": "output-format",
         "required": False,
         "description": "Query output format among `json`[default], `csv`, `parquet`, `votable`",

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -266,17 +266,12 @@ args_objects = [
     {
         "name": "withcutouts",
         "required": False,
-        "description": "If True, retrieve also cutout data. See also `cutout-kind` and `cutout-format`.",
+        "description": "If True, retrieve also cutout data as 2D array. See also `cutout-kind`. More information on the original cutouts at https://irsa.ipac.caltech.edu/data/ZTF/docs/ztf_explanatory_supplement.pdf",
     },
     {
         "name": "cutout-kind",
         "required": False,
         "description": "`Science`, `Template`, or `Difference`. If not specified, returned all three.",
-    },
-    {
-        "name": "cutout-format",
-        "required": False,
-        "description": "Cutout format among `array`[default] or `FITS`",
     },
     {
         "name": "columns",
@@ -404,17 +399,12 @@ args_sso = [
     {
         "name": "withcutouts",
         "required": False,
-        "description": "If True, retrieve also cutout data. See also `cutout-kind` and `cutout-format`.",
+        "description": "If True, retrieve also cutout data as 2D array. See also `cutout-kind`. More information on the original cutouts at https://irsa.ipac.caltech.edu/data/ZTF/docs/ztf_explanatory_supplement.pdf",
     },
     {
         "name": "cutout-kind",
         "required": False,
         "description": "`Science`[default], `Template`, or `Difference`",
-    },
-    {
-        "name": "cutout-format",
-        "required": False,
-        "description": "Cutout format among `array`[default] or `FITS`",
     },
     {
         "name": "output-format",

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -266,7 +266,17 @@ args_objects = [
     {
         "name": "withcutouts",
         "required": False,
-        "description": "If True, retrieve also uncompressed FITS cutout data (2D array).",
+        "description": "If True, retrieve also cutout data. See also `cutout-kind` and `cutout-format`.",
+    },
+    {
+        "name": "cutout-kind",
+        "required": False,
+        "description": "`Science`, `Template`, or `Difference`. If not specified, returned all three.",
+    },
+    {
+        "name": "cutout-format",
+        "required": False,
+        "description": "Cutout format among `array`[default] or `FITS`",
     },
     {
         "name": "columns",

--- a/apps/api/doc.py
+++ b/apps/api/doc.py
@@ -517,6 +517,7 @@ wget "https://fink-portal.org/api/v1/sso?n_or_d=8467&output-format=json" -O 8467
 In python, you would use
 
 ```python
+import io
 import requests
 import pandas as pd
 

--- a/apps/api/doc.py
+++ b/apps/api/doc.py
@@ -631,7 +631,58 @@ r = requests.post(
 )
 ```
 
-Note that the fields should be comma-separated. Unknown field names are ignored.
+Note that the fields should be comma-separated. Unknown field names are ignored. Finally you can query stamps for all alerts using the argument `withcutouts`:
+
+```python
+import requests
+
+# get data for object 8467
+r = requests.post(
+  'https://fink-portal.org/api/v1/sso',
+  json={
+    'n_or_d': '8467',
+    'withcutouts': True,
+    'output-format': 'json'
+  }
+)
+
+# print one cutout
+r.json()[0]["b:cutoutScience_stampData"]
+[[123.70613861, 125.00068665, 129.01676941, ..., 123.77194214,
+  130.44299316, 106.22817993],
+ [121.61331177, 128.18247986, 124.99162292, ..., 115.30529785,
+  129.93824768, 100.24826813],
+ [124.31635284, 134.16503906, 125.13191223, ..., 131.05186462,
+  116.30375671, 102.97401428],
+ ...,
+ [133.20661926, 123.14172363, 121.78632355, ..., 132.95498657,
+  131.95939636, 111.22276306],
+ [129.26271057, 127.34268188, 123.1470108 , ..., 126.02961731,
+  128.23413086, 107.28420258],
+ [126.06323242, 122.42414093, 121.47638702, ..., 129.28106689,
+  131.03790283, 109.95378876]]
+```
+
+![sso_example](https://github.com/user-attachments/assets/ade5fd85-3b75-4281-8933-b2ae62ee53eb)
+
+Note that by default, the `Science` cutouts are downloaded. You can also ask for the `Template` or the `Difference` stamps:
+
+```python
+# get data for object 8467
+r = requests.post(
+  'https://fink-portal.org/api/v1/sso',
+  json={
+    'n_or_d': '8467',
+    'withcutouts': True,
+    'cutout-kind': 'Template',
+    'output-format': 'json'
+  }
+)
+```
+
+Downloading cutouts for SSO is time-consuming, and heavy for the server because (a) data is indexed against `objectId` and not `ssnamenr` and (b) decoding each binary gzipped FITS file has a cost. On average, it takes 0.5 second per alert.
+
+For more information about the ZTF stamps, see https://irsa.ipac.caltech.edu/data/ZTF/docs/ztf_explanatory_supplement.pdf
 """
 
 api_doc_tracklets = """

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -575,6 +575,8 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
                 }
                 return Response(str(rep), 400)
 
+            colname = "b:cutout{}_stampData".format(cutout_kind)
+
             # get all cutouts
             cutouts = []
             for k, result in results.items():
@@ -589,7 +591,7 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
                 )
                 if r.status_code == 200:
                     # the result should be unique (based on candid)
-                    cutouts.append(r.json()[0])
+                    cutouts.append(r.json()[0][colname])
                 else:
                     rep = {
                         "status": "error",
@@ -597,7 +599,7 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
                     }
                     return Response(str(rep), 400)
 
-            pdf["b:cutout{}_stampData".format(cutout_kind)] = cutouts
+            pdf[colname] = cutouts
 
     if "withEphem" in payload:
         if payload["withEphem"] == "True" or payload["withEphem"] is True:

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -581,15 +581,15 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
 
             # get all cutouts
             cutouts = []
-            for k, result in results.items():
+            for result in results.values():
                 r = requests.post(
                     f"{APIURL}/api/v1/cutouts",
                     json={
                         "objectId": result["i:objectId"],
                         "candid": result["i:candid"],
                         "kind": cutout_kind,
-                        "output-format": cutout_format
-                    }
+                        "output-format": cutout_format,
+                    },
                 )
                 if r.status_code == 200:
                     # the result should be unique (based on candid)

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -567,8 +567,6 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
     if "withcutouts" in payload:
         if payload["withcutouts"] == "True" or payload["withcutouts"] is True:
             # Extract cutouts
-            cutout_format = payload.get("cutout-format", "array")
-
             cutout_kind = payload.get("cutout-kind", "Science")
             if cutout_kind not in ["Science", "Template", "Difference"]:
                 rep = {
@@ -588,7 +586,7 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
                         "objectId": result["i:objectId"],
                         "candid": result["i:candid"],
                         "kind": cutout_kind,
-                        "output-format": cutout_format,
+                        "output-format": "array",
                     },
                 )
                 if r.status_code == 200:

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -590,7 +590,14 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
                         "output-format": cutout_format
                     }
                 )
-                results[k].update(out)
+                if r.status_code == 200:
+                    results[k].putAll(r.json()[0])
+                else:
+                    rep = {
+                        "status": "error",
+                        "text": r.content,
+                    }
+                    return Response(str(rep), 400)
 
     pdf = format_hbase_output(
         results,

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -127,7 +127,11 @@ def return_object_pdf(payload: dict) -> pd.DataFrame:
             return Response(str(rep), 400)
         # Default `None` returns all 3 cutouts
         cutout_kind = payload.get("cutout-kind", None)
-        pdf = extract_cutouts(pdf, client, col=cutout_kind, return_type=cutout_format)
+        if cutout_kind is None:
+            colname = None
+        else:
+            colname = "b:cutout{}_stampData".format(cutout_kind)
+        pdf = extract_cutouts(pdf, client, col=colname, return_type=cutout_format)
 
     if withupperlim:
         clientU = connect_to_hbase_table("ztf.upper")

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -579,12 +579,31 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
                 }
                 return Response(str(rep), 400)
 
-            pdf = extract_cutouts(
-                pdf,
-                client,
-                col="b:cutout{}_stampData".format(cutout_kind),
-                return_type=cutout_format,
+
+            colname = "b:cutout{}_stampData".format(cutout_kind)
+
+            pdf[colname] = (
+                "binary:"
+                + pdf["i:objectId"]
+                + "_"
+                + pdf["i:jd"].astype("str")
+                + colname[1:]
             )
+
+            from apps.utils import readstamp
+            pdf[colname] = pdf[colname].apply(
+                lambda x: readstamp(client.repository().get(x), return_type=cutout_format),
+            )
+
+
+
+
+            #pdf = extract_cutouts(
+            #    pdf,
+            #    client,
+            #    col="b:cutout{}_stampData".format(cutout_kind),
+            #    return_type=cutout_format,
+            #)
 
             client.close()
 

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -850,13 +850,7 @@ def format_and_send_cutout(payload: dict) -> pd.DataFrame:
             col="b:cutout{}_stampData".format(payload["kind"]),
             return_type="array",
         )
-    elif output_format == "raw":
-        pdf = extract_cutouts(
-            pdf,
-            client,
-            col="b:cutout{}_stampData".format(payload["kind"]),
-            return_type="raw",
-        )
+
     client.close()
 
     array = pdf["b:cutout{}_stampData".format(payload["kind"])].to_numpy()[0]
@@ -870,7 +864,7 @@ def format_and_send_cutout(payload: dict) -> pd.DataFrame:
             download_name=filename,
         )
     # send the array
-    elif output_format in ["array", "raw"]:
+    elif output_format == "array":
         return pdf[["b:cutout{}_stampData".format(payload["kind"])]].to_json(
             orient="records"
         )

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -118,20 +118,13 @@ def return_object_pdf(payload: dict) -> pd.DataFrame:
     )
 
     if withcutouts:
-        cutout_format = payload.get("cutout-format", "array")
-        if cutout_format not in ["array", "raw"]:
-            rep = {
-                "status": "error",
-                "text": "`cutout-format` must be `array` or `raw`.\n",
-            }
-            return Response(str(rep), 400)
         # Default `None` returns all 3 cutouts
         cutout_kind = payload.get("cutout-kind", None)
         if cutout_kind is None:
             colname = None
         else:
             colname = "b:cutout{}_stampData".format(cutout_kind)
-        pdf = extract_cutouts(pdf, client, col=colname, return_type=cutout_format)
+        pdf = extract_cutouts(pdf, client, col=colname, return_type="array")
 
     if withupperlim:
         clientU = connect_to_hbase_table("ztf.upper")
@@ -574,14 +567,6 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
     if "withcutouts" in payload:
         if payload["withcutouts"] == "True" or payload["withcutouts"] is True:
             # Extract cutouts
-            cutout_format = payload.get("cutout-format", "array")
-            if cutout_format not in ["array", "raw"]:
-                rep = {
-                    "status": "error",
-                    "text": "`cutout-format` must be `array` or `raw`.\n",
-                }
-                return Response(str(rep), 400) 
-
             cutout_kind = payload.get("cutout-kind", "Science")
             if cutout_kind not in ["Science", "Template", "Difference"]:
                 rep = {
@@ -599,7 +584,7 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
                         "objectId": result["i:objectId"],
                         "candid": result["i:candid"],
                         "kind": cutout_kind,
-                        "output-format": cutout_format
+                        "output-format": "array"
                     }
                 )
                 if r.status_code == 200:

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -119,13 +119,12 @@ def return_object_pdf(payload: dict) -> pd.DataFrame:
 
     if withcutouts:
         cutout_format = payload.get("cutout-format", "array")
-        if cutout_format not in ["array", "FITS"]:
+        if cutout_format not in ["array", "raw"]:
             rep = {
                 "status": "error",
-                "text": "`cutout-format` must be `array` or `FITS`.\n",
+                "text": "`cutout-format` must be `array` or `raw`.\n",
             }
             return Response(str(rep), 400)
-
         # Default `None` returns all 3 cutouts
         cutout_kind = payload.get("cutout-kind", None)
         pdf = extract_cutouts(pdf, client, col=cutout_kind, return_type=cutout_format)
@@ -572,10 +571,10 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
         if payload["withcutouts"] == "True" or payload["withcutouts"] is True:
             # Extract cutouts
             cutout_format = payload.get("cutout-format", "array")
-            if cutout_format not in ["array", "FITS"]:
+            if cutout_format not in ["array", "raw"]:
                 rep = {
                     "status": "error",
-                    "text": "`cutout-format` must be `array` or `FITS`.\n",
+                    "text": "`cutout-format` must be `array` or `raw`.\n",
                 }
                 return Response(str(rep), 400) 
 

--- a/apps/api/utils.py
+++ b/apps/api/utils.py
@@ -597,7 +597,7 @@ def return_sso_pdf(payload: dict) -> pd.DataFrame:
                     }
                     return Response(str(rep), 400)
 
-        pdf["b:cutout{}_stampData".format(cutout_kind)] = cutouts
+            pdf["b:cutout{}_stampData".format(cutout_kind)] = cutouts
 
     if "withEphem" in payload:
         if payload["withEphem"] == "True" or payload["withEphem"] is True:

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -286,7 +286,7 @@ def readstamp(stamp: str, return_type="array", gzipped=True) -> np.array:
         2D array containing image data (`array`) or FITS file uncompressed as file-object (`FITS`)
     """
     if return_type == 'raw':
-        return stamp
+        return io.BytesIO(stamp)
 
     def extract_stamp(fitsdata):
         with fits.open(fitsdata, ignore_missing_simple=True) as hdul:

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -285,8 +285,6 @@ def readstamp(stamp: str, return_type="array", gzipped=True) -> np.array:
     data: np.array
         2D array containing image data (`array`) or FITS file uncompressed as file-object (`FITS`)
     """
-    if return_type == 'raw':
-        return stamp
 
     def extract_stamp(fitsdata):
         with fits.open(fitsdata, ignore_missing_simple=True) as hdul:

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -286,7 +286,7 @@ def readstamp(stamp: str, return_type="array", gzipped=True) -> np.array:
         2D array containing image data (`array`) or FITS file uncompressed as file-object (`FITS`)
     """
     if return_type == 'raw':
-        return io.BytesIO(stamp)
+        return stamp
 
     def extract_stamp(fitsdata):
         with fits.open(fitsdata, ignore_missing_simple=True) as hdul:

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -285,6 +285,8 @@ def readstamp(stamp: str, return_type="array", gzipped=True) -> np.array:
     data: np.array
         2D array containing image data (`array`) or FITS file uncompressed as file-object (`FITS`)
     """
+    if return_type == 'raw':
+        return stamp
 
     def extract_stamp(fitsdata):
         with fits.open(fitsdata, ignore_missing_simple=True) as hdul:

--- a/tests/api_single_object_test.py
+++ b/tests/api_single_object_test.py
@@ -34,7 +34,6 @@ def get_an_object(
     cutout_kind=None,
 ):
     """Query an object from the Science Portal using the Fink REST API"""
-
     payload = {
         "objectId": oid,
         "columns": columns,
@@ -44,12 +43,9 @@ def get_an_object(
     }
 
     if cutout_kind is not None:
-        payload.update({'cutout-kind': cutout_kind})
+        payload.update({"cutout-kind": cutout_kind})
 
-    r = requests.post(
-        "{}/api/v1/objects".format(APIURL),
-        json=payload
-    )
+    r = requests.post("{}/api/v1/objects".format(APIURL), json=payload)
 
     assert r.status_code == 200, r.content
 

--- a/tests/api_single_object_test.py
+++ b/tests/api_single_object_test.py
@@ -31,17 +31,24 @@ def get_an_object(
     columns="*",
     withupperlim=False,
     withcutouts=False,
+    cutout_kind=None,
 ):
     """Query an object from the Science Portal using the Fink REST API"""
+
+    payload = {
+        "objectId": oid,
+        "columns": columns,
+        "output-format": output_format,
+        "withupperlim": withupperlim,
+        "withcutouts": withcutouts,
+    }
+
+    if cutout_kind is not None:
+        payload.update({'cutout-kind': cutout_kind})
+
     r = requests.post(
         "{}/api/v1/objects".format(APIURL),
-        json={
-            "objectId": oid,
-            "columns": columns,
-            "output-format": output_format,
-            "withupperlim": withupperlim,
-            "withcutouts": withcutouts,
-        },
+        json=payload
     )
 
     assert r.status_code == 200, r.content
@@ -133,6 +140,18 @@ def test_withcutouts() -> None:
     assert isinstance(pdf["b:cutoutScience_stampData"].to_numpy()[0], list)
     assert isinstance(pdf["b:cutoutTemplate_stampData"].to_numpy()[0], list)
     assert isinstance(pdf["b:cutoutDifference_stampData"].to_numpy()[0], list)
+
+
+def test_withcutouts_single_field() -> None:
+    """
+    Examples
+    --------
+    >>> test_withcutouts_single_field()
+    """
+    pdf = get_an_object(oid=OID, withcutouts=True, cutout_kind="Science")
+
+    assert isinstance(pdf["b:cutoutScience_stampData"].to_numpy()[0], list)
+    assert "b:cutoutTemplate_stampData" not in pdf.columns
 
 
 def test_formatting() -> None:

--- a/tests/api_sso_test.py
+++ b/tests/api_sso_test.py
@@ -22,7 +22,14 @@ import sys
 APIURL = sys.argv[1]
 
 
-def ssosearch(n_or_d="8467", withEphem=False, withCutouts=False, cutout_kind=None, columns="*", output_format="json"):
+def ssosearch(
+    n_or_d="8467",
+    withEphem=False,
+    withCutouts=False,
+    cutout_kind=None,
+    columns="*",
+    output_format="json",
+):
     """Perform a sso search in the Science Portal using the Fink REST API"""
     payload = {
         "n_or_d": n_or_d,
@@ -178,13 +185,14 @@ def test_withcutouts() -> None:
     pdf = ssosearch(withCutouts=True)
 
     assert "b:cutoutScience_stampData" in pdf.columns
-    assert isinstance(pdf["b:cutoutScience_stampData"].to_numpy()[0], list), pdf["b:cutoutScience_stampData"]
+    assert isinstance(pdf["b:cutoutScience_stampData"].to_numpy()[0], list), pdf[
+        "b:cutoutScience_stampData"
+    ]
 
     pdf = ssosearch(withCutouts=True, cutout_kind="Template")
 
     assert "b:cutoutTemplate_stampData" in pdf.columns
     assert isinstance(pdf["b:cutoutTemplate_stampData"].to_numpy()[0], list)
-
 
 
 if __name__ == "__main__":

--- a/tests/api_sso_test.py
+++ b/tests/api_sso_test.py
@@ -22,14 +22,18 @@ import sys
 APIURL = sys.argv[1]
 
 
-def ssosearch(n_or_d="8467", withEphem=False, columns="*", output_format="json"):
+def ssosearch(n_or_d="8467", withEphem=False, withCutouts=False, cutout_kind=None, columns="*", output_format="json"):
     """Perform a sso search in the Science Portal using the Fink REST API"""
     payload = {
         "n_or_d": n_or_d,
         "withEphem": withEphem,
+        "withcutouts": withCutouts,
         "columns": columns,
         "output-format": output_format,
     }
+
+    if cutout_kind is not None:
+        payload.update({"cutout_kind": cutout_kind})
 
     r = requests.post("{}/api/v1/sso".format(APIURL), json=payload)
 
@@ -163,6 +167,24 @@ def test_with_ephem_multiple_ssosearch() -> None:
         pdf[m2].to_numpy(),
         pdf2.to_numpy(),
     )
+
+
+def test_withcutouts() -> None:
+    """
+    Examples
+    --------
+    >>> test_withcutouts()
+    """
+    pdf = ssosearch(withCutouts=True)
+
+    assert "b:cutoutScience_stampData" in pdf.columns
+    assert isinstance(pdf["b:cutoutScience_stampData"].to_numpy()[0], list), pdf["b:cutoutScience_stampData"]
+
+    pdf = ssosearch(withCutouts=True, cutout_kind="Template")
+
+    assert "b:cutoutTemplate_stampData" in pdf.columns
+    assert isinstance(pdf["b:cutoutTemplate_stampData"].to_numpy()[0], list)
+
 
 
 if __name__ == "__main__":

--- a/tests/api_sso_test.py
+++ b/tests/api_sso_test.py
@@ -40,7 +40,7 @@ def ssosearch(
     }
 
     if cutout_kind is not None:
-        payload.update({"cutout_kind": cutout_kind})
+        payload.update({"cutout-kind": cutout_kind})
 
     r = requests.post("{}/api/v1/sso".format(APIURL), json=payload)
 


### PR DESCRIPTION
There is now a new argument `withcutouts` to `api/v1/sso` to include stamps data when querying a Solar System object:

```python
import requests

# get data for object 8467
r = requests.post(
  'https://fink-portal.org/api/v1/sso',
  json={
    'n_or_d': '8467',
    'withcutouts': True,
    'output-format': 'json'
  }
)

# print one cutout
r.json()[0]["b:cutoutScience_stampData"]
[[123.70613861, 125.00068665, 129.01676941, ..., 123.77194214,
  130.44299316, 106.22817993],
 [121.61331177, 128.18247986, 124.99162292, ..., 115.30529785,
  129.93824768, 100.24826813],
 [124.31635284, 134.16503906, 125.13191223, ..., 131.05186462,
  116.30375671, 102.97401428],
 ...,
 [133.20661926, 123.14172363, 121.78632355, ..., 132.95498657,
  131.95939636, 111.22276306],
 [129.26271057, 127.34268188, 123.1470108 , ..., 126.02961731,
  128.23413086, 107.28420258],
 [126.06323242, 122.42414093, 121.47638702, ..., 129.28106689,
  131.03790283, 109.95378876]]
```

![sso_example](https://github.com/user-attachments/assets/ade5fd85-3b75-4281-8933-b2ae62ee53eb)

Note that by default, the `Science` cutouts are downloaded. You can also ask for the `Template` or the `Difference` stamps:

```python
# get data for object 8467
r = requests.post(
  'https://fink-portal.org/api/v1/sso',
  json={
    'n_or_d': '8467',
    'withcutouts': True,
    'cutout-kind': 'Template',
    'output-format': 'json'
  }
)
```

Downloading cutouts for SSO is time-consuming, and heavy for the server because (a) data is indexed against `objectId` and not `ssnamenr` and (b) decoding each binary gzipped FITS file has a cost. On average, it takes 0.5 second per alert. 

For more information about the ZTF stamps, see https://irsa.ipac.caltech.edu/data/ZTF/docs/ztf_explanatory_supplement.pdf