### PR TITLE
New lightcurve view for difference flux

### DIFF
--- a/apps/cards.py
+++ b/apps/cards.py
@@ -71,11 +71,24 @@ The view also shows, with dashed horizontal lines, the levels corresponding to t
 
 This view may be augmented with the photometric points from [ZTF Data Releases](https://www.ztf.caltech.edu/ztf-public-releases.html) by clicking `Get DR photometry` button. The points will be shown with semi-transparent dots (&#8226;).
 
+##### Difference flux
+Difference flux (in Jansky) is constructed from difference magnitude by using the following:
+$$
+f = 3631 \times \texttt{sign} 10^{-0.4m_{magpsf}}
+$$
+where `sign` = 1 if `isdiffpos` = 't' or `sign` = -1 if `isdiffpos` = 'f'.
+
+This view also shows the photometry from ZTF Data Releases (see above), which is converted to fluxes using the same formula. Then, the "baseline" flux, which is computed from the nearest reference image catalog magnitude (`magnr`), is subtracted from it, so that the value represent the flux variation w.r.t. the template image, i.e. the difference flux.
+
+Note that we display the flux in milli-Jansky.
+
 ##### DC flux
 DC flux (in Jansky) is constructed from DC magnitude by using the following:
 $$
 f_{DC} = 3631 \times 10^{-0.4m_{DC}}
 $$
+
+This view also shows the fluxes from ZTF Data Releases, without any baseline correction.
 
 Note that we display the flux in milli-Jansky.
 """

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -90,9 +90,10 @@ colors_ = [
 ]
 
 all_radio_options = {
-    "Difference magnitude": ["Difference magnitude", "DC magnitude", "DC flux"],
-    "DC magnitude": ["Difference magnitude", "DC magnitude", "DC flux"],
-    "DC flux": ["Difference magnitude", "DC magnitude", "DC flux"],
+    "Difference magnitude": ["Difference magnitude", "DC magnitude", "Difference flux", "DC flux"],
+    "DC magnitude": ["Difference magnitude", "DC magnitude", "Difference flux", "DC flux"],
+    "Difference flux": ["Difference magnitude", "DC magnitude", "Difference flux", "DC flux"],
+    "DC flux": ["Difference magnitude", "DC magnitude", "Difference flux", "DC flux"],
 }
 
 layout_lightcurve = dict(
@@ -1747,6 +1748,20 @@ def draw_lightcurve(
         layout["yaxis"]["title"] = "Apparent DC magnitude"
         layout["yaxis"]["autorange"] = "reversed"
         scale = 1.0
+    elif switch == "Difference flux":
+        mag, err = apparent_flux(mag, err, 99.0, 0.0, "t")
+
+        # Data release photometry
+        if not pdf_release.empty:
+            pdf_release['flux'], pdf_release['fluxerr'] = apparent_flux(
+                pdf_release['mag'],
+                pdf_release['magerr'],
+                99.0, 0.0, "t"
+            )
+
+        layout["yaxis"]["title"] = "Difference flux (milliJansky)"
+        layout["yaxis"]["autorange"] = True
+        scale = 1e3
     elif switch == "DC flux":
         # inplace replacement
         mag, err = np.transpose(
@@ -1935,6 +1950,51 @@ def draw_lightcurve(
                         "error_y": {
                             "type": "data",
                             "array": pdf_release["magerr"][idx],
+                            "visible": True,
+                            "width": 0,
+                            "opacity": 0.5,
+                            "color": color,
+                        },
+                        "mode": "markers",
+                        "name": "",
+                        "customdata": pdf_release["mjd"][idx],
+                        "hovertemplate": hovertemplate_release,
+                        "legendgroup": f"{fname} band release",
+                        "legendrank": 102 + 10 * fid,
+                        "marker": {
+                            "color": color,
+                            "symbol": ".",
+                        },
+                        "opacity": 0.5,
+                        # 'showlegend': False
+                    },
+                )
+
+        elif switch == "Difference flux":
+            # Data release photometry
+            if not pdf_release.empty:
+                ref = 0
+                if is_dc_corrected:
+                    # Overplot the levels of nearby source magnitudes
+                    idx = pdf["i:fid"] == fid
+                    if np.sum(idx):
+                        ref = 3631 * 10**(-0.4*np.mean(pdf["i:magnr"][idx])) * scale
+
+                hovertemplate_release = r"""
+                <b>Baseline subtracted data release flux (mulliJansky)</b>: %{y:.2f} &plusmn; %{error_y.array:.2f}<br>
+                <b>%{xaxis.title.text}</b>: %{x|%Y/%m/%d %H:%M:%S.%L}<br>
+                <b>mjd</b>: %{customdata}
+                <b>baseline</b>: """ + "{:.2f}".format(ref) + r""" milliJansky
+                <extra></extra>
+                """
+                idx = pdf_release["filtercode"] == "z" + fname
+                figure["data"].append(
+                    {
+                        "x": dates_release[idx],
+                        "y": pdf_release["flux"][idx] * scale - ref,
+                        "error_y": {
+                            "type": "data",
+                            "array": pdf_release["fluxerr"][idx] * scale,
                             "visible": True,
                             "width": 0,
                             "opacity": 0.5,

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -1764,6 +1764,14 @@ def draw_lightcurve(
             ],
         )
 
+        # Data release photometry
+        if not pdf_release.empty:
+            pdf_release['flux'], pdf_release['fluxerr'] = apparent_flux(
+                pdf_release['mag'],
+                pdf_release['magerr'],
+                99.0, 0.0, "t"
+            )
+
         layout["yaxis"]["title"] = "Apparent DC flux (milliJansky)"
         layout["yaxis"]["autorange"] = True
         scale = 1e3
@@ -1946,6 +1954,65 @@ def draw_lightcurve(
                         # 'showlegend': False
                     },
                 )
+
+        elif switch == "DC flux":
+            if is_dc_corrected:
+                # Overplot the levels of nearby source magnitudes
+                idx = pdf["i:fid"] == fid
+                if np.sum(idx):
+                    ref = 3631 * 10**(-0.4*np.mean(pdf["i:magnr"][idx])) * scale
+
+                    figure["layout"]["shapes"].append(
+                        {
+                            "type": "line",
+                            "yref": "y",
+                            "y0": ref,
+                            "y1": ref,  # adding a horizontal line
+                            "xref": "paper",
+                            "x0": 0,
+                            "x1": 1,
+                            "line": {"color": color, "dash": "dash", "width": 1},
+                            "legendgroup": f"{fname} band",
+                            "opacity": 0.3,
+                        },
+                    )
+
+            # Data release photometry
+            if not pdf_release.empty:
+                hovertemplate_release = r"""
+                <b>Data release flux (mulliJansky)</b>: %{y:.2f} &plusmn; %{error_y.array:.2f}<br>
+                <b>%{xaxis.title.text}</b>: %{x|%Y/%m/%d %H:%M:%S.%L}<br>
+                <b>mjd</b>: %{customdata}
+                <extra></extra>
+                """
+                idx = pdf_release["filtercode"] == "z" + fname
+                figure["data"].append(
+                    {
+                        "x": dates_release[idx],
+                        "y": pdf_release["flux"][idx] * scale,
+                        "error_y": {
+                            "type": "data",
+                            "array": pdf_release["fluxerr"][idx] * scale,
+                            "visible": True,
+                            "width": 0,
+                            "opacity": 0.5,
+                            "color": color,
+                        },
+                        "mode": "markers",
+                        "name": "",
+                        "customdata": pdf_release["mjd"][idx],
+                        "hovertemplate": hovertemplate_release,
+                        "legendgroup": f"{fname} band release",
+                        "legendrank": 102 + 10 * fid,
+                        "marker": {
+                            "color": color,
+                            "symbol": ".",
+                        },
+                        "opacity": 0.5,
+                        # 'showlegend': False
+                    },
+                )
+
 
     if show_color:
         hovertemplate_gr = r"""


### PR DESCRIPTION
This PR adds new lightcurve view that shows difference flux. Also, it adds DR photometry to DC flux (trivial, for consistency), and to new difference flux views (after subtraction of baseline flux corresponding to `magnr`).
The reason is to have long-term behaviour centered around zero, so that the color variations are more easily seen (in DC views it is difficult due to random shifts between bands).
It is in principle possible to also add DR photometry to diff mag view also (to better see e.g. historical flares and their colors), but it will be very confusing due to the flux being centered around zero, so mags will be crazy. Thus I decided to skip it for now.