### PR TITLE
Re-use POST for metadata

### DIFF
--- a/apps/cards.py
+++ b/apps/cards.py
@@ -1028,7 +1028,6 @@ def generate_metadata_name(oid):
         json={
             "objectId": oid,
         },
-        method="GET",
         output="json",
     )
 


### PR DESCRIPTION
I was wrong in #750 -- the endpoint `/metadata` uses POST. 