### PR TITLE
Rename DatePicker into DatePickerInput (dmc>=0.15)

### DIFF
--- a/apps/query_cluster.py
+++ b/apps/query_cluster.py
@@ -157,7 +157,7 @@ def filter_tab():
     """Section containing filtering options"""
     options = html.Div(
         [
-            dmc.DatePicker(
+            dmc.DatePickerInput(
                 type="range",
                 id="date-range-picker",
                 label="Date Range",


### PR DESCRIPTION
Closes #699 

@FusRoman -- bug due to the renaming of an object in a new version of dmc #694 