### PR TITLE
[searchbar] Enable conesearch with h:m:s d:m:s

### DIFF
--- a/apps/parse.py
+++ b/apps/parse.py
@@ -187,19 +187,22 @@ def parse_query(string, timeout=None):
         m = re.match(r"^(\w+)[=:](.*?)$", token)
         if m:
             key = m[1].lower()
-            value = m[2]
-            # Special handling for numbers, possibly ending with d/m/s for degrees etc
-            m = re.match(r'^([+-]?(\d+)(.\d+)?)([dms\'"]?)$', value)
-            if m:
-                value = float(m[1]) if "." in m[1] else int(m[1])
-                if m[4] == "d":
-                    value *= 3600
-                elif m[4] == "m" or m[4] == "'":
-                    value *= 60
-                elif m[4] == "s" or m[4] == '"' or key == "r":
-                    value *= 1
+            if not key.isnumeric():  # avoid the start of a conesearch with HH:MM:SS
+                value = m[2]
+                # Special handling for numbers, possibly ending with d/m/s for degrees etc
+                m = re.match(r'^([+-]?(\d+)(.\d+)?)([dms\'"]?)$', value)
+                if m:
+                    value = float(m[1]) if "." in m[1] else int(m[1])
+                    if m[4] == "d":
+                        value *= 3600
+                    elif m[4] == "m" or m[4] == "'":
+                        value *= 60
+                    elif m[4] == "s" or m[4] == '"' or key == "r":
+                        value *= 1
 
-            query["params"][key] = value
+                query["params"][key] = value
+            else:
+                unparsed.append(token)
 
         else:
             unparsed.append(token)

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -231,6 +231,9 @@ def parse_query(string, timeout=None):
             ) or re.search(
                 r"^(\d{1,2})[:h](\d{1,2})[:m](\d{1,2}\.?\d*)[s]?\s+([+-])?\s*(\d{1,3})[d:](\d{1,2})[m:](\d{1,2}\.?\d*)[s]?(\s+(\d+\.?\d*))?$",
                 string,
+            ) or re.search(
+                r"^(\d{1,2})[:](\d{1,2})[:](\d{1,2}\.?\d*)?\s+([+-])?\s*(\d{1,3})[:](\d{1,2})[:](\d{1,2}\.?\d*)?(\s+(\d+\.?\d*))?$",
+                string,
             )
             if m:
                 query["params"]["ra"] = (

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -185,25 +185,23 @@ def parse_query(string, timeout=None):
 
         # Try to parse keyword parameters, either as key:value or key=value
         m = re.match(r"^(\w+)[=:](.*?)$", token)
-        if m:
+
+        # avoid the start of a conesearch with HH:MM:SS
+        if m and not m[1].isnumeric():
             key = m[1].lower()
-            if not key.isnumeric():  # avoid the start of a conesearch with HH:MM:SS
-                value = m[2]
-                # Special handling for numbers, possibly ending with d/m/s for degrees etc
-                m = re.match(r'^([+-]?(\d+)(.\d+)?)([dms\'"]?)$', value)
-                if m:
-                    value = float(m[1]) if "." in m[1] else int(m[1])
-                    if m[4] == "d":
-                        value *= 3600
-                    elif m[4] == "m" or m[4] == "'":
-                        value *= 60
-                    elif m[4] == "s" or m[4] == '"' or key == "r":
-                        value *= 1
+            value = m[2]
+            # Special handling for numbers, possibly ending with d/m/s for degrees etc
+            m = re.match(r'^([+-]?(\d+)(.\d+)?)([dms\'"]?)$', value)
+            if m:
+                value = float(m[1]) if "." in m[1] else int(m[1])
+                if m[4] == "d":
+                    value *= 3600
+                elif m[4] == "m" or m[4] == "'":
+                    value *= 60
+                elif m[4] == "s" or m[4] == '"' or key == "r":
+                    value *= 1
 
-                query["params"][key] = value
-            else:
-                unparsed.append(token)
-
+            query["params"][key] = value
         else:
             unparsed.append(token)
 

--- a/apps/parse.py
+++ b/apps/parse.py
@@ -234,9 +234,6 @@ def parse_query(string, timeout=None):
             ) or re.search(
                 r"^(\d{1,2})[:h](\d{1,2})[:m](\d{1,2}\.?\d*)[s]?\s+([+-])?\s*(\d{1,3})[d:](\d{1,2})[m:](\d{1,2}\.?\d*)[s]?(\s+(\d+\.?\d*))?$",
                 string,
-            ) or re.search(
-                r"^(\d{1,2})[:](\d{1,2})[:](\d{1,2}\.?\d*)?\s+([+-])?\s*(\d{1,3})[:](\d{1,2})[:](\d{1,2}\.?\d*)?(\s+(\d+\.?\d*))?$",
-                string,
             )
             if m:
                 query["params"]["ra"] = (


### PR DESCRIPTION
Closes #648 

In the case of a conesearch in the form `h:m:s d:m:s`, the [regex](https://github.com/astrolabsoftware/fink-science-portal/blob/363511ac5c2287a71851ba2289b7879c6f4a2c7e/apps/parse.py#L187) `^(\w+)[=:](.*?)$` was interpreting the left side of the first occurence of `:` as a valid key:

```python
# built query before coordinates parsing
{'object': None, 'type': None, 'partial': False, 'hint': None, 'action': None, 
'params': {'18': '45:05.2'}, 'completions': [], 'string': '18:45:05.2 -63:57:47.4'}
```

This PR adds a guard against numeric keys found, assuming they reflect the start of a conesearch of the form `h:m:s d:m:s` (I do not think having a numerical key can happen in another query context?).


![Screenshot from 2024-09-04 10-58-56](https://github.com/user-attachments/assets/3f5b28a5-d0a0-4bca-b45b-70ed186a217d)

---

**Note**: explicitly specifying `RA=h:m:s DEC=d:m:s` still does not work, as the parser recognises correctly `ra` and `dec` entries:

```python
# built query before coordinates parsing
{'object': None, 'type': None, 'partial': False, 'hint': None, 'action': None,
'params': {'ra': '18:45:05.2', 'dec': '-63:57:47.4'}, 'completions': [], 'string': 'RA=18:45:05.2 DEC=-63:57:47.4'}
```

but it mixes `=` and `:` later and coordinates are not put into float leading to a [ValueError](https://github.com/astrolabsoftware/fink-science-portal/blob/363511ac5c2287a71851ba2289b7879c6f4a2c7e/index.py#L1169-L1170) later when getting parameters. (to be done on a future PR)