### PR TITLE
Observability panel does not load for SSO 

### DIFF
--- a/apps/observability/utils.py
+++ b/apps/observability/utils.py
@@ -367,7 +367,6 @@ def query_miriade_cached(
     shift=15.0,
     timeout=30,
     return_json=True,
-    iofile="ephemcc-photom.xml",
 ):
     return query_miriade(
         ssnamenr,
@@ -378,7 +377,6 @@ def query_miriade_cached(
         shift=shift,
         timeout=timeout,
         return_json=return_json,
-        iofile=iofile,
     )
 
 
@@ -403,7 +401,6 @@ Error: the object is associated to multiple known SSOs \
         shift=15.0,
         timeout=30,
         return_json=True,
-        iofile="ephemcc-photom.xml",
     )
     ra = np.full(len(time), np.nan)
     dec = np.full(len(time), np.nan)

--- a/apps/summary.py
+++ b/apps/summary.py
@@ -650,7 +650,7 @@ which may result in less accurate predictions than those for a static object."""
             children=[
                 dmc.Paper(
                     [
-                        dmc.Space(h=10),
+                        dmc.Space(h=20),
                         dmc.Center(dcc.Markdown(id="observability_title_polar")),
                         html.Div(
                             dcc.Loading(


### PR DESCRIPTION
Correct the query_miriade function to load the ephemerides for SSOs.
Closes #821.