### PR TITLE
Remove deprecated arguments

### DIFF
--- a/apps/utils.py
+++ b/apps/utils.py
@@ -231,8 +231,8 @@ def _data_stretch(
         stretch=stretch,
         power=exponent,
         asinh_a=vmid,
-        min_cut=vmin,
-        max_cut=vmax,
+        vmin=vmin,
+        vmax=vmax,
         clip=False,
     )
 


### PR DESCRIPTION
Remove ``AstropyDeprecationWarning`` by changing ``min_cut`` and ``max_cut`` to ``vmin`` and ``vmax``, respectively, in the function ``_data_stretch`` of ``apps/utils.py``.
Closes #817.