### PR TITLE
Enable label aggregation

### DIFF
--- a/apps/cards.py
+++ b/apps/cards.py
@@ -31,6 +31,7 @@ from apps.utils import (
     class_colors,
     create_button_for_external_conesearch,
     get_first_value,
+    get_multi_labels,
     help_popover,
     loading,
     request_api,
@@ -301,14 +302,14 @@ def card_neighbourhood(pdf):
     distpsnr1 = get_first_value(pdf, "i:distpsnr1")
     neargaia = get_first_value(pdf, "i:neargaia")
     constellation = get_first_value(pdf, "v:constellation")
-    gaianame = get_first_value(pdf, "d:DR3Name")
-    cdsxmatch = get_first_value(pdf, "d:cdsxmatch")
-    vsx = get_first_value(pdf, "d:vsx")
-    gcvs = get_first_value(pdf, "d:gcvs")
+    gaianame = get_multi_labels(pdf, "d:DR3Name", to_avoid=["nan"])
+    cdsxmatch = get_multi_labels(pdf, "d:cdsxmatch", to_avoid=["nan"])
+    vsx = get_multi_labels(pdf, "d:vsx", to_avoid=["nan"])
+    gcvs = get_multi_labels(pdf, "d:gcvs", to_avoid=["nan"])
 
     # Sanitize empty values
     if ssnamenr == "null":
-        ssnamenr = ""
+        ssnamenr = "N/A"
 
     if not vsx or vsx == "nan":
         vsx = "Unknown"

--- a/apps/cards.py
+++ b/apps/cards.py
@@ -906,6 +906,11 @@ def generate_tns_badge(oid):
 def generate_generic_badges(row, variant="dot"):
     """Operates on first row of a DataFrame, or directly on Series from pdf.iterrow()"""
     if isinstance(row, pd.DataFrame):
+        # for VSX, aggregate values
+        vsx_label = get_multi_labels(row, "d:vsx", default="Unknown", to_avoid=["nan"])
+        if vsx_label != row.loc[0].get("d:vsx"):
+            row["d:vsx"] = vsx_label
+
         # Get first row from DataFrame
         row = row.loc[0]
 

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -502,6 +502,51 @@ def get_first_value(pdf, colname, default=None):
         return default
 
 
+def get_multi_labels(pdf, colname, default=None, to_avoid=None):
+    """Get aggregation of unique labels from given column of a DataFrame, or default value if not exists.
+
+    Parameters
+    ----------
+    pdf: pd.DataFrame
+        Fink Pandas DataFrame
+    colname: str
+        Column name
+    default: NoneType, optional
+        Default value to assign if the
+        column is not defined in the DataFrame schema
+    to_avoid: NoneType or list, optional
+        If provided, list of labels to avoid
+
+    Returns
+    -------
+    out: str
+
+    Examples
+    --------
+    >>> pdf = pd.DataFrame({"a": ["nan", "AM", "AM", "toto"]})
+    >>> get_multi_labels(pdf, "a", to_avoid=["nan"])
+    'AM/toto'
+    """
+    if colname in pdf.columns:
+        if to_avoid is None:
+            to_avoid = []
+
+        if len(np.unique(pdf[colname])) == 1:
+            return pdf.loc[0, colname]
+
+        # Case for multilabels
+        out = "/".join(
+            [
+                i
+                for i in np.unique(pdf[colname].values)
+                if not i.startswith("Fail") and i not in to_avoid
+            ]
+        )
+        return out
+    else:
+        return default
+
+
 def request_api(endpoint, json=None, output="pandas", method="POST", **kwargs):
     """Output is one of 'pandas' (default), 'raw' or 'json'"""
     args = extract_configuration("config.yml")


### PR DESCRIPTION
Closes #744 

This PR enables aggregation of labels. If a DataFrame column has many entries (e.g. a label from a crossmatch that varies over time), one can aggregate them in the form `label1/label2/...`. This is particularly useful to show all available labels in the summary page (Neighborhood tab):

![image](https://github.com/user-attachments/assets/d3f402ca-2230-4979-a1cd-de52f0fb9b75)

or in the list of badges in the summary page:

![image](https://github.com/user-attachments/assets/bd332392-733c-4508-a31a-712f98ee70e0)

Note however it does not apply to the card result (index page), as badge refers as to the _alert_ content (the row).

![image](https://github.com/user-attachments/assets/e378413e-2c88-4720-ace6-0536ea192dc8)

@emilleishida 
